### PR TITLE
Feat: Add admin and super owner accounts list in info plugin

### DIFF
--- a/bin/plugin/open/info
+++ b/bin/plugin/open/info
@@ -134,6 +134,16 @@ else {
 }
 $ret{'slave_mode'} = $config->{'readOnlySlaveMode'};
 
+if (OVH::Bastion::is_auditor(account => $self)) {
+    my @adminAccounts = @{$config->{'adminAccounts'}};
+    osh_info "My admins are: " . colored(@adminAccounts ? join(", ", @adminAccounts) : "-", "magenta");
+    $ret{'adminAccounts'} = \@adminAccounts;
+
+    my @superOwnerAccounts = @{$config->{'superOwnerAccounts'}};
+    osh_info "My super owners are: " . colored(@superOwnerAccounts ? join(", ", @superOwnerAccounts) : "-", "magenta");
+    $ret{'superOwnerAccounts'} = \@superOwnerAccounts;
+}
+
 my @allowedNets = @{$config->{'allowedNetworks'}};
 osh_info "The networks I'm able to connect you to on the egress side are: " . colored(@allowedNets ? join(", ", @allowedNets) : "all", "magenta");
 $ret{'allowed_networks_list'} = \@allowedNets;

--- a/tests/functional/tests.d/320-base.sh
+++ b/tests/functional/tests.d/320-base.sh
@@ -7,6 +7,12 @@
 
 testsuite_base()
 {
+    grant accountCreate
+    # create regular account to compare info access between auditor and non auditor
+    success accountCreate a0_create_a1 $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key "\"$(cat $account1key1file.pub)\""
+    json .error_code OK .command accountCreate .value null
+    revoke accountCreate
+
     # basic stuff and help
     run     base  nocmd     $a0
     retvalshouldbe 112
@@ -30,9 +36,30 @@ testsuite_base()
     contain "Unknown command"
     json .error_code KO_UNKNOWN_COMMAND .command null .value null
 
+    # grant account0 as admin
+    success admin_superowner set_a0_as_admin $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; add_user_to_group_compat $account0 osh-admin\""
+    configchg 's=^\\\\x22adminAccounts\\\\x22.+=\\\\x22adminAccounts\\\\x22:[\\\\x22'"$account0"'\\\\x22],='
+    # grant account1 as auditor
+    success osh   accountGrantAuditor $a0 --osh accountGrantCommand --command auditor --account $account1
+    success osh   info $a1                --osh info
+    contain "Your alias to connect"
+    contain "My admins are: "
+    contain "My super owners are: "
+    json .error_code OK .command info .value.account $account1 .value.adminAccounts '["'"$account0"'"]'
+
+
+    # now check that regular user do not see admins list
     success osh   info $a0 -osh info
     contain "Your alias to connect"
+    nocontain "My admins are: "
+    nocontain "My super owners are: "
     json .error_code OK .command info .value.account $account0
+
+    # delete account1
+    grant accountDelete
+    success admin_superowner delete_a1 $a0 --osh accountDelete --account $account1 --no-confirm
+    revoke accountDelete
+
 }
 
 testsuite_base


### PR DESCRIPTION
For auditing purposes, get admin and super owner list in info plugin
Available for auditor role only