### PR TITLE
feat: add groupDestroy command for owners

### DIFF
--- a/bin/helper/osh-groupDelete
+++ b/bin/helper/osh-groupDelete
@@ -2,6 +2,8 @@
 # vim: set filetype=perl ts=4 sw=4 sts=4 et:
 # NEEDGROUP osh-groupDelete
 # SUDOERS %osh-groupDelete ALL=(root) NOPASSWD:/usr/bin/env perl -T /opt/bastion/bin/helper/osh-groupDelete *
+# KEYSUDOERS # as an owner, we can delete our own group
+# KEYSUDOERS SUPEROWNERS, %%GROUP%-owner      ALL=(root)        NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupDelete --group %GROUP%
 # FILEMODE 0700
 # FILEOWN 0 0
 
@@ -50,20 +52,6 @@ if (!$group) {
 
 #<HEADER
 
-#>RIGHTSCHECK
-if ($self eq 'root') {
-    osh_debug "Real root, skipping checks of permissions";
-}
-else {
-    # need to perform another security check
-    $fnret = OVH::Bastion::is_user_in_group(user => $self, group => "osh-groupDelete");
-    if (!$fnret) {
-        HEXIT('ERR_SECURITY_VIOLATION', msg => "You're not allowed to run this, dear $self");
-    }
-}
-
-#<RIGHTSCHECK
-
 #>PARAMS:GROUP
 # test if start by key, append if necessary
 osh_debug("Checking group");
@@ -75,6 +63,25 @@ $group = $fnret->value->{'group'};
 my $shortGroup = $fnret->value->{'shortGroup'};
 
 #<PARAMS:GROUP
+
+#>RIGHTSCHECK
+if ($self eq 'root') {
+    osh_debug "Real root, skipping checks of permissions";
+}
+else {
+    # either we can delete any group
+    $fnret = OVH::Bastion::is_user_in_group(user => $self, group => "osh-groupDelete");
+    if (!$fnret) {
+
+        # or we can delete our own group as the owner of said group
+        $fnret = OVH::Bastion::is_group_owner(account => $self, group => $shortGroup, sudo => 1, superowner => 1);
+        if (!$fnret) {
+            HEXIT('ERR_SECURITY_VIOLATION', msg => "You're not allowed to run this, dear $self");
+        }
+    }
+}
+
+#<RIGHTSCHECK
 
 #>CODE
 # last security check

--- a/bin/plugin/group-owner/groupDestroy
+++ b/bin/plugin/group-owner/groupDestroy
@@ -1,6 +1,5 @@
 #! /usr/bin/env perl
 # vim: set filetype=perl ts=4 sw=4 sts=4 et:
-# TODO move this from restricted/ to group-owner/
 
 use common::sense;
 
@@ -25,8 +24,8 @@ Usage: --osh SCRIPT_NAME --group GROUP
   --group GROUP  Group name to delete
   --no-confirm   Skip group name confirmation, but blame yourself if you deleted the wrong group!
 
-This restricted command is able to delete any group. Group owners can however delete
-their own groups using the sibling `groupDestroy` command.
+This command is able to delete any group you're an owner of.
+Granted users to the sibling restricted command `groupDelete` can delete any group.
 EOF
 );
 
@@ -50,6 +49,11 @@ $fnret or osh_exit($fnret);
 # get returned untainted value
 $group = $fnret->value->{'group'};
 my $shortGroup = $fnret->value->{'shortGroup'};
