### PR TITLE
feat: add UTF-8 chars to output when supported and allowed

### DIFF
--- a/bin/plugin/open/selfGenerateEgressKey
+++ b/bin/plugin/open/selfGenerateEgressKey
@@ -22,7 +22,7 @@ my $remainingOptions = OVH::Bastion::Plugin::begin(
 );
 
 sub help {
-    print <<"EOF";
+    my $text = <<"EOF";
 Create a new public + private key pair on your bastion account
 
 Usage: --osh $scriptName --algo ALGO --size SIZE [--encrypted]
@@ -37,6 +37,7 @@ Usage: --osh $scriptName --algo ALGO --size SIZE [--encrypted]
   --encrypted  if specified, a passphrase will be prompted for the new key
 
 EOF
+    osh_info($text);
     OVH::Bastion::Plugin::generateEgressKey::help_algos();
     return 1;
 }

--- a/bin/plugin/open/selfPlaySession
+++ b/bin/plugin/open/selfPlaySession
@@ -89,11 +89,11 @@ if (!-r $ttyrecfile) {
     osh_exit R('ERR_NOT_FOUND', msg => "Recorded session for ID $id couldn't be found, it might have been archived");
 }
 
-osh_warn "Press '+' to play faster";
-osh_warn "Press '-' to play slower";
-osh_warn "Press '1' to restore normal playing speed";
-osh_warn "\nWhen you're ready to replay session $id, press ENTER.";
-osh_warn "Starting from the next line, the Total Recall begins. Press CTRL+C to jolt awake.";
+osh_info "Press '+' to play faster";
+osh_info "Press '-' to play slower";
+osh_info "Press '1' to restore normal playing speed";
+osh_info "\nWhen you're ready to replay session $id, press ENTER.";
+osh_info "Starting from the next line, the Total Recall begins. Press CTRL+C to jolt awake.";
 <STDIN>;
 my $sysret = system('ttyplay', $ttyrecfile);
 osh_ok {};

--- a/bin/shell/osh.pl
+++ b/bin/shell/osh.pl
@@ -14,7 +14,6 @@ use POSIX qw(strftime);
 use Term::ANSIColor;
 use JSON;
 
-$ENV{'LANG'} = 'C';
 $| = 1;
 my $fnret;
 

--- a/doc/sphinx/administration/bastion_conf.rst
+++ b/doc/sphinx/administration/bastion_conf.rst
@@ -91,6 +91,7 @@ Session policies
 Options to customize the established sessions behaviour
 
 - :ref:`displayLastLogin`
+- :ref:`allowUTF8`
 - :ref:`interactiveModeAllowed`
 - :ref:`interactiveModeTimeout`
 - :ref:`interactiveModeByDefault`
@@ -609,6 +610,17 @@ displayLastLogin
 :Default: ``true``
 
 If ``true``, display their last login information on connection to your users.
+
+.. _allowUTF8:
+
+allowUTF8
+*********
+
+:Type: ``boolean``
+
+:Default: ``true``
+
+When ``true``, The Bastion will use some UTF-8 characters on the output, for a more pleasant experience (for warnings, critical messages, etc.). Note that if the terminal doesn't advertise UTF-8 support, UTF-8 will not be used, even when enabled here.
 
 .. _interactiveModeAllowed:
 

--- a/doc/sphinx/plugins/admin/adminMaintenance.rst
+++ b/doc/sphinx/plugins/admin/adminMaintenance.rst
@@ -28,3 +28,4 @@ Manage the bastion maintenance mode
 
 
 
+

--- a/doc/sphinx/plugins/admin/adminSudo.rst
+++ b/doc/sphinx/plugins/admin/adminSudo.rst
@@ -31,3 +31,4 @@ Don't forget the double-double-dash as seen in the example above: one after the 
 and another one to separate adminSudo options from the options of the plugin to be called.
 
 
+

