### PR TITLE
Feat: Add SSHFP support for egress connections

### DIFF
--- a/bin/plugin/open/scp
+++ b/bin/plugin/open/scp
@@ -183,7 +183,9 @@ if (not $atleastonekey) {
     );
 }
 
-push @cmd, "--", $ip, $decoded;
+my $hostto = OVH::Bastion::ip2host($ip)->value || $ip;
+
+push @cmd, "--", $hostto, $decoded;
 
 =cut attempt to be more secure than even standard scp, but don't bother ...
 my ($additionalParams,$remoteFile) = ($2,$3);

--- a/bin/shell/osh.pl
+++ b/bin/shell/osh.pl
@@ -1143,7 +1143,7 @@ else {
         $passwordFile = $fnretpass->value;
         osh_debug("going to use ssh with this password file : $passwordFile");
         print " will use SSH with password autologin\n\n" unless $quiet;
-        push @command, $OVH::Bastion::BASEPATH . '/bin/shell/autologin', 'ssh', $user, $ip, $port, $passwordFile, ($timeout ? $timeout : 45);
+        push @command, $OVH::Bastion::BASEPATH . '/bin/shell/autologin', 'ssh', $user, $hostto, $port, $passwordFile, ($timeout ? $timeout : 45);
 
     }
 
@@ -1159,7 +1159,7 @@ else {
         # also set password if allowed in bastion config (to allow users to enter a remote password interactively)
         push @preferredAuths, 'password' if $config->{'passwordAllowed'};
 
-        push @command, '/usr/bin/ssh', $ip, '-l', $user, '-p', $port;
+        push @command, '/usr/bin/ssh', $hostto, '-l', $user, '-p', $port;
 
         my @keysToTry;
         print " will try the following accesses you have: \n" unless $quiet;


### PR DESCRIPTION
Allow SSHFP fields to be used for connections between The Bastion and backends.

For SSH we just replace `$ip` by `$hostto` and for SCP we use `ip2host` with `$ip` to obtain hostname.

When the host cannot be resolved or  no SSHFP fields available (dns unreachable or no SSHFP / PTR entry):, classical TOFU is used

`ip2host` call : 

```
my $hostto = OVH::Bastion::ip2host($ip)->value || $ip;
```