### PR TITLE
fix: accountInfo: get rid of 2 warn()

### DIFF
--- a/bin/plugin/restricted/accountInfo
+++ b/bin/plugin/restricted/accountInfo
@@ -175,7 +175,8 @@ if (OVH::Bastion::is_auditor(account => $self)) {
     $fnret = OVH::Bastion::account_config(account => $account, public => 1, key => OVH::Bastion::OPT_ACCOUNT_INGRESS_PIV_POLICY);
     $ret{'ingress_piv_enforced'} = ($fnret && $fnret->value eq 'yes') ? 1 : 0;    # keep for backwards compat
     $ret{'ingress_piv_policy'}   = $fnret->value || undef;
-    osh_info "- PIV policy for ingress keys on this account is set to " . colored($ret{'ingress_piv_policy'}, $ret{'ingress_piv_policy'} eq 'default' ? 'blue' : 'green');
+    my $ingress_piv_policy_print = $ret{'ingress_piv_policy'} ? $ret{'ingress_piv_policy'} : 'default';
+    osh_info "- PIV policy for ingress keys on this account is set to " . colored($ingress_piv_policy_print, $ingress_piv_policy_print eq 'default' ? 'blue' : 'green');
 
     $fnret = OVH::Bastion::account_config(account => $account, public => 1, key => OVH::Bastion::OPT_ACCOUNT_INGRESS_PIV_GRACE);
     if ($fnret && $fnret->value > time()) {

--- a/lib/perl/OVH/Bastion/interactive.inc
+++ b/lib/perl/OVH/Bastion/interactive.inc
@@ -75,7 +75,14 @@ EOM
 
     # setup readline
 
-    $term->ornaments(1);
+    if (!$ENV{'TERM'}) {
+
+        # if TERM is undef, don't call $term->ornaments(1) or we'll generate a warn
+        print "Your TERM envvar is not defined, some things might not work correctly!\n\n";
+    }
+    else {
+        $term->ornaments(1);
+    }
     my $attribs = $term->Attribs;
 
     $attribs->{'completion_function'} = sub {


### PR DESCRIPTION
This occurred since `v3.01.99-rc1` when requesting an `accountInfo`
of an account without an `ingress_piv_policy` set.

`Use of uninitialized value  in concatenation (.) or string at /usr/share/perl/5.28/Term/ANSIColor.pm line 510.
 at /opt/bastion/bin/plugin/restricted/../../../lib/perl/OVH/Bastion.pm line 41.
OVH::Bastion::__ANON__("Use of uninitialized value \ in concatenation (.) or st"...) called at /usr/share/perl/5.28/Term/ANSIColor.pm line 510
Term::ANSIColor::colored(undef, "green") called at /opt/bastion/bin/plugin/restricted/accountInfo line 178`