--- a/doc/sphinx/plugins/group-aclkeeper/groupAddServer.rst
+++ b/doc/sphinx/plugins/group-aclkeeper/groupAddServer.rst
@@ -70,3 +70,4 @@ Examples::
   --osh groupAddServer --group grp2 --host srv1.example.org --user root --port 22
 
 
+

--- a/doc/sphinx/plugins/group-aclkeeper/groupDelServer.rst
+++ b/doc/sphinx/plugins/group-aclkeeper/groupDelServer.rst
@@ -48,3 +48,4 @@ Remove an IP or IP block from a group's serrver list
 
 
 
+

--- a/doc/sphinx/plugins/group-gatekeeper/groupAddGuestAccess.rst
+++ b/doc/sphinx/plugins/group-gatekeeper/groupAddGuestAccess.rst
@@ -73,3 +73,4 @@ must be on the remote server).
 This command is the opposite of ``groupDelGuestAccess``.
 
 
+

--- a/doc/sphinx/plugins/group-gatekeeper/groupAddMember.rst
+++ b/doc/sphinx/plugins/group-gatekeeper/groupAddMember.rst
@@ -29,3 +29,4 @@ If you need to give a specific and/or temporary access instead,
 see ``groupAddGuestAccess``
 
 
+

--- a/doc/sphinx/plugins/group-gatekeeper/groupDelGuestAccess.rst
+++ b/doc/sphinx/plugins/group-gatekeeper/groupDelGuestAccess.rst
@@ -60,3 +60,4 @@ key instead of the group key, please use ``accountDelPersonalAccess`` instead.
 This command is the opposite of ``groupAddGuestAccess``.
 
 
+

--- a/doc/sphinx/plugins/group-gatekeeper/groupDelMember.rst
+++ b/doc/sphinx/plugins/group-gatekeeper/groupDelMember.rst
@@ -29,3 +29,4 @@ Note that if this account also had specific guest accesses to this group, they m
 still apply, see ``groupListGuestAccesses``
 
 
+

--- a/doc/sphinx/plugins/group-gatekeeper/groupListGuestAccesses.rst
+++ b/doc/sphinx/plugins/group-gatekeeper/groupListGuestAccesses.rst
@@ -24,3 +24,4 @@ List the guest accesses to servers of a group specifically granted to an account
 
 
 
+

--- a/doc/sphinx/plugins/group-owner/groupAddAclkeeper.rst
+++ b/doc/sphinx/plugins/group-owner/groupAddAclkeeper.rst
@@ -26,3 +26,4 @@ Add the group aclkeeper role to an account
 The specified account will be able to manage the server list of this group
 
 
+

--- a/doc/sphinx/plugins/group-owner/groupAddGatekeeper.rst
+++ b/doc/sphinx/plugins/group-owner/groupAddGatekeeper.rst
@@ -27,3 +27,4 @@ The specified account will be able to manage the members list of this group,
 along with the guests list
 
 
+

--- a/doc/sphinx/plugins/group-owner/groupAddOwner.rst
+++ b/doc/sphinx/plugins/group-owner/groupAddOwner.rst
@@ -29,3 +29,4 @@ have all possible rights to manage the group and delegate some or all
 of the rights to other accounts
 
 
+

--- a/doc/sphinx/plugins/group-owner/groupDelAclkeeper.rst
+++ b/doc/sphinx/plugins/group-owner/groupDelAclkeeper.rst
@@ -26,3 +26,4 @@ Remove the group aclkeeper role from an account
 The specified account will no longer be able to manage the server list of this group
 
 
+

--- a/doc/sphinx/plugins/group-owner/groupDelEgressKey.rst
+++ b/doc/sphinx/plugins/group-owner/groupDelEgressKey.rst
@@ -24,3 +24,4 @@ Remove a bastion group egress key
 
 
 
+

--- a/doc/sphinx/plugins/group-owner/groupDelGatekeeper.rst
+++ b/doc/sphinx/plugins/group-owner/groupDelGatekeeper.rst
@@ -27,3 +27,4 @@ The specified account will no longer be able to manager the members nor
 the guest list of this group
 
 
