### PR TITLE
enh: accountInfo: add --list-groups

### DIFF
--- a/bin/plugin/restricted/accountInfo
+++ b/bin/plugin/restricted/accountInfo
@@ -15,13 +15,14 @@ use OVH::Bastion::Plugin qw( :DEFAULT help );
 OVH::Bastion::Plugin::begin(
     argv     => \@ARGV,
     header   => "account information",
-    options  => {'account=s' => \my $account},
+    options  => {'account=s' => \my $account, "list-groups" => \my $listGroups},
     helptext => <<'EOF',
 Display some information about an account
 
-Usage: --osh SCRIPT_NAME --account ACCOUNT
+Usage: --osh SCRIPT_NAME --account ACCOUNT [--list-groups]
 
   --account ACCOUNT  The account name to work on
+  --list-groups      Show which groups the account has a role on
 EOF
 );
 
@@ -64,34 +65,37 @@ if (!@granted) {
 }
 $ret{'allowed_commands'} = \@granted;
 
-$fnret = OVH::Bastion::get_group_list(groupType => "key");
-$fnret or osh_exit $fnret;
-
-osh_info "\nThis account is part of the following groups:";
-
 my $result_hash = {};
-foreach my $name (sort keys %{$fnret->value}) {
-    my @flags;
-    push @flags, 'owner' if OVH::Bastion::is_group_owner(group => $name, account => $account);
-    push @flags, 'gatekeeper' if OVH::Bastion::is_group_gatekeeper(group => $name, account => $account);
-    push @flags, 'aclkeeper' if OVH::Bastion::is_group_aclkeeper(group => $name, account => $account);
-    push @flags, 'member' if OVH::Bastion::is_group_member(group => $name, account => $account);
-    push @flags, 'guest' if OVH::Bastion::is_group_guest(group => $name, account => $account);
-    if (@flags) {
-        my $line = sprintf "%18s", $name;
-        $line .= sprintf " %14s", colored(grep({ $_ eq 'owner' } @flags)      ? 'Owner'      : '-', 'red');
-        $line .= sprintf " %19s", colored(grep({ $_ eq 'gatekeeper' } @flags) ? 'GateKeeper' : '-', 'yellow');
-        $line .= sprintf " %18s", colored(grep({ $_ eq 'aclkeeper' } @flags)  ? 'ACLKeeper'  : '-', 'magenta');
-        $line .= sprintf " %15s", colored(grep({ $_ eq 'member' } @flags)     ? 'Member'     : '-', 'green');
-        $line .= sprintf " %14s", colored(grep({ $_ eq 'guest' } @flags)      ? 'Guest'      : '-', 'cyan');
-        osh_info $line;
-        $result_hash->{$name} = {flags => \@flags, name => $name};
+
+if ($listGroups) {
+    $fnret = OVH::Bastion::get_group_list(groupType => "key");
+    $fnret or osh_exit $fnret;
+
+    osh_info "\nThis account is part of the following groups:";
+
+    foreach my $name (sort keys %{$fnret->value}) {
+        my @flags;
+        push @flags, 'owner' if OVH::Bastion::is_group_owner(group => $name, account => $account);
+        push @flags, 'gatekeeper' if OVH::Bastion::is_group_gatekeeper(group => $name, account => $account);
+        push @flags, 'aclkeeper' if OVH::Bastion::is_group_aclkeeper(group => $name, account => $account);
+        push @flags, 'member' if OVH::Bastion::is_group_member(group => $name, account => $account);
+        push @flags, 'guest' if OVH::Bastion::is_group_guest(group => $name, account => $account);
+        if (@flags) {
+            my $line = sprintf "%18s", $name;
+            $line .= sprintf " %14s", colored(grep({ $_ eq 'owner' } @flags)      ? 'Owner'      : '-', 'red');
+            $line .= sprintf " %19s", colored(grep({ $_ eq 'gatekeeper' } @flags) ? 'GateKeeper' : '-', 'yellow');
+            $line .= sprintf " %18s", colored(grep({ $_ eq 'aclkeeper' } @flags)  ? 'ACLKeeper'  : '-', 'magenta');
+            $line .= sprintf " %15s", colored(grep({ $_ eq 'member' } @flags)     ? 'Member'     : '-', 'green');
+            $line .= sprintf " %14s", colored(grep({ $_ eq 'guest' } @flags)      ? 'Guest'      : '-', 'cyan');
+            osh_info $line;
+            $result_hash->{$name} = {flags => \@flags, name => $name};
+        }
     }
+    if (not keys %$result_hash) {
+        osh_info "(none)";
+    }
+    osh_info "\n";
 }
-if (not keys %$result_hash) {
-    osh_info "(none)";
-}
-osh_info "\n";
 
 $ret{'groups'} = $result_hash;
 

--- a/doc/sphinx/plugins/restricted/accountInfo.rst
+++ b/doc/sphinx/plugins/restricted/accountInfo.rst
@@ -9,7 +9,7 @@ Display some information about an account
 .. admonition:: usage
    :class: cmdusage
 
-   --osh accountInfo --account ACCOUNT
+   --osh accountInfo --account ACCOUNT [--list-groups]
 
 .. program:: accountInfo
 
@@ -17,6 +17,10 @@ Display some information about an account
 .. option:: --account ACCOUNT
 
    The account name to work on
+
+.. option:: --list-groups    
+
+   Show which groups the account has a role on
 
 Output example
 ==============

--- a/tests/functional/tests.d/325-accountinfo.sh
+++ b/tests/functional/tests.d/325-accountinfo.sh
@@ -30,11 +30,11 @@ testsuite_accountinfo()
 
     # a0 should see basic info about a2
     success 325-accountinfo a0_accountinfo_a2_basic $a0 --osh accountInfo --account $account2
-    json_document '{"error_message":"OK","command":"accountInfo","error_code":"OK","value":{"always_active":1,"is_active":1,"allowed_commands":[],"groups":{}}}'
+    json_document '{"error_message":"OK","command":"accountInfo","error_code":"OK","value":{"always_active":1,"is_active":1,"allowed_commands":[],}}'
 
     # a1 should see detailed info about a2
     success 325-accountinfo a1_accountinfo_a2_detailed $a1 --osh accountInfo --account $account2
-    json .error_code OK .command accountInfo .value.always_active 1 .value.is_active 1 .value.allowed_commands "[]" .value.groups "{}"
+    json .error_code OK .command accountInfo .value.always_active 1 .value.is_active 1 .value.allowed_commands "[]"
     json .value.ingress_piv_policy null .value.personal_egress_mfa_required none .value.pam_auth_bypass 0
     json .value.password.min_days 0 .value.password.warn_days 7 .value.password.user "$account2" .value.password.password locked
     json .value.password.inactive_days -1 .value.password.date_disabled null .value.password.date_disabled_timestamp 0 .value.password.date_changed $(date +%Y-%m-%d)


### PR DESCRIPTION
Listing groups can be slow on bastions having thousands
of groups, hence this is now disabled by default.