### PR TITLE
accountModify - Add a new `accept-new` POLICY in egress-strict-host-key-checking parameter

### DIFF
--- a/bin/helper/osh-accountModify
+++ b/bin/helper/osh-accountModify
@@ -288,7 +288,7 @@ foreach my $tuple (@modify) {
     }
     elsif ($key eq 'egress-strict-host-key-checking') {
         osh_info "Changing the egress StrictHostKeyChecking option for this account...";
-        if (not grep { $value eq $_ } qw{ yes no ask default bypass }) {
+        if (not grep { $value eq $_ } qw{ yes accept-new no ask default bypass }) {
             osh_warn "Invalid parameter '$value', skipping";
             $result{$jsonkey} = R('ERR_INVALID_PARAMETER');
         }

--- a/bin/plugin/restricted/accountModify
+++ b/bin/plugin/restricted/accountModify
@@ -39,7 +39,7 @@ Usage: --osh SCRIPT_NAME --account ACCOUNT [--option value [--option value [...]
                                                 this overrides the global bastion configuration 'accountMFAPolicy'. If 'bypass' is specified,
                                                 no OTP will ever be asked, even for groups or plugins explicitly requiring it
   --egress-strict-host-key-checking POLICY   Modify the egress SSH behavior of this account regarding StrictHostKeyChecking (see man ssh_config),
-                                               POLICY can be 'yes', 'no', 'ask', 'default' or 'bypass'
+                                               POLICY can be 'yes', 'accept-new', 'no', 'ask', 'default' or 'bypass'
   --personal-egress-mfa-required POLICY      Enforce UNIX password requirement, or TOTP requirement, or any MFA requirement, when connecting to a server
                                                using the personal keys of the account, POLICY can be 'password', 'totp', 'any' or 'none'
   --always-active yes|no                     Set or unset the account as always active (i.e. disable the check of the 'active' status on this account)
@@ -78,9 +78,9 @@ foreach my $key (qw{ always-active pam-auth-bypass idle-ignore osh-only }) {
         osh_exit 'ERR_INVALID_PARAMETER', "Expected '--$key yes' or '--$key no' instead of '--$key $modify{$key}'";
     }
 }
-if ($modify{'egress-strict-host-key-checking'} && !grep { $modify{'egress-strict-host-key-checking'} eq $_ } qw{ yes no ask default bypass }) {
+if ($modify{'egress-strict-host-key-checking'} && !grep { $modify{'egress-strict-host-key-checking'} eq $_ } qw{ yes accept-new no ask default bypass }) {
     help();
-    osh_exit 'ERR_INVALID_PARAMETER', "Expected option 'yes', 'no', 'ask', 'default' or 'bypass' to --egress-strict-host-key-checking";
+    osh_exit 'ERR_INVALID_PARAMETER', "Expected option 'yes', 'accept-new', 'no', 'ask', 'default' or 'bypass' to --egress-strict-host-key-checking";
 }
 if ($modify{'personal-egress-mfa-required'} && !grep { $modify{'personal-egress-mfa-required'} eq $_ } qw{ password totp any none }) {
     help();

--- a/bin/plugin/restricted/accountModify.json
+++ b/bin/plugin/restricted/accountModify.json
@@ -1,13 +1,13 @@
 {
     "master_only": true,
     "interactive": [
-        "accountModify"                                                                       , {"ac": ["--account"]},
-        "accountModify --account"                                                             , {"ac": ["<ACCOUNT>"]},
-        "accountModify --account \\S+"                                                        , {"ac": ["--mfa-password-required","--mfa-totp-required","--pam-auth-bypass","--always-active","--egress-strict-host-key-checking","--personal-egress-mfa-required","--idle-ignore"]},
-        "accountModify --account \\S+ .*(--mfa-password-required|--mfa-totp-required)"        , {"ac": ["yes","no","bypass"]},
+        "accountModify"                                                                                   , {"ac": ["--account"]},
+        "accountModify --account"                                                                         , {"ac": ["<ACCOUNT>"]},
+        "accountModify --account \\S+"                                                                    , {"ac": ["--mfa-password-required","--mfa-totp-required","--pam-auth-bypass","--always-active","--egress-strict-host-key-checking","--personal-egress-mfa-required","--idle-ignore"]},
+        "accountModify --account \\S+ .*(--mfa-password-required|--mfa-totp-required)"                    , {"ac": ["yes","no","bypass"]},
         "accountModify --account \\S+ .*(--pam-auth-bypass|--mfa-auth-bypass|--always-active|idle-ignore)", {"ac": ["yes","no"]},
-        "accountModify --account \\S+ .*(--egress-strict-host-key-checking)"                  , {"ac": ["yes","no","ask","default","bypass"]},
-        "accountModify --account \\S+ .*(--personal-egress-mfa-required)"                     , {"ac": ["password","totp","any","none"]},
-        "accountModify --account \\S+ .*(yes|no|bypass|ask|default|totp|password|none)"       , {"ac": ["--mfa-password-required","--mfa-totp-required","--pam-auth-bypass","--always-active","--egress-strict-host-key-checking","--personal-egress-mfa-required","--idle-ignore","<enter>"]}
+        "accountModify --account \\S+ .*(--egress-strict-host-key-checking)"                              , {"ac": ["yes","accept-new","no","ask","default","bypass"]},
+        "accountModify --account \\S+ .*(--personal-egress-mfa-required)"                                 , {"ac": ["password","totp","any","none"]},
+        "accountModify --account \\S+ .*(yes|accept-new|no|bypass|ask|default|totp|password|none)"        , {"ac": ["--mfa-password-required","--mfa-totp-required","--pam-auth-bypass","--always-active","--egress-strict-host-key-checking","--personal-egress-mfa-required","--idle-ignore","<enter>"]}
     ]
 }

--- a/doc/sphinx/plugins/restricted/accountModify.rst
+++ b/doc/sphinx/plugins/restricted/accountModify.rst
@@ -40,7 +40,7 @@ Modify an account configuration
 
    Modify the egress SSH behavior of this account regarding StrictHostKeyChecking (see man ssh_config),
 
-                                               POLICY can be 'yes', 'no', 'ask', 'default' or 'bypass'
+                                               POLICY can be 'yes', 'accept-new', 'no', 'ask', 'default' or 'bypass'
 .. option:: --personal-egress-mfa-required POLICY    
 
    Enforce UNIX password requirement, or TOTP requirement, or any MFA requirement, when connecting to a server

--- a/tests/functional/tests.d/330-selfkeys.sh
+++ b/tests/functional/tests.d/330-selfkeys.sh
@@ -94,6 +94,14 @@ testsuite_selfkeys()
     json .value.account_egress_ssh_config.type custom
     json .value.account_egress_ssh_config.items.stricthostkeychecking no
 
+    success accountssh modifyssh2 $a0 --osh accountModify --account $account1 --egress-strict-host-key-checking accept-new
+    json .error_code OK .command accountModify
+
+    success accountssh info2 $a0 --osh accountInfo --account $account1
+    json .error_code OK .command accountInfo
+    json .value.account_egress_ssh_config.type custom
+    json .value.account_egress_ssh_config.items.stricthostkeychecking accept-new
+
     success accountssh modifyssh2 $a0 --osh accountModify --account $account1 --egress-strict-host-key-checking yes
     json .error_code OK .command accountModify
 


### PR DESCRIPTION
Hi,

Currently, the parameter `--egress-strict-host-key-checking` of `accountModify` plugin only supports `yes`, `no`, `ask`, `default`, `bypass` and then references `man ssh_config` for additional informations.

One of the keyword is missing, it is called `accept-new` and is very convenient in our usage with The Bastion and CI/CD. It permits to auto accept new HostKeys but blocks in case of the already auto accepted HostKey is changed, to avoid MitM.
It something between `yes` and `no`.

I tested this code in our The Bastion test cluster which is running `v3.03.01`.

Regards,
DCO: Signed-off-by: Jonathan Marsaud <jonathan.marsaud@iguanesolutions.com>