+

--- a/doc/sphinx/plugins/group-owner/groupDelOwner.rst
+++ b/doc/sphinx/plugins/group-owner/groupDelOwner.rst
@@ -27,3 +27,4 @@ The specified account will no longer be able to manage the owner,
 gatekeeper and aclkeeper lists of this group
 
 
+

--- a/doc/sphinx/plugins/group-owner/groupGenerateEgressKey.rst
+++ b/doc/sphinx/plugins/group-owner/groupGenerateEgressKey.rst
@@ -56,3 +56,4 @@ This table is meant as a quick cheat-sheet, you're warmly advised to do
 your own research, as other constraints may apply to your environment.
 
 
+

--- a/doc/sphinx/plugins/group-owner/groupGeneratePassword.rst
+++ b/doc/sphinx/plugins/group-owner/groupGeneratePassword.rst
@@ -40,3 +40,4 @@ doesn't work, but please ensure that this new password is deployed on the remote
 devices as soon as possible.
 
 
+

--- a/doc/sphinx/plugins/group-owner/groupModify.rst
+++ b/doc/sphinx/plugins/group-owner/groupModify.rst
@@ -29,3 +29,4 @@ Modify the configuration of a group
                                                 set to zero to allow guest accesses creation without any TTL set (default)
 
 
+

--- a/doc/sphinx/plugins/group-owner/groupTransmitOwnership.rst
+++ b/doc/sphinx/plugins/group-owner/groupTransmitOwnership.rst
@@ -27,3 +27,4 @@ Note that this command has the same net effect than using ``groupAddOwner``
 to add ACCOUNT as an owner, then removing yourself with ``groupDelOwner``
 
 
+

--- a/doc/sphinx/plugins/open/alive.rst
+++ b/doc/sphinx/plugins/open/alive.rst
@@ -23,3 +23,4 @@ Note that if you want to ssh to it afterwards, you can simply use the ``--wait``
 
 
 
+

--- a/doc/sphinx/plugins/open/batch.rst
+++ b/doc/sphinx/plugins/open/batch.rst
@@ -37,3 +37,4 @@ Run a batch of osh commands fed through STDIN
   for i in user1 user2 user3; do echo "groupAddMember --account $i --group grp4"; done | bssh --osh batch
 
 
+

--- a/doc/sphinx/plugins/open/clush.rst
+++ b/doc/sphinx/plugins/open/clush.rst
@@ -36,3 +36,4 @@ Launch a remote command on several machines sequentially (clush-like)
 
 
 
+

--- a/doc/sphinx/plugins/open/groupInfo.rst
+++ b/doc/sphinx/plugins/open/groupInfo.rst
@@ -20,6 +20,7 @@ Print some basic information about a group
 
 
 
+
 Output example
 ==============
 

--- a/doc/sphinx/plugins/open/groupList.rst
+++ b/doc/sphinx/plugins/open/groupList.rst
@@ -30,3 +30,4 @@ List the groups available on this bastion
                         can be used multiple times. Note that --exclude takes precedence over --include
 
 
+

--- a/doc/sphinx/plugins/open/groupListPasswords.rst
+++ b/doc/sphinx/plugins/open/groupListPasswords.rst
@@ -22,3 +22,4 @@ List the hashes and metadata of egress passwords of a group
 The passwords corresponding to these hashes are only needed for devices that don't support key-based SSH
 
 
+

--- a/doc/sphinx/plugins/open/groupListServers.rst
+++ b/doc/sphinx/plugins/open/groupListServers.rst
@@ -24,3 +24,4 @@ List the servers (IPs and IP blocks) pertaining to a group
 
 
 
+

--- a/doc/sphinx/plugins/open/help.rst
+++ b/doc/sphinx/plugins/open/help.rst
@@ -15,6 +15,7 @@ I'm So Meta, Even This Acronym
 
 
 
