### PR TITLE
enh: config: detect warnBefore/idleTimeout misconfiguration

### DIFF
--- a/doc/sphinx/administration/bastion_conf.rst
+++ b/doc/sphinx/administration/bastion_conf.rst
@@ -674,7 +674,7 @@ warnBeforeLockSeconds
 
 :Default: ``0``
 
-If set to a positive value >0, the number of seconds before ``idleLockTimeout`` where the user will receive a warning message telling him about the upcoming lock of his session.
+If set to a positive value >0, the number of seconds before ``idleLockTimeout`` where the user will receive a warning message telling them about the upcoming lock of his session. Don't enable this (by setting a non-zero value) if `idleLockTimeout` is disabled (set to zero).
 
 .. _warnBeforeKillSeconds:
 
@@ -685,7 +685,7 @@ warnBeforeKillSeconds
 
 :Default: ``0``
 
-If set to a positive value >0, the number of seconds before ``idleKillTimeout`` where the user will receive a warning message telling him about the upcoming kill of his session.
+If set to a positive value >0, the number of seconds before ``idleKillTimeout`` where the user will receive a warning message telling them about the upcoming kill of his session. Don't enable this (by setting a non-zero value) if `idleKillTimeout` is disabled (set to zero).
 
 .. _accountExternalValidationProgram:
 
@@ -799,7 +799,7 @@ accountMFAPolicy
 
 Set a MFA policy for the bastion accounts, the supported values are:
 
-- ``disabled``: the commands to setup TOTP and UNIX account password are disabled, nobody can setup MFA for himself or others. Already configured MFA still applies, unless the sshd configuration is modified to no longer call PAM on the authentication phase
+- ``disabled``: the commands to setup TOTP and UNIX account password are disabled, nobody can setup MFA for themselves or others. Already configured MFA still applies, unless the sshd configuration is modified to no longer call PAM on the authentication phase
 - ``password-required``: for all accounts, a UNIX account password is required in addition to the ingress SSH public key. On first connection with his SSH key, the user is forced to setup a password for his account, and can't disable it afterwards
 - ``totp-required``: for all accounts, a TOTP is required in addition to the ingress SSH public key. On first connection with his SSH key, the user is forced to setup a TOTP for his account, and can't disable it afterwards
 - ``any-required``: for all accounts, either a TOTP or an UNIX account password is required in addition to the ingress SSH public key. On first connection with his SSH key, the user is forced to setup either of those, as he sees fit, and can't disable it afterwards

--- a/etc/bastion/bastion.conf.dist
+++ b/etc/bastion/bastion.conf.dist
@@ -288,12 +288,12 @@
 "idleKillTimeout": 0,
 #
 # warnBeforeLockSeconds (int >= 0 (seconds))
-#     DESC: If set to a positive value >0, the number of seconds before ``idleLockTimeout`` where the user will receive a warning message telling him about the upcoming lock of his session.
+#     DESC: If set to a positive value >0, the number of seconds before ``idleLockTimeout`` where the user will receive a warning message telling them about the upcoming lock of his session. Don't enable this (by setting a non-zero value) if `idleLockTimeout` is disabled (set to zero).
 #  DEFAULT: 0
 "warnBeforeLockSeconds": 0,
 #
 # warnBeforeKillSeconds (int >= 0 (seconds))
-#     DESC: If set to a positive value >0, the number of seconds before ``idleKillTimeout`` where the user will receive a warning message telling him about the upcoming kill of his session.
+#     DESC: If set to a positive value >0, the number of seconds before ``idleKillTimeout`` where the user will receive a warning message telling them about the upcoming kill of his session. Don't enable this (by setting a non-zero value) if `idleKillTimeout` is disabled (set to zero).
 #  DEFAULT: 0
 "warnBeforeKillSeconds": 0,
 #
@@ -353,7 +353,7 @@
 # accountMFAPolicy (string)
 #     DESC: Set a MFA policy for the bastion accounts, the supported values are:
 #
-#     - ``disabled``: the commands to setup TOTP and UNIX account password are disabled, nobody can setup MFA for himself or others. Already configured MFA still applies, unless the sshd configuration is modified to no longer call PAM on the authentication phase
+#     - ``disabled``: the commands to setup TOTP and UNIX account password are disabled, nobody can setup MFA for themselves or others. Already configured MFA still applies, unless the sshd configuration is modified to no longer call PAM on the authentication phase
 #     - ``password-required``: for all accounts, a UNIX account password is required in addition to the ingress SSH public key. On first connection with his SSH key, the user is forced to setup a password for his account, and can't disable it afterwards
 #     - ``totp-required``: for all accounts, a TOTP is required in addition to the ingress SSH public key. On first connection with his SSH key, the user is forced to setup a TOTP for his account, and can't disable it afterwards
 #     - ``any-required``: for all accounts, either a TOTP or an UNIX account password is required in addition to the ingress SSH public key. On first connection with his SSH key, the user is forced to setup either of those, as he sees fit, and can't disable it afterwards

--- a/lib/perl/OVH/Bastion/configuration.inc
+++ b/lib/perl/OVH/Bastion/configuration.inc
@@ -439,6 +439,17 @@ sub load_configuration {
         $C->{'idleLockTimeout'} = 0;
     }
 
+    # ... if warnBefore*Seconds are set whereas idle*Timeout are not, unset the warnBefore*Seconds params and log the misconfiguration
+    foreach my $what (qw{ Kill Lock }) {
+        if ($C->{"warnBefore${what}Seconds"} && !$C->{"idle${what}Timeout"}) {
+            push @errors,
+                "Configuration error: option 'warnBefore${what}Seconds' ("
+              . $C->{"warnBefore${what}Seconds"}
+              . ") is set whereas the corresponding 'idle${what}Timeout' option is not, setting 'warnBefore${what}Seconds' to 0";
+            $C->{"warnBefore${what}Seconds"} = 0;
+        }
+    }
+
     # ... check that adminAccounts are actually valid accounts
     {
         my @validAccounts;


### PR DESCRIPTION
Before, an inconsistency in the configuration settings of the warnBefore(Lock|Kill)Seconds
and idle(Lock|Kill)Timeout could break any new connection (ttyrec refuses to launch).

Now we detect this case properly, and fallback to a sane setting for
warnBefore(Lock|Kill)Seconds (zero) if those were set without enabling the corresponding
idle(Lock|Kill)Timeout setting. We also log an error to syslog when it happens,
so that the sysadmin can fix their configuration.

Added hints about how these configuration options work together in the bastion.conf.dist file.

Fixes #125