### PR TITLE
fix: scp: abort early if host is not found to avoid a warn()

### DIFF
--- a/bin/plugin/open/scp
+++ b/bin/plugin/open/scp
@@ -96,6 +96,15 @@ if (not $host) {
     osh_exit;
 }
 
+if (not $ip) {
+
+    # use STDERR because stdout is eaten by scp itself
+    print STDERR "\nscp: Sorry, couldn't resolve the host you specified ('$host'), aborting.\n";
+
+    # note that the calling-side scp will not passthrough this exit code, but most probably "1" instead.
+    exit(OVH::Bastion::EXIT_HOST_NOT_FOUND);
+}
+
 my $machine = $ip;
 $machine = "$user\@$ip" if $user;
 $port ||= 22;       # scp uses 22 if not specified, so we need to test access to that port and not any port (aka undef)

--- a/tests/functional/tests.d/340-selfaccesses.sh
+++ b/tests/functional/tests.d/340-selfaccesses.sh
@@ -195,6 +195,10 @@ testsuite_selfaccesses()
     contain "No such file or directory"
     nocontain "Permission denied"
 
+    run scp invalidhostname scp -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file $shellaccount@_invalid._invalid:uptest /tmp/downloaded
+    retvalshouldbe 1
+    contain "Sorry, couldn't resolve the host you specified"
+
     success scp upload scp -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file /etc/passwd $shellaccount@127.0.0.2:uptest
     contain "through the bastion to"
     contain "Done,"


### PR DESCRIPTION
The following warn would happen if the scp wrapper was called with an invalid hostname:

```
Use of uninitialized value  in bitwise and (&) at /usr/share/perl5/Net/Netmask.pm line 699.
 at /opt/bastion/bin/plugin/open/../../../lib/perl/OVH/Bastion.pm line 41.
 OVH::Bastion::__ANON__("Use of uninitialized value \ in bitwise and (&) at /usr/shar"...) called at /usr/share/perl5/Net/Netmask.pm line 697
 Net::Netmask::match(Net::Netmask=HASH(0x55b1d5f11860), undef) called at /opt/bastion/lib/perl/OVH/Bastion/allowdeny.inc line 214
 OVH::Bastion::is_access_way_granted("port", 22, "exactUserMatch", 1, "ipfrom", "X.X.X.X", "ip", undef, ...) called at /opt/bastion/lib/perl/OVH/Bastion/allowdeny.inc line 688
 OVH::Bastion::is_access_granted(\"account\", \"johndoe\", \"user\", \"!scpupload\", \"ipfrom\", \"X.X.X.X\", \"ip\", undef, ...) called at /opt/bastion/bin/plugin/open/scp line 136
```