+
 Displays help about the available plugins callable with ``--osh``.
 
 If you need help on a specific plugin, you can use ``--osh PLUGIN --help``, replacing ``PLUGIN`` with the actual plugin name.

--- a/doc/sphinx/plugins/open/info.rst
+++ b/doc/sphinx/plugins/open/info.rst
@@ -15,6 +15,7 @@ Displays some information about this bastion instance
 
 
 
+
 Output example
 ==============
 

--- a/doc/sphinx/plugins/open/lock.rst
+++ b/doc/sphinx/plugins/open/lock.rst
@@ -15,6 +15,7 @@ Manually lock all your current sessions
 
 
 
+
 This command will lock all your current sessions on this bastion instance. Note that this only applies to the bastion instance you're launching this command on, not on the whole bastion cluster (if you happen to have one).
 
 To undo this action, you can use ``--osh unlock`` on the same instance.

--- a/doc/sphinx/plugins/open/mtr.rst
+++ b/doc/sphinx/plugins/open/mtr.rst
@@ -20,3 +20,4 @@ Runs the mtr tool to traceroute a host
 
 
 
+

--- a/doc/sphinx/plugins/open/nc.rst
+++ b/doc/sphinx/plugins/open/nc.rst
@@ -28,4 +28,5 @@ Check whether a remote TCP port is open
 
 
 
+
 Note that this is not a full-featured ``netcat``, we just test whether a remote port is open. There is no way to exchange data using this command.

--- a/doc/sphinx/plugins/open/ping.rst
+++ b/doc/sphinx/plugins/open/ping.rst
@@ -32,3 +32,4 @@ Ping a remote host from the bastion
 
 
 
+

--- a/doc/sphinx/plugins/open/selfAddIngressKey.rst
+++ b/doc/sphinx/plugins/open/selfAddIngressKey.rst
@@ -30,3 +30,4 @@ Add a new ingress public key to your account
                       expected on STDIN only, otherwise the public SSH key, the attestation and key certificate are expected on STDIN.
 
 
+

--- a/doc/sphinx/plugins/open/selfDelIngressKey.rst
+++ b/doc/sphinx/plugins/open/selfDelIngressKey.rst
@@ -26,3 +26,4 @@ Remove an ingress public key from your account
 If none of these options are specified, you'll be prompted interactively.
 
 
+

--- a/doc/sphinx/plugins/open/selfForgetHostKey.rst
+++ b/doc/sphinx/plugins/open/selfForgetHostKey.rst
@@ -28,3 +28,4 @@ however please verify that the host key change is legit before using this comman
 The warning SSH gives is there for a reason.
 
 
+

--- a/doc/sphinx/plugins/open/selfGeneratePassword.rst
+++ b/doc/sphinx/plugins/open/selfGeneratePassword.rst
@@ -36,3 +36,4 @@ doesn't work, but please ensure that this new password is deployed on the remote
 devices as soon as possible.
 
 
+

--- a/doc/sphinx/plugins/open/selfGenerateProxyPassword.rst
+++ b/doc/sphinx/plugins/open/selfGenerateProxyPassword.rst
@@ -33,3 +33,4 @@ BEWARE: once a new password is generated this way, it'll be set as the new
 HTTPS proxy ingress password to use right away for your account.
 
 
+

--- a/doc/sphinx/plugins/open/selfListAccesses.rst
+++ b/doc/sphinx/plugins/open/selfListAccesses.rst
@@ -26,3 +26,4 @@ Show the list of servers you have access to
 
 
 
+

--- a/doc/sphinx/plugins/open/selfListEgressKeys.rst
+++ b/doc/sphinx/plugins/open/selfListEgressKeys.rst
@@ -20,3 +20,4 @@ by putting one of those keys in the remote machine's ``authorized_keys`` file,
 and adding yourself access to this machine with ``selfAddPersonalAccess``.
 
 
+

--- a/doc/sphinx/plugins/open/selfListIngressKeys.rst
+++ b/doc/sphinx/plugins/open/selfListIngressKeys.rst
@@ -19,3 +19,4 @@ Their private counterpart should be detained only by you, and used
 to authenticate yourself to this bastion.
 
 
