### PR TITLE
fix: osh-lingering-sessions-reaper.sh: tocttou on kill

### DIFF
--- a/bin/cron/osh-lingering-sessions-reaper.sh
+++ b/bin/cron/osh-lingering-sessions-reaper.sh
@@ -23,8 +23,9 @@ do
     fi
 done < <(ps -C ttyrec -o etimes,pid,tty --no-header)
 if [ -n "$tokill" ]; then
+    # add || true to avoid script termination due to TOCTTOU and set -e
     # shellcheck disable=SC2086
-    kill $tokill
+    kill $tokill || true
     _log "Terminated $nb orphan ttyrec sessions (pids$tokill)"
 fi
 
@@ -41,8 +42,9 @@ do
     fi
 done < <(ps -C sshd --no-header -o etimes,pid,tty,user)
 if [ -n "$tokill" ]; then
+    # add || true to avoid script termination due to TOCTTOU and set -e
     # shellcheck disable=SC2086
-    kill $tokill
+    kill $tokill || true
     _log "Terminated $nb orphan sshd sessions (pids$tokill)"
 fi
 


### PR DESCRIPTION
which could terminate the script early with a

`osh-lingering-sessions-reaper.sh[12345]: ERROR: Unexpected termination!`

syslog message