+
+$fnret = OVH::Bastion::is_group_owner(group => $shortGroup, account => $self, superowner => 1);
+if (!$fnret) {
+    osh_exit 'ERR_NOT_GROUP_OWNER', "Sorry, you're not an owner of group $shortGroup, which is needed to being able to delete it";
+}
 
 if (!$noConfirm) {
     osh_info <<'EOS';

--- a/bin/plugin/group-owner/groupDestroy.json
+++ b/bin/plugin/group-owner/groupDestroy.json
@@ -1,0 +1,9 @@
+{
+    "interactive": [
+        "groupDestroy"              ,  {"ac" : ["--group"]},
+        "groupDestroy --group"      ,  {"ac" : ["<GROUP>"]},
+        "groupDestroy --group \\S+" ,  {"pr" : "<enter>"}
+    ],
+    "master_only": true,
+    "terminal_mode": "raw"
+}

--- a/bin/shell/connect.pl
+++ b/bin/shell/connect.pl
@@ -143,11 +143,11 @@ if ($sshClientHasOptionE) {
 my @comments;
 my $header;
 if (open(my $fh_ttyrec, '<', $saveFile)) {
-    read $fh_ttyrec, $header, 1000;    # 1K if there's the host key changed warning
+    read $fh_ttyrec, $header, 2000;    # 2K if there's the host key changed warning
     close($fh_ttyrec);
 }
 elsif (-r "$saveFile.zst") {
-    my $fnret = OVH::Bastion::execute(cmd => ['zstd', '-d', '-c', "$saveFile.zst"], max_stdout_bytes => 1000, must_succeed => 1);
+    my $fnret = OVH::Bastion::execute(cmd => ['zstd', '-d', '-c', "$saveFile.zst"], max_stdout_bytes => 2000, must_succeed => 1);
     $header = join("\n", @{$fnret->value->{'stdout'} || []}) if $fnret;
 }
 

--- a/doc/sphinx/plugins/group-owner/index.rst
+++ b/doc/sphinx/plugins/group-owner/index.rst
@@ -11,6 +11,7 @@ group-owner plugins
    groupDelEgressKey
    groupDelGatekeeper
    groupDelOwner
+   groupDestroy
    groupGenerateEgressKey
    groupGeneratePassword
    groupModify

--- a/doc/sphinx/plugins/restricted/groupDelete.rst
+++ b/doc/sphinx/plugins/restricted/groupDelete.rst
@@ -23,5 +23,8 @@ Delete a group
    Skip group name confirmation, but blame yourself if you deleted the wrong group!
 
 
+This restricted command is able to delete any group. Group owners can however delete
+their own groups using the sibling `groupDestroy` command.
+
 
 

--- a/etc/sudoers.group.template.d/500-base.sudoers
+++ b/etc/sudoers.group.template.d/500-base.sudoers
@@ -21,13 +21,18 @@ SUPEROWNERS, %%GROUP%-owner      ALL=(keykeeper)   NOPASSWD: /usr/bin/env perl -
 
 # as a gatekeeper, we can grant/revoke membership
 SUPEROWNERS, %%GROUP%-gatekeeper ALL=(root)        NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupSetRole --type member --group %GROUP% *
+
 # as a gatekeeper, to be able to symlink in /home/allowkeeper/ACCOUNT the /home/%GROUP%/allowed.ip file
 SUPEROWNERS, %%GROUP%-gatekeeper ALL=(allowkeeper) NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupAddSymlinkToAccount --group %GROUP% *
 
 # as a gatekeeper, we can grant/revoke a guest access
 SUPEROWNERS, %%GROUP%-gatekeeper ALL=(root)        NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupSetRole --type guest --group %GROUP% *
+
 # as a gatekeeper, to be able to add the servers to /home/allowkeeper/ACCOUNT/allowed.partial.%GROUP% file
 SUPEROWNERS, %%GROUP%-gatekeeper ALL=(allowkeeper) NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-accountAddGroupServer --group %GROUP% *
 
 # as an aclkeeper, we can add/del a server from the group server list in /home/%GROUP%/allowed.ip
 SUPEROWNERS, %%GROUP%-aclkeeper  ALL=(%GROUP%)     NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupAddServer --group %GROUP% *
+
+# as an owner, we can delete our own group
+SUPEROWNERS, %%GROUP%-owner      ALL=(root)        NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupDelete --group %GROUP%

--- a/tests/functional/tests.d/350-groups.sh
+++ b/tests/functional/tests.d/350-groups.sh
@@ -1170,21 +1170,19 @@ EOS
     )
     unset tmpfp
 
-    grant groupDelete
+    plgfail  end   groupDestroy_fail   $a2 --osh groupDestroy --group $group3 --no-confirm
+    retvalshouldbe 100
+    json .command groupDestroy .error_code ERR_NOT_GROUP_OWNER
 
-    script   end   groupDelete   $a0 --osh groupDelete --group $group3 '<<<' "$group3"
-    retvalshouldbe 0
-    json .command groupDelete .error_code OK
+    success  end   groupDestroy   $a3 --osh groupDestroy --group $group3 --no-confirm
+    json .command groupDestroy .error_code OK
 
-    script   end   groupDelete   $a0 --osh groupDelete --group $group2 '<<<' "$group2"
-    retvalshouldbe 0
-    json .command groupDelete .error_code OK
+    success  end   groupDestroy   $a2 --osh groupDestroy --group $group2 --no-confirm
+    json .command groupDestroy .error_code OK
 
-    script   end   groupDelete   $a0 --osh groupDelete --group $group1 '<<<' "$group1"
-    retvalshouldbe 0
-    json .command groupDelete .error_code OK
+    success  end   groupDestroy   $a2 --osh groupDestroy --group $group1 --no-confirm
+    json .command groupDestroy .error_code OK
 
-    revoke groupDelete
     grant accountDelete
 
     script   end   accountDelete   $a0 --osh accountDelete --account $account3 "<<< \"Yes, do as I say and delete $account3, kthxbye\""


### PR DESCRIPTION
This command deletes a group, as `groupDelete` does, but works
for owners so that they can delete their own group.
`groupDelete` remains as a restricted command, able to delete any group.