+

--- a/doc/sphinx/plugins/open/selfListPasswords.rst
+++ b/doc/sphinx/plugins/open/selfListPasswords.rst
@@ -17,3 +17,4 @@ List the hashes and metadata of the egress passwords associated to your account
 The passwords corresponding to these hashes are only needed for devices that don't support key-based SSH
 
 
+

--- a/doc/sphinx/plugins/open/selfListSessions.rst
+++ b/doc/sphinx/plugins/open/selfListSessions.rst
@@ -73,3 +73,4 @@ Note that only the sessions that happened on this precise bastion instance will 
 not the sessions from its possible cluster siblings.
 
 
+

--- a/doc/sphinx/plugins/open/selfMFAResetPassword.rst
+++ b/doc/sphinx/plugins/open/selfMFAResetPassword.rst
@@ -18,3 +18,4 @@ Note that if your password is set, you'll be prompted for it.
 Also note that this doesn't remove your UNIX password requirement, if set (see ``accountModify`` for this).
 
 
+

--- a/doc/sphinx/plugins/open/selfMFAResetTOTP.rst
+++ b/doc/sphinx/plugins/open/selfMFAResetTOTP.rst
@@ -18,3 +18,4 @@ Note that if your TOTP is set, you'll be prompted for it.
 Also note that this doesn't remove your TOTP requirement, if set (see accountModify for this).
 
 
+

--- a/doc/sphinx/plugins/open/selfMFASetupPassword.rst
+++ b/doc/sphinx/plugins/open/selfMFASetupPassword.rst
@@ -20,3 +20,4 @@ Setup an additional credential (UNIX password) to access your account
 
 
 
+

--- a/doc/sphinx/plugins/open/selfMFASetupTOTP.rst
+++ b/doc/sphinx/plugins/open/selfMFASetupTOTP.rst
@@ -20,3 +20,4 @@ Setup an additional credential (TOTP) to access your account
 
 
 
+

--- a/doc/sphinx/plugins/open/selfPlaySession.rst
+++ b/doc/sphinx/plugins/open/selfPlaySession.rst
@@ -20,3 +20,4 @@ Replay the ttyrec of a past session
 
 
 
+

--- a/doc/sphinx/plugins/open/unlock.rst
+++ b/doc/sphinx/plugins/open/unlock.rst
@@ -20,3 +20,4 @@ Note that this only applies to the bastion instance you're launching this
 command on, not on the whole bastion cluster (if you happen to have one).
 
 
+

--- a/doc/sphinx/plugins/restricted/accountAddPersonalAccess.rst
+++ b/doc/sphinx/plugins/restricted/accountAddPersonalAccess.rst
@@ -63,3 +63,4 @@ The access will work only if one of the account's personal egress public key has
 To get the list of an account's personal egress public keys, see ``accountListEgressKeyss`` and ``selfListEgressKeys``.
 
 
+

--- a/doc/sphinx/plugins/restricted/accountCreate.rst
+++ b/doc/sphinx/plugins/restricted/accountCreate.rst
@@ -58,3 +58,4 @@ Create a new bastion account
 
 
 
+

--- a/doc/sphinx/plugins/restricted/accountDelPersonalAccess.rst
+++ b/doc/sphinx/plugins/restricted/accountDelPersonalAccess.rst
@@ -48,3 +48,4 @@ Remove a personal server access from an account
 
 
 
+

--- a/doc/sphinx/plugins/restricted/accountDelete.rst
+++ b/doc/sphinx/plugins/restricted/accountDelete.rst
@@ -24,3 +24,4 @@ Delete an account from the bastion
 
 
 
+

--- a/doc/sphinx/plugins/restricted/accountGeneratePassword.rst
+++ b/doc/sphinx/plugins/restricted/accountGeneratePassword.rst
@@ -40,3 +40,4 @@ doesn't work, but please ensure that this new password is deployed on the remote
 devices as soon as possible.
 
 
