### PR TITLE
docs(readme): add related section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ Even with the most conservative, precautionous and paranoid coding process, code
     * local `sqlite3` databases for easy searching
 * This code is used in production in several PCI-DSS, ISO 27001, SOC1 and SOC2 certified environments
 
+## Related
+
+- [ovh-ttyrec](https://github.com/ovh/ovh-ttyrec) - A terminal (tty) recorder
+
 ## License
 
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
I noticed that in [`bin/admin`](https://github.com/ovh/the-bastion/blob/master/bin/admin/build-and-install-ttyrec.sh#L9) folder uses [`ovh-ttyrec`](https://github.com/ovh/ovh-ttyrec) which is also a repository on the ovh organization.

Maybe we can consider adding a link into the `README.md` file that refer to this repository.

Here is my suggestion by adding a *Related* section.

Hope you'll find this useful.

Thank you

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>