### PR TITLE
enh: packages-check.sh: add qrencode-libs for rhel/centos

### DIFF
--- a/bin/admin/packages-check.sh
+++ b/bin/admin/packages-check.sh
@@ -70,7 +70,7 @@ elif echo "$DISTRO_LIKE" | grep -q -w rhel; then
             perl-libwww-perl perl-Digest perl-Net-Server cryptsetup mosh \
             expect openssh-server nc bash perl-CGI perl(Test::More) passwd \
             cracklib-dicts perl-Time-Piece perl-Time-HiRes which \
-            perl-Sys-Syslog pamtester google-authenticator"
+            perl-Sys-Syslog pamtester google-authenticator qrencode-libs"
     if [ "$DISTRO_VERSION_MAJOR" = 7 ]; then
         wanted_list="$wanted_list fortune-mod coreutils"
     fi


### PR DESCRIPTION
This enables direct printing of the qrcode on the terminal for TOTP enrollment