+

--- a/doc/sphinx/plugins/restricted/accountGrantCommand.rst
+++ b/doc/sphinx/plugins/restricted/accountGrantCommand.rst
@@ -31,3 +31,4 @@ more verbose output for several other commands, suitable to audit rights or gran
 to be granted (e.g. to groups).
 
 
+

--- a/doc/sphinx/plugins/restricted/accountInfo.rst
+++ b/doc/sphinx/plugins/restricted/accountInfo.rst
@@ -20,6 +20,7 @@ Display some information about an account
 
 
 
+
 Output example
 ==============
 

--- a/doc/sphinx/plugins/restricted/accountList.rst
+++ b/doc/sphinx/plugins/restricted/accountList.rst
@@ -38,3 +38,4 @@ List the bastion accounts
                         can be used multiple times. Note that --exclude takes precedence over --include
 
 
+

--- a/doc/sphinx/plugins/restricted/accountListAccesses.rst
+++ b/doc/sphinx/plugins/restricted/accountListAccesses.rst
@@ -31,3 +31,4 @@ View the expanded access list of a given bastion account
 
 
 
+

--- a/doc/sphinx/plugins/restricted/accountListEgressKeys.rst
+++ b/doc/sphinx/plugins/restricted/accountListEgressKeys.rst
@@ -25,3 +25,4 @@ by putting one of those keys in the remote machine's ``authorized_keys`` file,
 and adding this account access to this machine with ``accountAddPersonalAccess``.
 
 
+

--- a/doc/sphinx/plugins/restricted/accountListIngressKeys.rst
+++ b/doc/sphinx/plugins/restricted/accountListIngressKeys.rst
@@ -24,3 +24,4 @@ Their private counterpart should be detained only by this account's user,
 so that they can to authenticate themselves to this bastion.
 
 
+

--- a/doc/sphinx/plugins/restricted/accountListPasswords.rst
+++ b/doc/sphinx/plugins/restricted/accountListPasswords.rst
@@ -22,3 +22,4 @@ List the hashes and metadata of the egress passwords associated to an account
 The passwords corresponding to these hashes are only needed for devices that don't support key-based SSH
 
 
+

--- a/doc/sphinx/plugins/restricted/accountMFAResetPassword.rst
+++ b/doc/sphinx/plugins/restricted/accountMFAResetPassword.rst
@@ -22,3 +22,4 @@ Remove the UNIX password of an account
 Note that if doesn't remove the account UNIX password requirement, if set (see ``accountModify`` for this)
 
 
+

--- a/doc/sphinx/plugins/restricted/accountMFAResetTOTP.rst
+++ b/doc/sphinx/plugins/restricted/accountMFAResetTOTP.rst
@@ -22,3 +22,4 @@ Remove the TOTP configuration of an account
 Note that if doesn't remove the TOTP requirement, if set (see ``accountModify`` for this).
 
 
+

--- a/doc/sphinx/plugins/restricted/accountModify.rst
+++ b/doc/sphinx/plugins/restricted/accountModify.rst
@@ -60,3 +60,4 @@ Modify an account configuration
 
 
 
+

--- a/doc/sphinx/plugins/restricted/accountPIV.rst
+++ b/doc/sphinx/plugins/restricted/accountPIV.rst
@@ -51,3 +51,4 @@ grace
    useful when people forget their PIV-enabled hardware token and you don't want to send them back home.
 
 
+

--- a/doc/sphinx/plugins/restricted/accountRevokeCommand.rst
+++ b/doc/sphinx/plugins/restricted/accountRevokeCommand.rst
@@ -24,3 +24,4 @@ Revoke access to a restricted command
 
 
 
+

--- a/doc/sphinx/plugins/restricted/accountUnexpire.rst
+++ b/doc/sphinx/plugins/restricted/accountUnexpire.rst
@@ -23,3 +23,4 @@ When the bastion is configured to expire accounts that haven't been seen in a wh
 this command can be used to activate them back.
 
 
+

--- a/doc/sphinx/plugins/restricted/groupDelete.rst
+++ b/doc/sphinx/plugins/restricted/groupDelete.rst
@@ -24,3 +24,4 @@ Delete a group
 
 
 
+

--- a/doc/sphinx/plugins/restricted/realmCreate.rst
+++ b/doc/sphinx/plugins/restricted/realmCreate.rst
@@ -34,3 +34,4 @@ Declare and create a new trusted realm
                       you'll be prompted interactively for it. Use double-quoting if your're under a shell.
 
 
+

--- a/doc/sphinx/plugins/restricted/realmDelete.rst
+++ b/doc/sphinx/plugins/restricted/realmDelete.rst
@@ -20,3 +20,4 @@ Delete a bastion realm
 
 
 
+

--- a/doc/sphinx/plugins/restricted/realmInfo.rst
+++ b/doc/sphinx/plugins/restricted/realmInfo.rst
@@ -20,3 +20,4 @@ Display information about a bastion realm
 
 
 
+

--- a/doc/sphinx/plugins/restricted/realmList.rst
+++ b/doc/sphinx/plugins/restricted/realmList.rst
@@ -20,3 +20,4 @@ List the bastions realms
 
 
 
+

--- a/doc/sphinx/plugins/restricted/rootListIngressKeys.rst
+++ b/doc/sphinx/plugins/restricted/rootListIngressKeys.rst
@@ -19,3 +19,4 @@ As it gives some information as to who can be root on the underlying system,
 please grant this command only to accounts that need to have this information.
 
 
+

--- a/doc/sphinx/plugins/restricted/selfAddPersonalAccess.rst
+++ b/doc/sphinx/plugins/restricted/selfAddPersonalAccess.rst
@@ -60,3 +60,4 @@ Add a personal server access on your account
 
 
 
+

--- a/doc/sphinx/plugins/restricted/selfDelPersonalAccess.rst
+++ b/doc/sphinx/plugins/restricted/selfDelPersonalAccess.rst
@@ -44,3 +44,4 @@ Remove a personal server access from your account
 
 
 
+

--- a/doc/sphinx/plugins/restricted/whoHasAccessTo.rst
+++ b/doc/sphinx/plugins/restricted/whoHasAccessTo.rst
@@ -47,3 +47,4 @@ This is only true if the remote server does have the group key installed, of cou
 can't tell without trying to connect "right now" (which it won't do).
 
 
+

--- a/etc/bastion/bastion.conf.dist
+++ b/etc/bastion/bastion.conf.dist
@@ -262,6 +262,11 @@
 #  DEFAULT: true
 "displayLastLogin": true,
 #
+# allowUTF8 (boolean)
+#     DESC: When ``true``, The Bastion will use some UTF-8 characters on the output, for a more pleasant experience (for warnings, critical messages, etc.). Note that if the terminal doesn't advertise UTF-8 support, UTF-8 will not be used, even when enabled here.
+#  DEFAULT: true
+"allowUTF8": true,
+#
 # interactiveModeAllowed (boolean)
 #     DESC: If set to ``true``, ``--interactive`` mode is allowed. Otherwise, this feature is disabled.
 #  DEFAULT: true

--- a/lib/perl/OVH/Bastion/configuration.inc
+++ b/lib/perl/OVH/Bastion/configuration.inc
@@ -226,7 +226,7 @@ sub load_configuration {
             options => [
                 qw{
                   enableSyslog enableGlobalAccessLog enableAccountAccessLog enableGlobalSqlLog enableAccountSqlLog displayLastLogin
-                  interactiveModeByDefault
+                  interactiveModeByDefault allowUTF8
                   }
             ],
         },


### PR DESCRIPTION
To enhance the readability and visibility of important messages
(such as critical ones). This can be disabled with the `allowUTF8`
global option set to `false`. It's never enabled if the user locale
or their terminal don't seem to support it.