### PR TITLE
chore: remove useless 'section' test info

### DIFF
--- a/tests/functional/docker/docker_build_and_run_tests.sh
+++ b/tests/functional/docker/docker_build_and_run_tests.sh
@@ -9,7 +9,7 @@ basedir=$(readlink -f "$(dirname "$0")"/../../..)
 namespace=the-bastion-test
 
 target="$1"
-shift
+shift || true
 
 # all remaining options will be passed as-is on the target docker, through target_role.sh to launch-tests-on-instance.sh
 
@@ -45,9 +45,12 @@ print_supported_targets() {
 
 if [ -z "$target" ] || [ "$target" = "--list-targets" ]; then
     if [ -z "$target" ]; then
-        echo "Usage: $0 <TARGET>" >&2
-        echo "Supported targets are: " >&2
-        print_supported_targets >&2
+        echo "Usage: $0 <TARGET> [additional options]"
+        echo
+        echo "Supported targets are: "
+        print_supported_targets
+        echo "These additional options are passed directly to the worker:"
+        "$basedir"/tests/functional/launch_tests_on_instance.sh --help-light
         exit 1
     else
         # shellcheck disable=SC2086

--- a/tests/functional/tests.d/300-activeness.sh
+++ b/tests/functional/tests.d/300-activeness.sh
@@ -9,33 +9,33 @@ testsuite_activeness()
 {
     grant accountCreate
     # create account1 on local bastion
-    success activeness create_account1 $a0 --osh accountCreate --account $account1 --uid $uid1 --public-key \""$(cat $account1key1file.pub)"\"
+    success create_account1 $a0 --osh accountCreate --account $account1 --uid $uid1 --public-key \""$(cat $account1key1file.pub)"\"
     json .error_code OK .command accountCreate .value null
 
-    success activeness create_account2 $a0 --osh accountCreate --account $account2 --uid $uid2 --public-key \""$(cat $account2key1file.pub)"\"
+    success create_account2 $a0 --osh accountCreate --account $account2 --uid $uid2 --public-key \""$(cat $account2key1file.pub)"\"
     json .error_code OK .command accountCreate .value null
 
-    success activeness create_account3 $a0 --osh accountCreate --account $account3 --uid $uid3 --always-active --public-key \""$(cat $account3key1file.pub)"\"
+    success create_account3 $a0 --osh accountCreate --account $account3 --uid $uid3 --always-active --public-key \""$(cat $account3key1file.pub)"\"
     json .error_code OK .command accountCreate .value null
 
     revoke accountCreate
 
     configchg 's=^\\\\x22accountExternalValidationProgram\\\\x22.+=\\\\x22accountExternalValidationProgram\\\\x22:\\\\x22/opt/bastion/bin/other/doesnotexist.pl\\\\x22,='
 
-    success activeness test_invalid_config_but_always_active $a3 --osh info
+    success test_invalid_config_but_always_active $a3 --osh info
 
     ignorecodewarn 'is not readable+executable'
-    run activeness test_invalid_config $a1 --osh info
+    run test_invalid_config $a1 --osh info
     retvalshouldbe 101
 
     configchg 's=^\\\\x22accountExternalValidationProgram\\\\x22.+=\\\\x22accountExternalValidationProgram\\\\x22:\\\\x22/opt/bastion/bin/other/check-active-account-fortestsonly.pl\\\\x22,='
 
-    run activeness test_account1 $a1 --osh info
+    run test_account1 $a1 --osh info
     retvalshouldbe 101
 
-    success activeness test_account2 $a2 --osh info
+    success test_account2 $a2 --osh info
 
-    success activeness test_account3 $a3 --osh info
+    success test_account3 $a3 --osh info
 
     # for remaining tests, disable the feature
     configchg 's=^\\\\x22accountExternalValidationProgram\\\\x22.+=\\\\x22accountExternalValidationProgram\\\\x22:\\\\x22\\\\x22,='
@@ -43,14 +43,14 @@ testsuite_activeness()
     grant accountDelete
 
     # delete account1
-    success realm account1_cleanup $a0 --osh accountDelete --account $account1 --no-confirm
+    success account1_cleanup $a0 --osh accountDelete --account $account1 --no-confirm
 
     # delete account2
-    script realm account2_cleanup "$a0 --osh accountDelete --account $account2 <<< \"Yes, do as I say and delete $account2, kthxbye\""
+    script account2_cleanup "$a0 --osh accountDelete --account $account2 <<< \"Yes, do as I say and delete $account2, kthxbye\""
     retvalshouldbe 0
 
     # delete account3
-    success realm account3_cleanup $a0 --osh accountDelete --account $account3 --no-confirm
+    success account3_cleanup $a0 --osh accountDelete --account $account3 --no-confirm
 
     revoke accountDelete
 }

--- a/tests/functional/tests.d/305-admin-superowner.sh
+++ b/tests/functional/tests.d/305-admin-superowner.sh
@@ -11,63 +11,63 @@ testsuite_admin_superowner()
     grant groupCreate
 
     # create account1
-    success admin_superowner create_a1 $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key "\"$(cat $account1key1file.pub)\""
+    success create_a1 $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key "\"$(cat $account1key1file.pub)\""
     json .error_code OK .command accountCreate .value null
 
     # create a group, account1 is not a member or anything
-    success admin_superowner create_g1 $a0 --osh groupCreate --owner $account0 --no-key --group $group1
+    success create_g1 $a0 --osh groupCreate --owner $account0 --no-key --group $group1
     json .error_code OK .command groupCreate
 
     # account1 can't add members
-    run admin_superowner a1_add_members_g1_fail $a1 --osh groupAddMember --group $group1 --account $account1
+    run a1_add_members_g1_fail $a1 --osh groupAddMember --group $group1 --account $account1
     retvalshouldbe 106
     json .error_code KO_RESTRICTED_COMMAND .command null
 
     # now set account1 as superowner
-    success admin_superowner set_a1_as_superowner $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; add_user_to_group_compat $account1 osh-superowner\""
+    success set_a1_as_superowner $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; add_user_to_group_compat $account1 osh-superowner\""
     configchg 's=^\\\\x22superOwnerAccounts\\\\x22.+=\\\\x22superOwnerAccounts\\\\x22:[\\\\x22'"$account1"'\\\\x22],='
 
     # account1 now can add/del members
-    success admin_superowner a1_add_members_g1_ok $a1 --osh groupAddMember --group $group1 --account $account1
+    success a1_add_members_g1_ok $a1 --osh groupAddMember --group $group1 --account $account1
     json .error_code OK .command groupAddMember
     contain OVERRIDE
 
-    success admin_superowner a1_del_members_g1_ok $a1 --osh groupDelMember --group $group1 --account $account1
+    success a1_del_members_g1_ok $a1 --osh groupDelMember --group $group1 --account $account1
     json .error_code OK .command groupDelMember
     contain OVERRIDE
 
     # now set account1 as admin
-    success admin_superowner set_a1_as_admin $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; add_user_to_group_compat $account1 osh-admin\""
+    success set_a1_as_admin $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; add_user_to_group_compat $account1 osh-admin\""
     configchg 's=^\\\\x22adminAccounts\\\\x22.+=\\\\x22adminAccounts\\\\x22:[\\\\x22'"$account0"'\\\\x22,\\\\x22'"$account1"'\\\\x22],='
 
     # account1 now can add/del aclkeepers
-    success admin_superowner a1_add_gk_g1_ok $a1 --osh groupAddAclkeeper --group $group1 --account $account1
+    success a1_add_gk_g1_ok $a1 --osh groupAddAclkeeper --group $group1 --account $account1
     json .error_code OK .command groupAddAclkeeper
     contain OVERRIDE
 
-    success admin_superowner a1_del_gk_g1_ok $a1 --osh groupDelAclkeeper --group $group1 --account $account1
+    success a1_del_gk_g1_ok $a1 --osh groupDelAclkeeper --group $group1 --account $account1
     json .error_code OK .command groupDelAclkeeper
     contain OVERRIDE
 
     # now remove superowner grant from a1, the account is still admin so it should inherhit superowner powers
-    success admin_superowner del_a1_as_superowner $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; del_user_from_group_compat $account1 osh-superowner\""
+    success del_a1_as_superowner $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; del_user_from_group_compat $account1 osh-superowner\""
     configchg 's=^\\\\x22superOwnerAccounts\\\\x22.+=\\\\x22superOwnerAccounts\\\\x22:[],='
 
     # account1 can add/del gatekeepers
-    success admin_superowner a1_add_members_g1_ok2 $a1 --osh groupAddGatekeeper --group $group1 --account $account1
+    success a1_add_members_g1_ok2 $a1 --osh groupAddGatekeeper --group $group1 --account $account1
     json .error_code OK .command groupAddGatekeeper
     contain OVERRIDE
 
-    success admin_superowner a1_del_members_g1_ok2 $a1 --osh groupDelGatekeeper --group $group1 --account $account1
+    success a1_del_members_g1_ok2 $a1 --osh groupDelGatekeeper --group $group1 --account $account1
     json .error_code OK .command groupDelGatekeeper
     contain OVERRIDE
 
     # and finally remove admin grant
-    success admin_superowner del_a1_as_admin $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; del_user_from_group_compat $account1 osh-admin\""
+    success del_a1_as_admin $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; del_user_from_group_compat $account1 osh-admin\""
     configchg 's=^\\\\x22adminAccounts\\\\x22.+=\\\\x22adminAccounts\\\\x22:[\\\\x22'"$account0"'\\\\x22],='
 
     # account1 can no longer add members
-    run admin_superowner a1_add_members_g1_fail2 $a1 --osh groupAddMember --group $group1 --account $account1
+    run a1_add_members_g1_fail2 $a1 --osh groupAddMember --group $group1 --account $account1
     retvalshouldbe 106
     json .error_code KO_RESTRICTED_COMMAND .command null
 
@@ -76,11 +76,11 @@ testsuite_admin_superowner()
     grant accountDelete
     grant groupDelete
 
-    script admin_superowner delete_a1 $a0 --osh accountDelete --account $account1 "<<< \"Yes, do as I say and delete $account1, kthxbye\""
+    script delete_a1 $a0 --osh accountDelete --account $account1 "<<< \"Yes, do as I say and delete $account1, kthxbye\""
     retvalshouldbe 0
     json .command accountDelete .error_code OK
 
-    script admin_superowner delete_g1 "$a0 --osh groupDelete --group $group1 <<< $group1"
+    script delete_g1 "$a0 --osh groupDelete --group $group1 <<< $group1"
     retvalshouldbe 0
     json .command groupDelete .error_code OK
 

--- a/tests/functional/tests.d/310-realm.sh
+++ b/tests/functional/tests.d/310-realm.sh
@@ -14,62 +14,62 @@ testsuite_realm()
     grant accountModify
 
     # create account1 on local bastion
-    success realm create_account1 $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key \""$(cat $account1key1file.pub)"\"
+    success create_account1 $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key \""$(cat $account1key1file.pub)"\"
     json .error_code OK .command accountCreate .value null
-    success realm modify_account1 $a0 --osh accountModify --pam-auth-bypass yes --account $account1
+    success modify_account1 $a0 --osh accountModify --pam-auth-bypass yes --account $account1
     json .error_code OK .command accountModify
 
     # create account2 on local bastion
-    success realm create_account2 $a0 --osh accountCreate --always-active --account $account2 --uid $uid2 --public-key \""$(cat $account2key1file.pub)"\"
+    success create_account2 $a0 --osh accountCreate --always-active --account $account2 --uid $uid2 --public-key \""$(cat $account2key1file.pub)"\"
     json .error_code OK .command accountCreate .value null
-    success realm modify_account1 $a0 --osh accountModify --pam-auth-bypass yes --account $account2
+    success modify_account1 $a0 --osh accountModify --pam-auth-bypass yes --account $account2
     json .error_code OK .command accountModify
 
     revoke accountModify
     grant groupCreate
 
     # create realm-egress group on local bastion
-    success realm create_support_group $a0 --osh groupCreate --group $realm_egress_group --owner $account0 --algo rsa --size 4096
+    success create_support_group $a0 --osh groupCreate --group $realm_egress_group --owner $account0 --algo rsa --size 4096
     local realm_group_key
     realm_group_key=$(get_json | $jq '.value.public_key.line')
 
-    success realm a0_delowner_egressgroup $a0 --osh groupDelOwner --group $realm_egress_group --account $account0
+    success a0_delowner_egressgroup $a0 --osh groupDelOwner --group $realm_egress_group --account $account0
 
     # add account1 to this group on local bastion
-    success realm add_account1_to_support_group $a0 --osh groupAddMember --group $realm_egress_group --account $account1
+    success add_account1_to_support_group $a0 --osh groupAddMember --group $realm_egress_group --account $account1
 
     # add account1 to this group on local bastion
-    success realm add_account2_to_support_group $a0 --osh groupAddMember --group $realm_egress_group --account $account2
+    success add_account2_to_support_group $a0 --osh groupAddMember --group $realm_egress_group --account $account2
 
     grant realmCreate
 
     # fail to create a realm with forbidden name
-    plgfail realm realm_forbidden_name $a0 --osh realmCreate --realm realm --from 0.0.0.0/0 --public-key \"$realm_group_key\"
+    plgfail realm_forbidden_name $a0 --osh realmCreate --realm realm --from 0.0.0.0/0 --public-key \"$realm_group_key\"
 
     # fail to create account with forbidden name
-    plgfail realm account_forbidden_name $a0 --osh accountCreate --account realm_foobar --uid-auto --public-key \""$(cat $account1key1file.pub)"\"
+    plgfail account_forbidden_name $a0 --osh accountCreate --account realm_foobar --uid-auto --public-key \""$(cat $account1key1file.pub)"\"
 
     # create shared realm-account on remote bastion
-    success realm create_shared_account $a0 --osh realmCreate --realm $realm_shared_account --public-key \"$realm_group_key\" --from 0.0.0.0/0
+    success create_shared_account $a0 --osh realmCreate --realm $realm_shared_account --public-key \"$realm_group_key\" --from 0.0.0.0/0
 
     revoke accountCreate
     revoke realmCreate
 
     # add remote bastion ip on group of local bastion
-    success realm add_remote_bastion_to_group $a0 --osh groupAddServer --host 127.0.0.1 --user realm_$realm_shared_account --port 22 --group $realm_egress_group --kbd-interactive
+    success add_remote_bastion_to_group $a0 --osh groupAddServer --host 127.0.0.1 --user realm_$realm_shared_account --port 22 --group $realm_egress_group --kbd-interactive
 
     # attempt inter-realm connection
-    success realm firstconnect1 $a1 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js --osh info
+    success firstconnect1 $a1 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js --osh info
     json .value.account $account1 .value.realm $realm_shared_account
 
     # attempt inter-realm connection
-    success realm firstconnect2 $a2 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js --osh info
+    success firstconnect2 $a2 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js --osh info
     json .value.account $account2 .value.realm $realm_shared_account
 
     # try forbidden plugins
     for plugin in selfAddPersonalAccess selfAddIngressKey selfDelIngressKey selfGenerateEgressKey selfAddPersonalAccess selfDelPersonalAccess selfPlaySession selfListSessions selfResetIngressKeys
     do
-            run realm plugindenied $a2 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js --osh $plugin
+            run plugindenied $a2 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js --osh $plugin
             retvalshouldbe 106
             json .error_message "Realm accounts can't execute this plugin, use --osh help to get the allowed plugin list" .error_code KO_RESTRICTED_COMMAND
     done
@@ -77,41 +77,41 @@ testsuite_realm()
     grant accountAddPersonalAccess
 
     # add an access to account1 from realm on remote bastion
-    success realm add_access_to_remote $a0 --osh accountAddPersonalAccess --account $realm_shared_account/$account1 --user-any --port-any --host 127.0.0.5
+    success add_access_to_remote $a0 --osh accountAddPersonalAccess --account $realm_shared_account/$account1 --user-any --port-any --host 127.0.0.5
     json .error_code OK
 
     # fail to add a dup access to account1 from realm on remote bastion
-    success realm add_access_to_remote_dup $a0 --osh accountAddPersonalAccess --account $realm_shared_account/$account1 --user-any --port-any --host 127.0.0.5
+    success add_access_to_remote_dup $a0 --osh accountAddPersonalAccess --account $realm_shared_account/$account1 --user-any --port-any --host 127.0.0.5
     json .error_code OK_NO_CHANGE
 
     # list accesses remotely
-    success realm list_my_accesses1 $a1 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js --osh selfListAccesses
+    success list_my_accesses1 $a1 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js --osh selfListAccesses
     json .error_code OK .value[0].acl[0].addedBy $account0 .value[0].acl[0].ip 127.0.0.5
 
     # list accesses remotely
-    success realm list_my_accesses2 $a2 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js --osh selfListAccesses
+    success list_my_accesses2 $a2 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js --osh selfListAccesses
     json .error_code OK_EMPTY
 
     # try to access remotely (success)
-    run realm access1 $a1 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- test@127.0.0.5
+    run access1 $a1 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- test@127.0.0.5
     retvalshouldbe 255
     nocontain 'Access denied'
     contain 'will try the following accesses you have'
 
     # try to access remotely (fail)
-    run realm access2 $a2 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- test@127.0.0.5
+    run access2 $a2 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- test@127.0.0.5
     retvalshouldbe 107
     contain "Access denied for $realm_shared_account/$account2 to test@127.0.0.5:22"
 
     # create a group on remote bastion
-    success realm create_normal_group $a0 --osh groupCreate --group $group1 --owner $account0 --algo rsa --size 4096
+    success create_normal_group $a0 --osh groupCreate --group $group1 --owner $account0 --algo rsa --size 4096
 
     # can't add a realm user as gk, aclk or owner of group
     for acc in "realm_$realm_shared_account" "$realm_shared_account/$account1"
     do
         for role in Owner Gatekeeper Aclkeeper
         do
-            plgfail realm add_${acc}_as_$role $a0 --osh groupAdd$role --group $group1 --account $acc
+            plgfail add_${acc}_as_$role $a0 --osh groupAdd$role --group $group1 --account $acc
             if [ "$acc" = "$realm_shared_account/$account1" ]; then
                 json .error_code ERR_REALM_USER
             else
@@ -119,150 +119,150 @@ testsuite_realm()
             fi
         done
     done
-    plgfail realm add_support_account_as_member $a0 --osh groupAddMember --group $group1 --account realm_$realm_shared_account
+    plgfail add_support_account_as_member $a0 --osh groupAddMember --group $group1 --account realm_$realm_shared_account
 
     # add account1 as member
-    success realm add_account1_as_member $a0 --osh groupAddMember --group $group1 --account $realm_shared_account/$account1
+    success add_account1_as_member $a0 --osh groupAddMember --group $group1 --account $realm_shared_account/$account1
     json .error_code OK
 
-    success realm add_account1_as_member $a0 --osh groupAddMember --group $group1 --account $realm_shared_account/$account1
+    success add_account1_as_member $a0 --osh groupAddMember --group $group1 --account $realm_shared_account/$account1
     json .error_code OK_NO_CHANGE
 
     # check groupInfo
-    success realm groupinfo $a0 --osh groupInfo --group $group1
+    success groupinfo $a0 --osh groupInfo --group $group1
     json --arg want "$realm_shared_account/$account1 $account0" '.value.members|sort == ($want|split(" ")|sort)' true
 
     # add a remote account as member
-    success realm add_account2_as_member $a0 --osh groupAddMember --group $group1 --account $realm_shared_account/alien
+    success add_account2_as_member $a0 --osh groupAddMember --group $group1 --account $realm_shared_account/alien
     json .error_code OK
 
-    success realm add_account2_as_member $a0 --osh groupAddMember --group $group1 --account $realm_shared_account/alien
+    success add_account2_as_member $a0 --osh groupAddMember --group $group1 --account $realm_shared_account/alien
     json .error_code OK_NO_CHANGE
 
     # check groupInfo
-    success realm groupinfo $a0 --osh groupInfo --group $group1
+    success groupinfo $a0 --osh groupInfo --group $group1
     json --arg want "$realm_shared_account/$account1 $realm_shared_account/alien $account0" '.value.members|sort == ($want|split(" ")|sort)' true
 
     # add a dummy host to the group, to see it in the accountListAccesses afterwards
-    success realm add_server_to_group1 $a0 --osh groupAddServer --group $group1 --host 172.16.4.4 --user nobody --port 12345 --force
-    success realm add_server_to_group1 $a0 --osh groupAddServer --group $group1 --host 172.16.4.4 --user nobody --port 12346 --force
+    success add_server_to_group1 $a0 --osh groupAddServer --group $group1 --host 172.16.4.4 --user nobody --port 12345 --force
+    success add_server_to_group1 $a0 --osh groupAddServer --group $group1 --host 172.16.4.4 --user nobody --port 12346 --force
 
-    success realm removemyselffromaclk $a0 --osh groupDelAclkeeper --group $group1 --account $account0
-    success realm a0_delowner_group1 $a0 --osh groupDelOwner --group $group1 --account $account0
+    success removemyselffromaclk $a0 --osh groupDelAclkeeper --group $group1 --account $account0
+    success a0_delowner_group1 $a0 --osh groupDelOwner --group $group1 --account $account0
     grant accountListAccesses
 
     # check access list
-    success realm access_list_account1 $a0 --osh accountListAccesses --account $realm_shared_account/$account1
+    success access_list_account1 $a0 --osh accountListAccesses --account $realm_shared_account/$account1
     json '.value|[.[]|.type]|sort' '["group-member","personal"]'
     json '.value[]|select(.type == "personal")|.acl[]|.ip' 127.0.0.5
     json '.value[]|select(.type == "group-member")|[.acl[]|.port]' '["12345","12346"]'
 
     # revoke group membership
-    success realm del_account1_as_member $a0 --osh groupDelMember --group $group1 --account $realm_shared_account/$account1
+    success del_account1_as_member $a0 --osh groupDelMember --group $group1 --account $realm_shared_account/$account1
     json .error_code OK
 
-    success realm del_account1_as_member_dup $a0 --osh groupDelMember --group $group1 --account $realm_shared_account/$account1
+    success del_account1_as_member_dup $a0 --osh groupDelMember --group $group1 --account $realm_shared_account/$account1
     json .error_code OK_NO_CHANGE
 
     # check groupInfo
-    success realm groupinfo $a0 --osh groupInfo --group $group1
+    success groupinfo $a0 --osh groupInfo --group $group1
     json --arg want "$realm_shared_account/alien $account0" '.value.members|sort == ($want|split(" ")|sort)' true
 
     # check access list
-    success realm access_list_account1_again $a0 --osh accountListAccesses --account $realm_shared_account/$account1
+    success access_list_account1_again $a0 --osh accountListAccesses --account $realm_shared_account/$account1
     json '.value|[.[]|.type]|sort' '["personal"]'
     json '.value[]|select(.type == "personal")|.acl[]|.ip' 127.0.0.5
 
     # check access list
-    success realm access_list_account2_again $a0 --osh accountListAccesses --account $realm_shared_account/alien
+    success access_list_account2_again $a0 --osh accountListAccesses --account $realm_shared_account/alien
     json '.value|[.[]|.type]|sort' '["group-member"]'
     json '.value[]|select(.type == "group-member")|[.acl[]|.port]' '["12345","12346"]'
 
     # revoke group membership
-    success realm del_account2_as_member $a0 --osh groupDelMember --group $group1 --account $realm_shared_account/alien
+    success del_account2_as_member $a0 --osh groupDelMember --group $group1 --account $realm_shared_account/alien
     json .error_code OK
 
-    success realm del_account2_as_member_dup $a0 --osh groupDelMember --group $group1 --account $realm_shared_account/alien
+    success del_account2_as_member_dup $a0 --osh groupDelMember --group $group1 --account $realm_shared_account/alien
     json .error_code OK_NO_CHANGE
 
     # check groupInfo
-    success realm groupinfo $a0 --osh groupInfo --group $group1
+    success groupinfo $a0 --osh groupInfo --group $group1
     json '.value.members|sort' "[\"$account0\"]"
 
     # add guest access
-    success realm add_guest_account1 $a0 --osh groupAddGuestAccess --account $realm_shared_account/first --group $group1 --host 172.16.4.4 --user nobody --port 12345
-    success realm add_guest_account1 $a0 --osh groupAddGuestAccess --account $realm_shared_account/first --group $group1 --host 172.16.4.4 --user nobody --port 12346
+    success add_guest_account1 $a0 --osh groupAddGuestAccess --account $realm_shared_account/first --group $group1 --host 172.16.4.4 --user nobody --port 12345
+    success add_guest_account1 $a0 --osh groupAddGuestAccess --account $realm_shared_account/first --group $group1 --host 172.16.4.4 --user nobody --port 12346
 
     # add other guest access
-    success realm add_guest_account2 $a0 --osh groupAddGuestAccess --account $realm_shared_account/second --group $group1 --host 172.16.4.4 --user nobody --port 12345
+    success add_guest_account2 $a0 --osh groupAddGuestAccess --account $realm_shared_account/second --group $group1 --host 172.16.4.4 --user nobody --port 12345
 
     # check groupInfo
-    success realm groupinfo $a0 --osh groupInfo --group $group1
+    success groupinfo $a0 --osh groupInfo --group $group1
     json '.value.members|sort' "[\"$account0\"]"
     json '.value.guests|sort' "[\"$realm_shared_account/first\",\"$realm_shared_account/second\"]"
 
     # check access list of account
-    success realm access_list_account1_guest $a0 --osh accountListAccesses --account $realm_shared_account/first
+    success access_list_account1_guest $a0 --osh accountListAccesses --account $realm_shared_account/first
     json '.value|[.[]|.type]|sort' '["group-guest"]'
     json '.value[]|select(.type == "group-guest")|[.acl[]|.port]' '["12345","12346"]'
 
     # remove guest access 1
-    success realm del_guest_account1 $a0 --osh groupDelGuestAccess --account $realm_shared_account/first --group $group1 --host 172.16.4.4 --user nobody --port 12345
+    success del_guest_account1 $a0 --osh groupDelGuestAccess --account $realm_shared_account/first --group $group1 --host 172.16.4.4 --user nobody --port 12345
     nocontain "removed group key"
 
     # check access list of account
-    success realm access_list_account1_guest $a0 --osh accountListAccesses --account $realm_shared_account/first
+    success access_list_account1_guest $a0 --osh accountListAccesses --account $realm_shared_account/first
     json '.value|[.[]|.type]|sort' '["group-guest"]'
     json '.value[]|select(.type == "group-guest")|.acl[]|.port' 12346
 
     # remove guest access 1
-    success realm del_guest_account1 $a0 --osh groupDelGuestAccess --account $realm_shared_account/first --group $group1 --host 172.16.4.4 --user nobody --port 12346
+    success del_guest_account1 $a0 --osh groupDelGuestAccess --account $realm_shared_account/first --group $group1 --host 172.16.4.4 --user nobody --port 12346
     nocontain "removed group key"
 
     # check groupInfo
-    success realm groupinfo $a0 --osh groupInfo --group $group1
+    success groupinfo $a0 --osh groupInfo --group $group1
     json '.value.members|sort' "[\"$account0\"]"
     json '.value.guests|sort' "[\"$realm_shared_account/second\"]"
 
     # remove last guest access
-    success realm del_guest_account2 $a0 --osh groupDelGuestAccess --account $realm_shared_account/second --group $group1 --host 172.16.4.4 --user nobody --port 12345
+    success del_guest_account2 $a0 --osh groupDelGuestAccess --account $realm_shared_account/second --group $group1 --host 172.16.4.4 --user nobody --port 12345
     contain "removed group key"
 
     # check groupInfo
-    success realm groupinfo $a0 --osh groupInfo --group $group1
+    success groupinfo $a0 --osh groupInfo --group $group1
     json '.value.members|sort' "[\"$account0\"]"
     json '.value.guests|sort' "[]"
 
     # check max account length
-    success realm add_guest_account3 $a0 --osh groupAddGuestAccess --account $realm_shared_account/verylongaccountnam --group $group1 --host 172.16.4.4 --user nobody --port 12345
+    success add_guest_account3 $a0 --osh groupAddGuestAccess --account $realm_shared_account/verylongaccountnam --group $group1 --host 172.16.4.4 --user nobody --port 12345
 
     grant accountDelete
 
     # delete account1
-    success realm account1_cleanup $a0 --osh accountDelete --account $account1 --no-confirm
+    success account1_cleanup $a0 --osh accountDelete --account $account1 --no-confirm
 
     # delete account2
-    script realm account2_cleanup "$a0 --osh accountDelete --account $account2 <<< \"Yes, do as I say and delete $account2, kthxbye\""
+    script account2_cleanup "$a0 --osh accountDelete --account $account2 <<< \"Yes, do as I say and delete $account2, kthxbye\""
     retvalshouldbe 0
 
     revoke accountDelete
     grant groupDelete
 
     # delete realm-egress group
-    run realm cleanup_realm_support_group $a0 --osh groupDelete --group $realm_egress_group --no-confirm
+    run cleanup_realm_support_group $a0 --osh groupDelete --group $realm_egress_group --no-confirm
     retvalshouldbe 0
 
     revoke groupDelete
     grant accountDelete
 
     # delete shared realm-account
-    script realm cleanup_shared_realm_account_fail "$a0 --osh accountDelete --account realm_$realm_shared_account <<< \"Yes, do as I say and delete realm_$realm_shared_account, kthxbye\""
+    script cleanup_shared_realm_account_fail "$a0 --osh accountDelete --account realm_$realm_shared_account <<< \"Yes, do as I say and delete realm_$realm_shared_account, kthxbye\""
     retvalshouldbe 100
     json .error_code KO_FORBIDDEN_PREFIX
 
     grant realmDelete
 
-    script realm cleanup_shared_realm_account "$a0 --osh realmDelete --realm $realm_shared_account <<< \"Yes, do as I say and delete $realm_shared_account, kthxbye\""
+    script cleanup_shared_realm_account "$a0 --osh realmDelete --realm $realm_shared_account <<< \"Yes, do as I say and delete $realm_shared_account, kthxbye\""
     retvalshouldbe 0
 
     revoke realmDelete
@@ -270,7 +270,7 @@ testsuite_realm()
     grant groupDelete
 
     # delete group1
-    script realm group_cleanup "$a0 --osh groupDelete --group $group1 <<< \"$group1\""
+    script group_cleanup "$a0 --osh groupDelete --group $group1 <<< \"$group1\""
     retvalshouldbe 0
 
     revoke groupDelete

--- a/tests/functional/tests.d/320-base.sh
+++ b/tests/functional/tests.d/320-base.sh
@@ -9,39 +9,39 @@ testsuite_base()
 {
     grant accountCreate
     # create regular account to compare info access between auditor and non auditor
-    success accountCreate a0_create_a1 $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key "\"$(cat $account1key1file.pub)\""
+    success a0_create_a1 $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key "\"$(cat $account1key1file.pub)\""
     json .error_code OK .command accountCreate .value null
     revoke accountCreate
 
     # basic stuff and help
-    run     base  nocmd     $a0
+    run     nocmd     $a0
     retvalshouldbe 112
     contain "command specified and no host to connect to"
     json .command null .error_code KO_NO_HOST .value null
 
-    success osh   empty     $a0 -osh
+    success   empty     $a0 -osh
     contain "OSH help"
     json .command help .error_code OK .value null
 
-    success osh   help1     $a0 -osh  help
+    success   help1     $a0 -osh  help
     contain "OSH help"
     json .error_code OK .command help .value null
 
-    success osh   help2     $a0 --osh help
+    success   help2     $a0 --osh help
     contain "OSH help"
     json .error_code OK .command help .value null
 
-    run osh   boguscmd  $a0 --osh nonexistent
+    run   boguscmd  $a0 --osh nonexistent
     retvalshouldbe 104
     contain "Unknown command"
     json .error_code KO_UNKNOWN_COMMAND .command null .value null
 
     # grant account0 as admin
-    success admin_superowner set_a0_as_admin $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; add_user_to_group_compat $account0 osh-admin\""
+    success set_a0_as_admin $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; add_user_to_group_compat $account0 osh-admin\""
     configchg 's=^\\\\x22adminAccounts\\\\x22.+=\\\\x22adminAccounts\\\\x22:[\\\\x22'"$account0"'\\\\x22],='
     # grant account1 as auditor
-    success osh   accountGrantAuditor $a0 --osh accountGrantCommand --command auditor --account $account1
-    success osh   info $a1                --osh info
+    success   accountGrantAuditor $a0 --osh accountGrantCommand --command auditor --account $account1
+    success   info $a1                --osh info
     contain "Your alias to connect"
     contain "My admins are: "
     contain "My super owners are: "
@@ -49,7 +49,7 @@ testsuite_base()
 
 
     # now check that regular user do not see admins list
-    success osh   info $a0 -osh info
+    success   info $a0 -osh info
     contain "Your alias to connect"
     nocontain "My admins are: "
     nocontain "My super owners are: "
@@ -57,7 +57,7 @@ testsuite_base()
 
     # delete account1
     grant accountDelete
-    success admin_superowner delete_a1 $a0 --osh accountDelete --account $account1 --no-confirm
+    success delete_a1 $a0 --osh accountDelete --account $account1 --no-confirm
     revoke accountDelete
 
 }

--- a/tests/functional/tests.d/325-accountinfo.sh
+++ b/tests/functional/tests.d/325-accountinfo.sh
@@ -9,31 +9,31 @@ testsuite_accountinfo()
 {
     grant accountCreate
     # create regular account to compare info access between auditor and non auditor
-    success 325-accountinfo a0_create_a1 $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key "\"$(cat $account1key1file.pub)\""
+    success a0_create_a1 $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key "\"$(cat $account1key1file.pub)\""
     json .error_code OK .command accountCreate .value null
 
     # create another target account we'll use for accountInfo
-    success 325-accountinfo a0_create_a2 $a0 --osh accountCreate --always-active --account $account2 --uid $uid2 --public-key "\"$(cat $account2key1file.pub)\"" --comment "\"'this is a comment'\""
+    success a0_create_a2 $a0 --osh accountCreate --always-active --account $account2 --uid $uid2 --public-key "\"$(cat $account2key1file.pub)\"" --comment "\"'this is a comment'\""
     json .error_code OK .command accountCreate .value null
     revoke accountCreate
 
     # grant account0 as admin
-    success 325-accountinfo set_a0_as_admin $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; add_user_to_group_compat $account0 osh-admin\""
+    success set_a0_as_admin $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; add_user_to_group_compat $account0 osh-admin\""
     configchg 's=^\\\\x22adminAccounts\\\\x22.+=\\\\x22adminAccounts\\\\x22:[\\\\x22'"$account0"'\\\\x22],='
 
     # grant account1 as auditor
-    success 325-accountinfo a0_grant_a1_as_auditor $a0 --osh accountGrantCommand --command auditor --account $account1
+    success a0_grant_a1_as_auditor $a0 --osh accountGrantCommand --command auditor --account $account1
 
     # grant accountInfo to a0 and a1
-    success 325-accountinfo a0_grant_a0_accountinfo $a0 --osh accountGrantCommand --command accountInfo --account $account0
-    success 325-accountinfo a0_grant_a1_accountinfo $a0 --osh accountGrantCommand --command accountInfo --account $account1
+    success a0_grant_a0_accountinfo $a0 --osh accountGrantCommand --command accountInfo --account $account0
+    success a0_grant_a1_accountinfo $a0 --osh accountGrantCommand --command accountInfo --account $account1
 
     # a0 should see basic info about a2
-    success 325-accountinfo a0_accountinfo_a2_basic $a0 --osh accountInfo --account $account2
-    json_document '{"error_message":"OK","command":"accountInfo","error_code":"OK","value":{"always_active":1,"is_active":1,"allowed_commands":[],}}'
+    success a0_accountinfo_a2_basic $a0 --osh accountInfo --account $account2
+    json_document '{"error_message":"OK","command":"accountInfo","error_code":"OK","value":{"always_active":1,"is_active":1,"allowed_commands":[],"groups":{}}}'
 
     # a1 should see detailed info about a2
-    success 325-accountinfo a1_accountinfo_a2_detailed $a1 --osh accountInfo --account $account2
+    success a1_accountinfo_a2_detailed $a1 --osh accountInfo --account $account2
     json .error_code OK .command accountInfo .value.always_active 1 .value.is_active 1 .value.allowed_commands "[]"
     json .value.ingress_piv_policy null .value.personal_egress_mfa_required none .value.pam_auth_bypass 0
     json .value.password.min_days 0 .value.password.warn_days 7 .value.password.user "$account2" .value.password.password locked
@@ -44,44 +44,44 @@ testsuite_accountinfo()
     json .value.max_inactive_days null
 
     # a2 connects, which will update already_seen_before
-    success 325-accountinfo a2_connects $a2 --osh info
+    success a2_connects $a2 --osh info
     json .command info .error_code OK
 
     # a1 should see the updated fields
-    success 325-accountinfo a1_accountinfo_a2_detailed2 $a1 --osh accountInfo --account $account2
+    success a1_accountinfo_a2_detailed2 $a1 --osh accountInfo --account $account2
     json .value.already_seen_before 1
     contain "Last seen on"
 
     grant accountModify
 
     # a0 changes a2 expiration policy
-    success 325-accountinfo a0_accountmodify_a2_expi_15 $a0 --osh accountModify --account $account2 --max-inactive-days 15
+    success a0_accountmodify_a2_expi_15 $a0 --osh accountModify --account $account2 --max-inactive-days 15
 
     # a1 should see the updated field
-    success 325-accountinfo a1_accountinfo_a2_inactive_days $a1 --osh accountInfo --account $account2
+    success a1_accountinfo_a2_inactive_days $a1 --osh accountInfo --account $account2
     json .value.max_inactive_days 15
 
     # a0 changes a2 expiration policy
-    success 325-accountinfo a0_accountmodify_a2_expi_disabled $a0 --osh accountModify --account $account2 --max-inactive-days 0
+    success a0_accountmodify_a2_expi_disabled $a0 --osh accountModify --account $account2 --max-inactive-days 0
 
     # a1 should see the updated field
-    success 325-accountinfo a1_accountinfo_a2_inactive_days_disabled $a1 --osh accountInfo --account $account2
+    success a1_accountinfo_a2_inactive_days_disabled $a1 --osh accountInfo --account $account2
     json .value.max_inactive_days 0
 
     # a0 changes a2 expiration policy
-    success 325-accountinfo a0_accountmodify_a2_expi_default $a0 --osh accountModify --account $account2 --max-inactive-days -1
+    success a0_accountmodify_a2_expi_default $a0 --osh accountModify --account $account2 --max-inactive-days -1
 
     # a1 should see the updated field
-    success 325-accountinfo a1_accountinfo_a2_inactive_days_default $a1 --osh accountInfo --account $account2
+    success a1_accountinfo_a2_inactive_days_default $a1 --osh accountInfo --account $account2
     json .value.max_inactive_days null
 
     # should work with accountcreate too
     grant accountCreate
-    success 325-accountinfo a0_accountcreate_a4_max_inactive_days $a0 --osh accountCreate --account $account4 --uid $uid4 --max-inactive-days 42 --no-key
+    success a0_accountcreate_a4_max_inactive_days $a0 --osh accountCreate --account $account4 --uid $uid4 --max-inactive-days 42 --no-key
     revoke accountCreate
 
     grant auditor
-    success 325-accountinfo a0_accountinfo_a4_max_inactive_days $a0 --osh accountInfo --account $account4
+    success a0_accountinfo_a4_max_inactive_days $a0 --osh accountInfo --account $account4
     json .value.max_inactive_days 42
     revoke auditor
 
@@ -89,9 +89,9 @@ testsuite_accountinfo()
 
     # delete account1 & account2
     grant accountDelete
-    success 325-accountinfo a0_delete_a1 $a0 --osh accountDelete --account $account1 --no-confirm
-    success 325-accountinfo a0_delete_a2 $a0 --osh accountDelete --account $account2 --no-confirm
-    success 325-accountinfo a0_delete_a4 $a0 --osh accountDelete --account $account4 --no-confirm
+    success a0_delete_a1 $a0 --osh accountDelete --account $account1 --no-confirm
+    success a0_delete_a2 $a0 --osh accountDelete --account $account2 --no-confirm
+    success a0_delete_a4 $a0 --osh accountDelete --account $account4 --no-confirm
     revoke accountDelete
 }
 

--- a/tests/functional/tests.d/330-selfkeys.sh
+++ b/tests/functional/tests.d/330-selfkeys.sh
@@ -15,7 +15,7 @@ _ingress_from_test()
     keytoadd="$4"
     fingerprint="$5"
 
-    script selfAddIngressKey $name "echo '$keytoadd' | $a1 --osh selfAddIngressKey"
+    script $name "echo '$keytoadd' | $a1 --osh selfAddIngressKey"
     retvalshouldbe 0
     json .value.connect_only_from[0] $ip1
     json .value.connect_only_from[1] $ip2
@@ -27,7 +27,7 @@ _ingress_from_test()
         json .value.key.prefix "from=\"$ip1,$ip2\""
     fi
 
-    success selfListIngressKeys $name $a1 --osh selfListIngressKeys
+    success $name $a1 --osh selfListIngressKeys
     json .value.keys[1].from_list[0] $ip1
     json .value.keys[1].from_list[1] $ip2
     if [ "$ip1" = null ] && [ "$ip2" = null ]; then
@@ -36,18 +36,18 @@ _ingress_from_test()
         json .value.keys[1].prefix "from=\"$ip1,$ip2\""
     fi
 
-    success selfDelIngressKey $name $a1 --osh selfDelIngressKey -f "$fingerprint"
+    success $name $a1 --osh selfDelIngressKey -f "$fingerprint"
 
     # now on account creation
     grant accountCreate
 
-    script accountCreate $name "echo '$keytoadd' | $a0 --osh accountCreate --account $account2 --uid $uid2"
+    script $name "echo '$keytoadd' | $a0 --osh accountCreate --account $account2 --uid $uid2"
     json .error_code OK .command accountCreate .value null
 
     revoke accountCreate
     grant accountListIngressKeys
 
-    success accountListIngressKeys $name $a0 --osh accountListIngressKeys --account $account2
+    success $name $a0 --osh accountListIngressKeys --account $account2
     json .value.keys[0].from_list[0] $ip1
     json .value.keys[0].from_list[1] $ip2
     if [ "$ip1" = null ] && [ "$ip2" = null ]; then
@@ -59,7 +59,7 @@ _ingress_from_test()
     revoke accountListIngressKeys
     grant accountDelete
 
-    script accountDelete $name "$a0 --osh accountDelete --account $account2" "<<< \"Yes, do as I say and delete $account2, kthxbye\""
+    script $name "$a0 --osh accountDelete --account $account2" "<<< \"Yes, do as I say and delete $account2, kthxbye\""
     retvalshouldbe 0
     json .error_code OK .command accountDelete
 
@@ -70,7 +70,7 @@ testsuite_selfkeys()
 {
     grant accountCreate
 
-    success osh accountCreate $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key \""$(cat $account1key1file.pub)"\"
+    success accountCreate $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key \""$(cat $account1key1file.pub)"\"
     json .error_code OK .command accountCreate .value null
 
     revoke accountCreate
@@ -82,55 +82,55 @@ testsuite_selfkeys()
 
     configchg 's=^\\\\x22minimumIngressRsaKeySize\\\\x22.+=\\\\x22minimumIngressRsaKeySize\\\\x22:4096,='
 
-    success accountssh info0 $a0 --osh accountInfo --account $account1
+    success info0 $a0 --osh accountInfo --account $account1
     json .error_code OK .command accountInfo
     json .value.account_egress_ssh_config.type default
 
-    success accountssh modifyssh1 $a0 --osh accountModify --account $account1 --egress-strict-host-key-checking no
+    success modifyssh1 $a0 --osh accountModify --account $account1 --egress-strict-host-key-checking no
     json .error_code OK .command accountModify
 
-    success accountssh info1 $a0 --osh accountInfo --account $account1
+    success info1 $a0 --osh accountInfo --account $account1
     json .error_code OK .command accountInfo
     json .value.account_egress_ssh_config.type custom
     json .value.account_egress_ssh_config.items.stricthostkeychecking no
 
-    success accountssh modifyssh2 $a0 --osh accountModify --account $account1 --egress-strict-host-key-checking accept-new
+    success modifyssh2 $a0 --osh accountModify --account $account1 --egress-strict-host-key-checking accept-new
     json .error_code OK .command accountModify
 
-    success accountssh info2 $a0 --osh accountInfo --account $account1
+    success info2 $a0 --osh accountInfo --account $account1
     json .error_code OK .command accountInfo
     json .value.account_egress_ssh_config.type custom
     json .value.account_egress_ssh_config.items.stricthostkeychecking accept-new
 
-    success accountssh modifyssh2 $a0 --osh accountModify --account $account1 --egress-strict-host-key-checking yes
+    success modifyssh2 $a0 --osh accountModify --account $account1 --egress-strict-host-key-checking yes
     json .error_code OK .command accountModify
 
-    success accountssh info2 $a0 --osh accountInfo --account $account1
+    success info2 $a0 --osh accountInfo --account $account1
     json .error_code OK .command accountInfo
     json .value.account_egress_ssh_config.type custom
     json .value.account_egress_ssh_config.items.stricthostkeychecking yes
 
-    success accountssh modifyssh3 $a0 --osh accountModify --account $account1 --egress-strict-host-key-checking ask
+    success modifyssh3 $a0 --osh accountModify --account $account1 --egress-strict-host-key-checking ask
     json .error_code OK .command accountModify
 
-    success accountssh info3 $a0 --osh accountInfo --account $account1
+    success info3 $a0 --osh accountInfo --account $account1
     json .error_code OK .command accountInfo
     json .value.account_egress_ssh_config.type custom
     json .value.account_egress_ssh_config.items.stricthostkeychecking ask
 
-    success accountssh modifyssh4 $a0 --osh accountModify --account $account1 --egress-strict-host-key-checking bypass
+    success modifyssh4 $a0 --osh accountModify --account $account1 --egress-strict-host-key-checking bypass
     json .error_code OK .command accountModify
 
-    success accountssh info4 $a0 --osh accountInfo --account $account1
+    success info4 $a0 --osh accountInfo --account $account1
     json .error_code OK .command accountInfo
     json .value.account_egress_ssh_config.type custom
     json .value.account_egress_ssh_config.items.stricthostkeychecking no
     json .value.account_egress_ssh_config.items.userknownhostsfile /dev/null
 
-    success accountssh modifyssh5 $a0 --osh accountModify --account $account1 --egress-strict-host-key-checking default
+    success modifyssh5 $a0 --osh accountModify --account $account1 --egress-strict-host-key-checking default
     json .error_code OK .command accountModify
 
-    success accountssh info5 $a0 --osh accountInfo --account $account1
+    success info5 $a0 --osh accountInfo --account $account1
     json .error_code OK .command accountInfo
     json .value.account_egress_ssh_config.type default
 
@@ -138,13 +138,13 @@ testsuite_selfkeys()
     revoke accountInfo
     # </accountModify --egress-strict-host-key-checking>
 
-    success realm modify_account1 $a0 --osh accountModify --pam-auth-bypass yes --account $account1
+    success modify_account1 $a0 --osh accountModify --pam-auth-bypass yes --account $account1
     json .error_code OK .command accountModify
 
     revoke accountModify
     grant accountListEgressKeys
 
-    success osh accountListEgressKeys $a0 --osh accountListEgressKeys --account $account1
+    success accountListEgressKeys $a0 --osh accountListEgressKeys --account $account1
     contain "keyline"
     json .error_code OK .command accountListEgressKeys
     set +e
@@ -166,7 +166,7 @@ EOS
     revoke accountListEgressKeys
 
     # add del list pub keys
-    success selfListIngressKeys beforeadd $a1 -osh selfListIngressKeys
+    success beforeadd $a1 -osh selfListIngressKeys
     json $(cat <<EOS
     .command selfListIngressKeys
     .error_code OK
@@ -178,10 +178,10 @@ EOS
     )
     account1key1fp=$(get_json | $jq '.value.keys[0].fingerprint')
 
-    script  selfAddIngressKey  flood   $a1 -osh selfAddIngressKey '<' /dev/urandom
+    script  flood   $a1 -osh selfAddIngressKey '<' /dev/urandom
     retvalshouldbe 255
 
-    script selfAddIngressKey  privkey $a1 -osh selfAddIngressKey '<<< "-----BEGIN DSA PRIVATE KEY-----
+    script  privkey $a1 -osh selfAddIngressKey '<<< "-----BEGIN DSA PRIVATE KEY-----
     MIIBugIBAAKBgQCawvohH0r9B4NxdaYHiBT5pLWDe14o3MTE3WwtKF0l7az+zw0P"'
     retvalshouldbe 100
     contain "HOLY SH"
@@ -192,36 +192,36 @@ EOS
 EOS
     )
 
-    script selfAddIngressKey  privkey $a1 -osh selfAddIngressKey '<<< "-----BEGIN RSA PRIVATE KEY-----
+    script  privkey $a1 -osh selfAddIngressKey '<<< "-----BEGIN RSA PRIVATE KEY-----
     MIIBugIBAAKBgQCawvohH0r9B4NxdaYHiBT5pLWDe14o3MTE3WwtKF0l7az+zw0P"'
     retvalshouldbe 100
     contain "HOLY SH"
     json .command selfAddIngressKey .error_code KO_PRIVATE_KEY .value null
 
-    script selfAddIngressKey  privkey $a1 -osh selfAddIngressKey '<<< "-----BEGIN EC PRIVATE KEY-----
+    script  privkey $a1 -osh selfAddIngressKey '<<< "-----BEGIN EC PRIVATE KEY-----
     MIIBugIBAAKBgQCawvohH0r9B4NxdaYHiBT5pLWDe14o3MTE3WwtKF0l7az+zw0P"'
     retvalshouldbe 100
     contain "HOLY SH"
     json .command selfAddIngressKey .error_code KO_PRIVATE_KEY .value null
 
-    script selfAddIngressKey  privkey $a1 -osh selfAddIngressKey '<<< "-----BEGIN OPENSSH PRIVATE KEY-----
+    script  privkey $a1 -osh selfAddIngressKey '<<< "-----BEGIN OPENSSH PRIVATE KEY-----
     MIIBugIBAAKBgQCawvohH0r9B4NxdaYHiBT5pLWDe14o3MTE3WwtKF0l7az+zw0P"'
     retvalshouldbe 100
     contain "HOLY SH"
     json .command selfAddIngressKey .error_code KO_PRIVATE_KEY .value null
 
-    script selfAddIngressKey  bogus $a1 -osh selfAddIngressKey '<<<' "bogus"
+    script  bogus $a1 -osh selfAddIngressKey '<<<' "bogus"
     retvalshouldbe 100
     contain "look like an SSH public key"
     json .command selfAddIngressKey .error_code KO_NOT_A_KEY .value.key.line bogus
 
-    script selfAddIngressKey  eof $a1 -osh selfAddIngressKey '</dev/null'
+    script  eof $a1 -osh selfAddIngressKey '</dev/null'
     retvalshouldbe 100
     contain "look like an SSH public key"
     json .command selfAddIngressKey .error_code KO_NOT_A_KEY .value null
 
     b64='AAAAB3NzaC1kc3MAAACBAPOCqEho94k9fEArLgR1kuNTMo52aozaw1jr7sKLTjt3BZslvt3zl264THsIN4XeuI6noiD7QwCO3PSMUsPnrlreQEGff8f97IE+LpH7rZQB7kSM50PGk0QfS1qpVnWbsi5NAvV3ib12gErtXg/YiJfx0x+lWaZTMkaFUdwpyaEXAAAAFQCOng3YNx+KK38h6675jJD78k6bpwAAAIEA2Y/3CZHgzIIBtddVssfLBv3196SAbYMA/eDmsbTM9dyhWdAGPc36/sfveITpbQ2kZYvR4S1pstQ4ZNMM3cdD6GHy+CkDXYEH7SbEa60jEaIue3OK4FhtBLSs4n7sIzNYgRm8hoXYNM4jpC+zf1dpUqIZd1d742JPFJAk07vnj2AAAACAWWpKTEg9ArdpkkvX6FC5lxq7uhVN1uo7+5TBCE8C31fXppHfp9M2FvL2hubbIRYJ+QNDzU+f0UYJr2Nv1v3tyG8LJ2942B9ym+TYb6SzMJ20jWW5v+wfSXuwaPLIAWYFLIbUCp/pv+BnQKAXrVLIsM+iWj6amB/2NrZH5q0j/8k='
-    script selfAddIngressKey  dsa     $a1 -osh selfAddIngressKey "<<< \"ssh-dss $b64 test@dsa\""
+    script  dsa     $a1 -osh selfAddIngressKey "<<< \"ssh-dss $b64 test@dsa\""
     retvalshouldbe 100
     contain "Wait, DSA key"
     # here we need to determine if ssh-keygen is using MD5 or SHA256 for fingerprints
@@ -246,7 +246,7 @@ EOS
         .value.key.line         "ssh-dss $b64 test@dsa" \
         .value.key.prefix       ""
 
-    script selfAddIngressKey  dsaDup   $a1 -osh selfAddIngressKey "<<< \"ssh-dss $b64 test@dsaduplicate\""
+    script  dsaDup   $a1 -osh selfAddIngressKey "<<< \"ssh-dss $b64 test@dsaduplicate\""
     retvalshouldbe 100
     contain "Wait, DSA key"
     json $(cat <<EOS
@@ -267,7 +267,7 @@ EOS
     b64='AAAAB3NzaC1yc2EAAAADAQABAAAAgQDNbJemAKF6u4xZtbbkHtQeXeh9EvsYgBdUlnES1oBSS/ICKU7lcUrW4UvUpYLQ0+N1f0XaYfGO01BnEPwJDYJngkybh1Qwo6IbCBySpIFJG7ToK4M1U2arALGelwgoVP3AE+HoLjSH9W0ZisBvWtiyCekBWnzf+kD5hLkblPXYkQ=='
     fp1024="SHA256:tHu5MD2vgUWxduQUnXqtHaRCCbez7CB9hOvD7zMZu/U"
     [ "$FP_TYPE" = md5 ] && fp1024="65:94:cc:f1:5d:29:6e:11:70:44:ce:a8:61:df:25:0a"
-    script selfAddIngressKey  rsa1024  $a1 -osh selfAddIngressKey "<<< \"ssh-rsa $b64 test@rsa1024\""
+    script  rsa1024  $a1 -osh selfAddIngressKey "<<< \"ssh-rsa $b64 test@rsa1024\""
     retvalshouldbe 100
     contain "This is too small"
     json $(cat <<EOS
@@ -288,7 +288,7 @@ EOS
     b64='AAAAB3NzaC1yc2EAAAADAQABAAABAQDUcjtSpPwY9kdBtmfAURXEIwvUnfJ41acboaNyXU0Vv9C0hg6DNemm8FjDC4xp9AtQgKc8Sq2VGrUXIMO/xxD8LA9u3DjwWLYAzoBYGzKZ9p7QynoeEAa/Fpv811LmSJMVw1NPDahMrv1mVR4vXrU5Z/S4VkIEY19DnO0TlpciWPC9ePLhcF/MIb2dwzRlWaKm0JRw8D/V3aPbacyZL1zO+Gdk8an95DZ7T8KbxDdLxf6pLLWbtdMxZKnTQeAJGW7JXsf6ybmHgOqHTI3gWfydbRe0bHBcqORT21resFcqqyqKrKjGedWYqDraAi3k8G+U0T8RwDGMJpC2EFDk7c0H'
     fp2048="SHA256:ZdeU0HZyYoqz+ysPxoZ5cUX8eDIV4PIn7s0oDipqUnI"
     [ "$FP_TYPE" = md5 ] && fp2048="a0:cf:72:54:59:b5:61:26:37:5f:98:14:83:c7:d3:8f"
-    script selfAddIngressKey  rsa2048  $a1 -osh selfAddIngressKey "<<< \"ssh-rsa $b64 test@rsa2048\""
+    script  rsa2048  $a1 -osh selfAddIngressKey "<<< \"ssh-rsa $b64 test@rsa2048\""
     retvalshouldbe 100
     contain "This is too small"
     json $(cat <<EOS
@@ -309,7 +309,7 @@ EOS
     b64='AAAAB3NzaC1yc2EAAAADAQABAAACAQDC6clamfZUjOfWR9T5TG/QbN8lTDwdJXPmKXa7P4F9+QKDRoKfcRn0hTW4LeTsBlbnPoeolRPNuhjW/l1Sv1MLCVqzwUljbbvAZ4QBAMhXIFy0Z2i2zE/jpi2oC7J7+/2sHtznW0mxQppcb6pMWLRNuU4p85l+XZanzbQoR+7aEdvjn1eTYa/jkAJwMCS+HO3F9nVkV7EyVYXoPYEDya/mrdgLcZktSuE42zD9TVpBXlW5pONeuo2q0h7soJp1VhJwwO1/VXPmz7JfvFhFrHit+Bh+RJeTOrLRG1kE/5DZoLbOiXpBzG08bbyQQS17DynHk2afMrbqQx3tV6a/TqCF0LJTaNPDTKmYinsremHXxKpzStNkJ7UArgfipoUk20QyPJX3P5T0JF1LLu8rfE6GpqB7CVgYDjPIKcfiG5o+gKrwYrLkyDaEKkhdD0KSAZ5HmL/Z4t/3aDYUK96/IiYE49PI6rsuD5RRCASv8U68v2Kk14X7MmR7mZxJZ2oRMtPftS/Z+nvoStyUQF5LBOTKlrJd5PTjC6OlMG85qLmYjbDViUK/b/KtdwgQPhupzsHIq3hAaSvudjMWqbOQ/YlwwOxqAC7EVe9nv6cZTyBHIq2AINlNRqL1f6hzxrL6oBAMAvirNYI8/B/8yYGYwbNdTTNIZOXxWqHW8OIeA+QgMQ=='
     fp4096="SHA256:esuEP68vVxW7uJd1jxUXfmMj0Hk3my/Lv181K/XFlfY"
     [ "$FP_TYPE" = md5 ] && fp4096="84:0a:ae:13:62:1e:c4:bc:d7:2b:b4:d4:fe:c8:6d:0a"
-    script selfAddIngressKey  rsa4096  $a1 -osh selfAddIngressKey "<<< \"ssh-rsa $b64 test@rsa4096\""
+    script  rsa4096  $a1 -osh selfAddIngressKey "<<< \"ssh-rsa $b64 test@rsa4096\""
     retvalshouldbe 0
     contain "key successfully added"
     json $(cat <<EOS
@@ -326,7 +326,7 @@ EOS
         .value.key.line   "ssh-rsa $b64 test@rsa4096" \
         .value.key.prefix ""
 
-    script selfAddIngressKey  rsa4096dup $a1 -osh selfAddIngressKey "<<< \"ssh-rsa $b64 test@rsa4096duplicate\""
+    script  rsa4096dup $a1 -osh selfAddIngressKey "<<< \"ssh-rsa $b64 test@rsa4096duplicate\""
     retvalshouldbe 100
     contain "already exists"
     json $(cat <<EOS
@@ -347,7 +347,7 @@ EOS
     b64='AAAAB3NzaC1yc2EAAAADAQABAAAEAQD2anHdMJgmE87uinVQjvg1BgsiLZm8Ra6b0xknf6IGd/ZK3FHq5FxBAHUtubqAsM5DyKgf9DtG+MIb43Zv3ECXWppPcplyM5B0L4Y/QVlPf6cgL6gug4ct6XiK1Ck+CH9kc5tkEdk10GV89teTBhq9xXw0tcVkoMwrc9mNGb7OVG6RQRROk+LzoWYiIMUPRW0gYRBxQnliBqQmlbs5lZbWbFhsjBJPSEeY2h0OEtoEItZyM6om2IwI2o9D8QzgoL8KbYEknuBS5zJIkT82HRBxKvttjaZakiEoT3Ir82YavFgwHpkA4N6Gz6IAyWofcB+qp2p0Wi1VILim07gXdWOmVbX/WN6NsY4g05V2FQVqECIR/dHwePkzA0DvHLbeY720nm6YV2v29i5imd1jOzgFPFDSQ12HL0JyHw0Cl8XH/1DpGYTIG1hXgCxi6wAtKKEg/hYaEvAA5Jl/GtVOWbRT9dZ0FNQyfvfPeM64+SBWVHeAIKpyr+Gpq81JbYDcUlm566ukwfUi1cif87ZU4MQZKIYJet1FDkEnOi8n20jeZH6EgCWROdPtXYHohT6u6g3JC4MEUl1V7fr2CXAP/XMQfjz31UycZjtI9/76YIF0N6NORSQ/eN0MY1kCvFaDahkaJwp98t6UxUMfTtDf1IImWWatWMB+viNhH5gi26ar3zWeBXRlwuUmz7t64qmwgywc7qYtGCfWAxuMhVS88rbnGSj/Dcw6dJFJu1+5ysYY7Z4tgbShFeOioFIf9hg/j1+Ouubcjs2wZELjfXr9KHCwoDINvn+wVDn/02V7OYxeP/a8UxECKPRL6qa1JfIKYlx9w8Kt0TDSAEOc5P+rsZFfTYeUro7V/gv9gXxI/GuWkCQOexaeDGqo9+QVtlxInWrjd+vXAzEs977oSkNmRD9Ev7pSTZSEHd9bYvoMB2dzJgeYwl9YsQ7mLNMLX/du/q7s7L8qvS4thHi68XmypFUtrq0g6K2ybodgdjUEd2IGuLDdqDw2EmXN9yXu/giVd0/XKx4eRf82OK6UAjr2ZSvBQE7CQN+HsvKrnS+V4xd758BWIjR78PUGIR0tNt8pZmpE7mbluWcBTPkPalSna5l4bigtJkKKjrKHELhsVr6LtBjMy+VVOBworsaqFXwDzj0a39vRwEcfuY7YPe12hrNI9zjq/3exr1GaK4YDa/mojsfxoyKgNaoOarIAX0RRBLqmJt3lTyAkvnxe23CVPAjNcOx/m1HjqbbxJ+GWXpOHvh3RXIZbvyAKYrgM3YydGaDGfMjgmWUHeYFcydfyRuNoCXKl0fCgduQAdjpyyUSFLvdeI4HEfVsWF4AUn7A4IwUmh2kcQ56naHABgpIbf+8V'
     fp8192="SHA256:nQl/AkakKTV25MKXZQpEBAEECq2BKLBqrRICR0YBn8s"
     [ "$FP_TYPE" = md5 ] && fp8192="cd:26:73:ff:7e:b5:72:d7:7d:d5:dd:da:d7:c0:8d:35"
-    script selfAddIngressKey  rsa8192 $a1 -osh selfAddIngressKey "<<< \"ssh-rsa $b64 test@rsa8192\""
+    script  rsa8192 $a1 -osh selfAddIngressKey "<<< \"ssh-rsa $b64 test@rsa8192\""
     retvalshouldbe 0
     contain "key successfully added"
     json $(cat <<EOS
@@ -368,7 +368,7 @@ EOS
     b64='AAAAB3NzaC1yc2EAAAADAQABAAAIAQDyGaS7u6eW9Zd363u8XFDxn8Bz5tvPM7pAjI401xETUnEQ+f4Gyp+68EJFFiKo64AN+V8jCR0vY1CIe/za6yau+b88dg5HxwN922FKeudhpIX5qOE98U0Q3KMWQVsCcFDGHcb8M5RthOswylsYQvFNooWxGyEDeNQnb7zpwPPTz02wisv962zxZuvlFtz+K76dgHSPb/sRS7/gdYkuCa+w/FRTfUu7Xf2gZ49pQJa6O6R0nGvoq7vP4UNtfF3aVRta5lv3z1jRrJwExVmJYLFgIVsR72SvzZIyMePaawb1cMiMzsO2+e5TK8ozIK5e5PoP4CFvBeif7IiK/rmhW4CUT83vX76cAt4MdVkLT4ah1ZRbnNq+8YieAYMb5gkShcCpTew/6mDUTGQs4zgByoPeOpBl3ggXTDHG2nZP7HJL/rSAUGD8KN/lMhINgiISlq7ZJnEZwvgv2azI1xu6wGYYa4qOkVxSNO0nfVDCzPAU+gye5GOHWGvOhGvVdM29EEZ4TEg07XVlHjwxEHzv0XaUA65c4500ROKTWbx1XIIiJZmritlyOIGA6ekuw9c0iU4hDFUBdW8WwvCjqSTCdLRRWvcIjznazB3azuBSX9UqjoCmrAKcRL/L9mhF+Q7/k1ntbBZMbu7JC3VrnrW13djlF8Ix5ke05h4IZxyDHOtTWPUsDWv5MhGaV5UO3phkgAD4pQOOqjWqn0/746tAqdpehOo3B45nh+kfaUlJv6SWgvYd/erOMubn3Givh/cT2Jy89C8UNL8/Jz72sTOA4bU7ul2pcXwN2j3ltQSEgVZE2yMCe18oBiSv9wnk0x2D4OK0AQcQNgD9wMmaKutl7DtHRw0exuMr7yYttsAb+oE+EifRZlPXgWXN8EK6u5WJrb+7sDC/zzkIk8XaREZjFO4dTADdeCIeE4i74pj/uw29U75ZG3AauU/Nxri9Mg4/k/ZRGl1cNyQ6cUlnNHSDtnGtXOaq0Zmn3pMVAOLdOh4UhVPW+rByHDkvbsu11mPo8xi9nh5X3hYr1jrwS0gqfnB5kpX5P8jiwkf6MUDwHlcRjTJmIta3oaw6Meyh69GRTb6pURGyurSSp7+WIYBCrwsgk54Y4ABAGmBUVlWlYRDGddSeZsX1yG+CBqaTtlUpTcvFFwzDonuzT6CymFf5RT5gnTenWaJpGrB3wxVQX6IxC2g6g9vlKuVnaRGnQ780ks157FFly+yW0VwTBJlppse1ZAM+pTI/5+b1a22rA7utnb38syCAs/Bto8qfeOg1UwCYraXEypkKnGiOxKSw+hPtEDuyoHBGuYi1AxVkEVXn9YlYrToF6JoGb392GG0F/wAGNp9VyXCKkghxo2kXMExj4s0AGzhqa3yqWesMYUqffTbxKSUdLpdQ12hSButmuc8YsiMyTI804NlfSm62aa7R5AS6FICJh0sU0lWOyiMPlYg0EAo2wCBId+k0fJ21bswJ7eof5Tea52tWG687b9GsOtNZZvFdU8tBXASTUaBHZkhsfMyT6jKzvm+FHykwebePeZHtOD3oBq4wWGx+IsCn9gb5Djp8Plp8k1fPKOXVa/2V5biVx3B7Bvs84VVGsHIeBv6hmLQCw/PiuSItnF9T6uxQL0FImGhRz3Kz/dEVYXS+1KW/VuE565p6F3LFjHrtqligIjDHXlWSF4v45LmaaD4v2WBEnZD2VsniwD7RFt/GftAyFMMqv9KgrBL9mUMqcL5bOLYjFbBy3jgegiNvIW0jlOv0aDUxqTbdNq7ghfTmho/P90D2JO0SLx40T4OrsaYEOCb2B5336rT2UqTNsIWDu1861dzEs3NaiqHLnF9NhWDLCaUO28JKW5+PT+YRHpv/wYMyDq/RRifjWpP9j+S74BA4KKiS5ZhomCQZi4uza2kX3OeMObzreVoXpnd080/tdaOb1pXawYXjWu+KyBLsX+FqefuBOhXiL92fRUNc0Zajt1ou5wgayTMeVHkrbCNmgMD6zSLmEeI5A5/a0TVVPzuaVDj6r/Bnbx+VcOeyVnKtIfKg5OBaE52HHE92BO3R/RjyFhBA+tam69hZMxI284AHLxP3JNhEP4VHd/c4k9oOGRc3l8izjMf72fPmj3tMHB/ex1JVzZGF40R/jJrTS6dJMB/mJPf8v5d1IBStL91jahV7rI5vc7nfEZUcKuIoGHD2StVTSaTLGjgqeM6orUsXgxNy3OToCObdEH6idvpxbrNWAahO2E02n52B/kH+idsPHxxNBoCbkPpAhD8udOWxU8NDGUSH0SqIu538NIeI8vol5+bF51emY/aSVNJNKlS4moroCJNo5QfF5y5kbx6sL2MEC04gUVG4IvURoviVAn6299AEdDHL+ahxJzCyD3Gc1FG5RgzPpYH4Dqi/gT01BEoBtF1Em8NEzZtFVj0tTdc+4kZdlBhcBQR/bsfpaYvehC+LuL5YMiWxLKA/XS9GZbB02EtY57osVZAVxqttrqsMdy68pWWDaLJ5mNQRS5eM+YWKJjmteN3hFeE1Sefqd/m6ELEN/XZ9v+Zyf6S2Z2VfTMEUsTVeDU4HUnUGe5PEioYtiA7nH9Ga+dFBbI31H0vQexx3iPBsRAJt53SR1u7RMGUFSlVG5ezHEOY+tQxx9VqSf3QPfeqzfqkJpAroNTtN5FKVNLb8rLhouzIQfUEdJOX7esoncyxpMw1bEdnuz/KEZAHcxHnpaKJ8Hp7a5RJ1BhzYePC+Ww=='
     fp16384="SHA256:xexcqmW+ZCLf5ulEQvVoldakfEJMcD51myTuxQbkgIA"
     [ "$FP_TYPE" = md5 ] && fp16384="fc:67:ee:6d:0e:d4:19:46:38:8f:2c:6b:e1:e8:07:f3"
-    script selfAddIngressKey  rsa16384  $a1 -osh selfAddIngressKey "<<< \"ssh-rsa $b64 test@rsa16384\""
+    script  rsa16384  $a1 -osh selfAddIngressKey "<<< \"ssh-rsa $b64 test@rsa16384\""
     retvalshouldbe 0
     contain "key successfully added"
     json $(cat <<EOS
@@ -389,7 +389,7 @@ EOS
     b64='AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBezrCa6RsyyWnHDypyGZ4/72UsiLaDmJ+A04vVuxO0XsjrhX52Q7zkz5NOA2VccAFJCLwN9h/+LLrIxM6FK64k='
     fpe256="SHA256:7jAGgQXAu4DfrL5cpa1Gh5gDJjwLDGLr0Ahc5TwTPOA"
     [ "$FP_TYPE" = md5 ] && fpe256="4d:35:52:9f:0f:c7:54:68:7e:57:c5:10:32:54:da:bc"
-    script selfAddIngressKey  ecdsa256  $a1 -osh selfAddIngressKey "<<< \"ecdsa-sha2-nistp256 $b64 test@ecdsa256\""
+    script  ecdsa256  $a1 -osh selfAddIngressKey "<<< \"ecdsa-sha2-nistp256 $b64 test@ecdsa256\""
     retvalshouldbe 0
     contain "key successfully added"
     json $(cat <<EOS
@@ -406,7 +406,7 @@ EOS
         .value.key.line   "ecdsa-sha2-nistp256 $b64 test@ecdsa256" \
         .value.key.prefix ""
 
-    script selfAddIngressKey  ecdsa256D $a1 -osh selfAddIngressKey "<<< \"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBezrCa6RsyyWnHDypyGZ4/72UsiLaDmJ+A04vVuxO0XsjrhX52Q7zkz5NOA2VccAFJCLwN9h/+LLrIxM6FK64k= test@ecdsa256duplicate\""
+    script  ecdsa256D $a1 -osh selfAddIngressKey "<<< \"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBezrCa6RsyyWnHDypyGZ4/72UsiLaDmJ+A04vVuxO0XsjrhX52Q7zkz5NOA2VccAFJCLwN9h/+LLrIxM6FK64k= test@ecdsa256duplicate\""
     retvalshouldbe 100
     contain "already exists"
     json $(cat <<EOS
@@ -427,7 +427,7 @@ EOS
     b64='AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBICjCWYk5lCOX/977vdlDqcuF1ZWb4cX8cZuskRCSJBwMaCBHKvSwxzcbVdS++4MAaCsQisDSgwAhK6KcbjwitKAiSUWmRhIxFrPQojrfrDlw20bgFqc/RGiSykMTbL1jg=='
     fpe384="SHA256:P2NDAsOb6ZelE6dwCdqnnSaw/KVXhXMgFWI/pwNF2z0"
     [ "$FP_TYPE" = md5 ] && fpe384="4d:e3:e3:c2:13:79:69:e9:f7:3d:4f:18:21:d3:1b:ef"
-    script selfAddIngressKey  ecdsa384  $a1 -osh selfAddIngressKey "<<< \"ecdsa-sha2-nistp384 $b64 test@ecdsa384\""
+    script  ecdsa384  $a1 -osh selfAddIngressKey "<<< \"ecdsa-sha2-nistp384 $b64 test@ecdsa384\""
     retvalshouldbe 0
     contain "key successfully added"
     json $(cat <<EOS
@@ -448,7 +448,7 @@ EOS
     b64='AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBADaVbKH5FN1Dcb/jXbb4Xa1UM/l4qVKFSHQKo1o0Zk/T9eHt+vpgvMUnbyZpawktdBgF4ScnPvO7qzgM+fgy62LYACbExQvYLcrYTK+h6TxISptpCFNli4XjjW88YhL7qGmZDlezZTUCHDZryVato7Fzfe66mqZcT6aMWO+Lyr5RLc4uw=='
     fpe521="SHA256:qK+FmUoa7OBqzyiuH+hp974f/pt8L9SWTsjzId2I4/w"
     [ "$FP_TYPE" = md5 ] && fpe521="2d:af:3a:b1:b7:9f:74:71:f9:8e:3f:85:03:f8:4e:c0"
-    script selfAddIngressKey  ecdsa521  $a1 -osh selfAddIngressKey "<<< \"ecdsa-sha2-nistp521 $b64 test@ecdsa521\""
+    script  ecdsa521  $a1 -osh selfAddIngressKey "<<< \"ecdsa-sha2-nistp521 $b64 test@ecdsa521\""
     retvalshouldbe 0
     contain "key successfully added"
     json $(cat <<EOS
@@ -470,7 +470,7 @@ EOS
     fped="SHA256:DFITA8tNfJknq6a/xbro1SxTLTWn/vwZkEROk4IB2LM"
     [ "$FP_TYPE" = md5 ] && fped="d7:92:5b:77:8b:69:03:cb:e7:5a:11:76:d1:a6:ea:e4"
     fplist="$fp4096 $fp8192 $fp16384 $fpe256 $fpe384 $fpe521"
-    script selfAddIngressKey  ed25519   $a1 -osh selfAddIngressKey "<<< \"ssh-ed25519 $b64 test@ed25519\""
+    script  ed25519   $a1 -osh selfAddIngressKey "<<< \"ssh-ed25519 $b64 test@ed25519\""
     if [ "${capabilities[ed25519]}" = "1" ] ; then
         fplist="$fplist $fped"
         retvalshouldbe 0
@@ -507,27 +507,27 @@ EOS
     fi
 
     if [ "${capabilities[blacklist]}" = 1 ] ; then
-    script selfAddIngressKey  rsa1024fucked $a1 -osh selfAddIngressKey "<<< \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEA90Td1GTx+tYMbsti93lyiyKYelBgaXRrnweoYJXjUFNU93jZ+RmBR8yp5J6mx7jz9ECaMS7Dn49fNQi5uG75+m+DTUgq3bfNv8cygoVC4g3NhzA3e+uA22D+iI53j3Gm9YxaJVOypGXGkOoWnmXZy7FQ4aSBFvgqa81xfnoa+4M= compromised@rsa1024\""
+    script  rsa1024fucked $a1 -osh selfAddIngressKey "<<< \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEA90Td1GTx+tYMbsti93lyiyKYelBgaXRrnweoYJXjUFNU93jZ+RmBR8yp5J6mx7jz9ECaMS7Dn49fNQi5uG75+m+DTUgq3bfNv8cygoVC4g3NhzA3e+uA22D+iI53j3Gm9YxaJVOypGXGkOoWnmXZy7FQ4aSBFvgqa81xfnoa+4M= compromised@rsa1024\""
     retvalshouldbe 100
     contain "IT IS VULNERABLE"
     json .command selfAddIngressKey .error_code KO_VULNERABLE_KEY
 
-    script selfAddIngressKey  rsa2048fucked $a1 -osh selfAddIngressKey "<<< \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAxP84hsnxNGSGczfSZTYwb7YCu7yFEyYq5r5qS0dKc6EVQkqdYCn5FrFj8d0+Qn9vglQyCMk+Aa9VLlmKV8/e43FqIq7oh4RDe3YhKKvQ28gLGB/nh2oBLDCB/AYMOjjkCsGU344mrcKQDZlPQsk7lJsied1YphOzHFD7MZVdWd0oUpKFdZSuGbpLRWR+bq29fx7JSiT2tw3G3+EQSW9bdqvzKgwQOAg94FFUTjiK/nVDXAowKMP3+R3cV/CxccA9q5glGw6Xh+K54oZRQ9frzEGmxOlDhMhthQCSRrAvwQQn9kBmcX8qiugHJGS91R5lWv+HU2ndyCQ6xTxRtYvMOw== compromised@rsa2048\""
+    script  rsa2048fucked $a1 -osh selfAddIngressKey "<<< \"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAxP84hsnxNGSGczfSZTYwb7YCu7yFEyYq5r5qS0dKc6EVQkqdYCn5FrFj8d0+Qn9vglQyCMk+Aa9VLlmKV8/e43FqIq7oh4RDe3YhKKvQ28gLGB/nh2oBLDCB/AYMOjjkCsGU344mrcKQDZlPQsk7lJsied1YphOzHFD7MZVdWd0oUpKFdZSuGbpLRWR+bq29fx7JSiT2tw3G3+EQSW9bdqvzKgwQOAg94FFUTjiK/nVDXAowKMP3+R3cV/CxccA9q5glGw6Xh+K54oZRQ9frzEGmxOlDhMhthQCSRrAvwQQn9kBmcX8qiugHJGS91R5lWv+HU2ndyCQ6xTxRtYvMOw== compromised@rsa2048\""
     retvalshouldbe 100
     contain "IT IS VULNERABLE"
     json .command selfAddIngressKey .error_code KO_VULNERABLE_KEY
     fi
 
-    run info user1key2beforeadd $a1k2 -osh info
+    run user1key2beforeadd $a1k2 -osh info
     retvalshouldbe 255
     contain "Permission denied"
 
-    script selfAddIngressKey user1key2 $a1 -osh selfAddIngressKey '<' $account1key2file.pub
+    script user1key2 $a1 -osh selfAddIngressKey '<' $account1key2file.pub
     retvalshouldbe 0
     contain "key successfully added"
     json .command selfAddIngressKey .error_code OK
 
-    success selfListIngressKeys afteradd $a1 -osh selfListIngressKeys
+    success afteradd $a1 -osh selfListIngressKeys
     account1key1fp=""
     account1key2fp=""
     for i in {0..20}
@@ -540,21 +540,21 @@ EOS
     unset tmpline
     json .command selfListIngressKeys .error_code OK .value.account $account1
 
-    script gotfingerprint key1 grep -Eq "'^SHA256:|([0-9a-f]{2}:){7}'" "<<<" "$account1key1fp"
+    script key1 grep -Eq "'^SHA256:|([0-9a-f]{2}:){7}'" "<<<" "$account1key1fp"
     retvalshouldbe 0
 
-    script gotfingerprint key2 grep -Eq "'^SHA256:|([0-9a-f]{2}:){7}'" "<<<" "$account1key2fp"
+    script key2 grep -Eq "'^SHA256:|([0-9a-f]{2}:){7}'" "<<<" "$account1key2fp"
     retvalshouldbe 0
 
     # remove all keys except key1 key2
     for fp in $fplist ; do
-        success selfDelIngressKey otherkeys $a1 -osh selfDelIngressKey -f $fp
+        success otherkeys $a1 -osh selfDelIngressKey -f $fp
         contain "successfully deleted"
         json .command selfDelIngressKey .error_code OK
     done
     unset fplist
 
-    success selfListIngressKeys afterdel $a1 -osh selfListIngressKeys
+    success afterdel $a1 -osh selfListIngressKeys
     json $(cat <<EOS
     .command    selfListIngressKeys
     .error_code OK
@@ -565,17 +565,17 @@ EOS
 EOS
     )
 
-    success info user1key2aftereadd $a1k2 -osh info
+    success user1key2aftereadd $a1k2 -osh info
     contain "Your alias to connect"
     json .command info .error_code OK .value.account $account1
 
-    success selfDelIngressKey key2 $a1k2 -osh selfDelIngressKey -f "$account1key2fp"
+    success key2 $a1k2 -osh selfDelIngressKey -f "$account1key2fp"
     json .command selfDelIngressKey .error_code OK .value.deleted_key.err OK
 
-    plgfail selfDelIngressKey a1k1mustfail $a1 -osh selfDelIngressKey -f "$account1key1fp"
+    plgfail a1k1mustfail $a1 -osh selfDelIngressKey -f "$account1key1fp"
     json .command selfDelIngressKey .error_code ERR_ONLY_ONE_KEY .value null
 
-    success selfListIngressKeys afterdel2only1remain $a1 -osh selfListIngressKeys
+    success afterdel2only1remain $a1 -osh selfListIngressKeys
     contain "$account1key1fp"
     nocontain "$account1key2fp"
     json $(cat <<EOS
@@ -619,12 +619,12 @@ EOS
 
     # delete account1
     grant accountDelete
-    script accountDelete cleanup $a0 --osh accountDelete --account $account1 "<<< \"Yes, do as I say and delete $account1, kthxbye\""
+    script cleanup $a0 --osh accountDelete --account $account1 "<<< \"Yes, do as I say and delete $account1, kthxbye\""
     retvalshouldbe 0
     revoke accountDelete
 
     # restore default config
-    success bastion configrestore $r0 "dd if=$opt_remote_etc_bastion/bastion.conf.bak.$now of=$opt_remote_etc_bastion/bastion.conf"
+    success configrestore $r0 "dd if=$opt_remote_etc_bastion/bastion.conf.bak.$now of=$opt_remote_etc_bastion/bastion.conf"
 }
 
 testsuite_selfkeys

--- a/tests/functional/tests.d/340-selfaccesses.sh
+++ b/tests/functional/tests.d/340-selfaccesses.sh
@@ -13,7 +13,7 @@ testsuite_selfaccesses()
     grant accountCreate
 
     for i in {1..10}; do
-        success selfaccess a0_create_a1_uidauto_nokey_$i $a0 --osh accountCreate --account delme$i --uid-auto --no-key
+        success a0_create_a1_uidauto_nokey_$i $a0 --osh accountCreate --account delme$i --uid-auto --no-key
         json .error_code OK .command accountCreate
     done
 
@@ -22,7 +22,7 @@ testsuite_selfaccesses()
 
     # delete those accounts
     for i in {1..10}; do
-        script selfaccess a0_delete_a1_uidauto_nokey_$i $a0 --osh accountDelete --account delme$i "<<< \"Yes, do as I say and delete delme$i, kthxbye\""
+        script a0_delete_a1_uidauto_nokey_$i $a0 --osh accountDelete --account delme$i "<<< \"Yes, do as I say and delete delme$i, kthxbye\""
         retvalshouldbe 0
         json .error_code OK .command accountDelete
     done
@@ -31,29 +31,29 @@ testsuite_selfaccesses()
     grant accountCreate
 
     # create account1
-    success osh accountCreate $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key "\"$(cat $account1key1file.pub)\""
+    success accountCreate $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key "\"$(cat $account1key1file.pub)\""
     json .error_code OK .command accountCreate .value null
 
     revoke accountCreate
     grant accountModify
 
-    success realm modify_account1 $a0 --osh accountModify --pam-auth-bypass yes --account $account1
+    success modify_account1 $a0 --osh accountModify --pam-auth-bypass yes --account $account1
     json .error_code OK .command accountModify
 
     # test osh-only
-    success accountModify enable_osh_only $a0 --osh accountModify --osh-only yes --account $account1
+    success enable_osh_only $a0 --osh accountModify --osh-only yes --account $account1
     json .error_code OK .command accountModify
 
     # account1 can not connect to anything
-    run accountModify no_ssh_after_osh_only $a1 anybody@127.0.0.1
+    run no_ssh_after_osh_only $a1 anybody@127.0.0.1
     retvalshouldbe 107
     json .error_code KO_ACCESS_DENIED .error_message "You don't have the right to connect anywhere"
 
-    success accountModify disable_osh_only $a0 --osh accountModify --osh-only no --account $account1
+    success disable_osh_only $a0 --osh accountModify --osh-only no --account $account1
     json .error_code OK .command accountModify
 
     # account1 can connect now (or could if they were granted)
-    run accountModify can_ssh_after_osh_only_disable $a1 anybody@127.0.0.1
+    run can_ssh_after_osh_only_disable $a1 anybody@127.0.0.1
     retvalshouldbe 107
     json .error_code KO_ACCESS_DENIED
     contain "Access denied"
@@ -61,16 +61,16 @@ testsuite_selfaccesses()
 
     revoke accountModify
 
-    success selfListEgressKeys beforeadd $a1 -osh selfListEgressKeys
+    success beforeadd $a1 -osh selfListEgressKeys
     tmpfp=$(get_json | $jq '.value|keys[0]')
     json .command selfListEgressKeys .error_code OK '.value|keys[1]'  null
     pattern "^$account1@fix-my-config-please-missing-bastion-name:[0-9]+$" "$(get_json | $jq ".value|.[\"$tmpfp\"]|.comment")"
 
-    success osh selfGenerateEgressKey $a1 --osh selfGenerateEgressKey --algo rsa --size 4096
+    success selfGenerateEgressKey $a1 --osh selfGenerateEgressKey --algo rsa --size 4096
     json .error_code OK .command selfGenerateEgressKey .value.size 4096 .value.family RSA
     tmpfp2=$(get_json | $jq '.value.fingerprint')
 
-    success selfListEgressKeys afteradd $a1 -osh selfListEgressKeys
+    success afteradd $a1 -osh selfListEgressKeys
     json .command    selfListEgressKeys .error_code OK '.value|keys[2]'  null
     pattern "^$account1@fix-my-config-please-missing-bastion-name:[0-9]+$" "$(get_json | $jq ".value|.[\"$tmpfp\"]|.comment")"
     pattern "^$account1@fix-my-config-please-missing-bastion-name:[0-9]+$" "$(get_json | $jq ".value|.[\"$tmpfp2\"]|.comment")"
@@ -79,7 +79,7 @@ testsuite_selfaccesses()
 
     # batch plugin
 
-    script plugin-batch one "printf \"%b\\n\" \"info\\naccountInfo --account $account0\\nselfListEgressKeys\" | $a1 --osh batch"
+    script one "printf \"%b\\n\" \"info\\naccountInfo --account $account0\\nselfListEgressKeys\" | $a1 --osh batch"
     retvalshouldbe 0
     json .command batch .error_code OK
     json '.value[0].result.error_code' OK '.value[0].command' info '.value[0].result.value.account' "$account1"
@@ -88,81 +88,81 @@ testsuite_selfaccesses()
 
     # ssh
 
-    run ssh a1atlo2 $a1 127.0.0.2 -- id
+    run a1atlo2 $a1 127.0.0.2 -- id
     retvalshouldbe 107
     contain "Access denied for"
     json .command    null .error_code KO_ACCESS_DENIED
 
-    run ssh invalid_host $a1 127.0./0.1 -- id
+    run invalid_host $a1 127.0./0.1 -- id
     retvalshouldbe 102
     json .error_code KO_HOST_NOT_FOUND
 
-    run ssh invalid_host $a1 127.0.%0.1 -- id
+    run invalid_host $a1 127.0.%0.1 -- id
     retvalshouldbe 128
     json .error_code KO_INVALID_REMOTE_HOST
 
-    run ssh invalid_user $a1 ro/ot@127.0.0.1 -- id
+    run invalid_user $a1 ro/ot@127.0.0.1 -- id
     retvalshouldbe 127
     json .error_code KO_INVALID_REMOTE_USER
 
     grant selfAddPersonalAccess
     grant selfDelPersonalAccess
 
-    run selfAddPersonalAccess mustfail $a1 -osh selfAddPersonalAccess -h 127.0.0.2 -u $shellaccount -p 22
+    run mustfail $a1 -osh selfAddPersonalAccess -h 127.0.0.2 -u $shellaccount -p 22
     retvalshouldbe 106
     contain "you to be specifically granted"
     json .command    null .error_code KO_RESTRICTED_COMMAND
 
-    success selfAddPersonalAccess mustwork $a0 -osh selfAddPersonalAccess -h 127.0.0.2 -u $shellaccount -p 22 --kbd-interactive
+    success mustwork $a0 -osh selfAddPersonalAccess -h 127.0.0.2 -u $shellaccount -p 22 --kbd-interactive
     nocontain "already"
     json .command   selfAddPersonalAccess .error_code   OK .value.ip 127.0.0.2 .value.user $shellaccount .value.port 22
 
-    success selfAddPersonalAccess dupe $a0 -osh selfAddPersonalAccess -h 127.0.0.2 -u $shellaccount -p 22 --kbd-interactive
+    success dupe $a0 -osh selfAddPersonalAccess -h 127.0.0.2 -u $shellaccount -p 22 --kbd-interactive
     contain "already"
     json .command   selfAddPersonalAccess .error_code   OK_NO_CHANGE .value null
 
-    success selfAddPersonalAccess withttl $a0 -osh selfAddPersonalAccess -h 127.0.0.4 -u $shellaccount -p 22 --force --ttl 0d0h0m3s
+    success withttl $a0 -osh selfAddPersonalAccess -h 127.0.0.4 -u $shellaccount -p 22 --force --ttl 0d0h0m3s
     json .command   selfAddPersonalAccess .error_code   OK .value.ip 127.0.0.4 .value.user $shellaccount .value.port 22 .value.ttl 3
 
-    run ssh a1atlo2_login8     $a0           127.0.0.2 -- id
+    run a1atlo2_login8     $a0           127.0.0.2 -- id
     retvalshouldbe 107
     contain "Access denied for"
     json .command null .value null .error_code KO_ACCESS_DENIED
 
     # auto hostname=$host comment
 
-    success selfAddPersonalAccess self_add_personal_access_auto_comment $a0 --osh selfAddPersonalAccess --host localhost -u autocomment -p 1234 --force --ttl 1
+    success self_add_personal_access_auto_comment $a0 --osh selfAddPersonalAccess --host localhost -u autocomment -p 1234 --force --ttl 1
     json .command selfAddPersonalAccess .error_code OK .value.comment "hostname=localhost" .value.user autocomment .value.port 1234 .value.ttl 1
 
     # forcekey
 
-    success selfListIngressKeys for_force_key $a0 --osh selfListEgressKeys
+    success for_force_key $a0 --osh selfListEgressKeys
     account0key1fp=$(get_json | $jq '.value|keys[0]')
 
-    success selfAddPersonalAccess forcekey $a0 --osh selfAddPersonalAccess -h 127.7.7.7 -u $shellaccount -p 22 --force --force-key "$account0key1fp"
+    success forcekey $a0 --osh selfAddPersonalAccess -h 127.7.7.7 -u $shellaccount -p 22 --force --force-key "$account0key1fp"
 
-    success selfListAccesses forcekey $a0 --osh selfListAccesses
+    success forcekey $a0 --osh selfListAccesses
     contain "$account0key1fp"
 
     # try to use the force key
 
-    success ssh forcekey $a0 $shellaccount@127.7.7.7 --kbd-interactive -- id
+    success forcekey $a0 $shellaccount@127.7.7.7 --kbd-interactive -- id
     contain 'FORCED IN ACL'
 
-    success selfDelPersonalAccess forcekey $a0 -osh selfDelPersonalAccess -h 127.7.7.7 -u $shellaccount -p 22
+    success forcekey $a0 -osh selfDelPersonalAccess -h 127.7.7.7 -u $shellaccount -p 22
 
     # /forcekey
 
-    success ssh shellaccountatlo2_mustwork   $a0 $shellaccount@127.0.0.2 --kbd-interactive -- echo $randomstr
+    success shellaccountatlo2_mustwork   $a0 $shellaccount@127.0.0.2 --kbd-interactive -- echo $randomstr
     contain REGEX "$shellaccount@[a-zA-Z0-9._-]+:22"
     contain "allowed ... log on"
     nocontain "Permission denied"
     contain "$randomstr"
 
     # scp
-    success accountAddPersonalAccess forscp $a0 --osh selfAddPersonalAccess --host 127.0.0.2 --scpup --port 22
+    success forscp $a0 --osh selfAddPersonalAccess --host 127.0.0.2 --scpup --port 22
 
-    success osh scp $a0 --osh scp
+    success scp $a0 --osh scp
     if [ "$COUNTONLY" != 1 ]; then
         tmpb64=$(get_json | $jq '.value.script')
         base64 -d <<< "$tmpb64" | gunzip -c > /tmp/scphelpertmp
@@ -172,207 +172,207 @@ testsuite_selfaccesses()
         unset tmpb64
     fi
 
-    run scp downloadfailnoright scp -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file $shellaccount@127.0.0.2:uptest /tmp/downloaded
+    run scp_downloadfailnoright scp -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file $shellaccount@127.0.0.2:uptest /tmp/downloaded
     retvalshouldbe 1
     contain "Sorry, but even"
 
-    success accountAddPersonalAccess forscp $a0 --osh selfAddPersonalAccess --host 127.0.0.2 --scpdown --port 22
+    success forscp $a0 --osh selfAddPersonalAccess --host 127.0.0.2 --scpdown --port 22
 
-    run scp downloadfailnofile scp -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file $shellaccount@127.0.0.2:uptest /tmp/downloaded
+    run scp_downloadfailnofile scp -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file $shellaccount@127.0.0.2:uptest /tmp/downloaded
     retvalshouldbe 1
     contain "through the bastion from"
     contain "Error launching transfer"
     contain "No such file or directory"
     nocontain "Permission denied"
 
-    run scp invalidhostname scp -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file $shellaccount@_invalid._invalid:uptest /tmp/downloaded
+    run scp_invalidhostname scp -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file $shellaccount@_invalid._invalid:uptest /tmp/downloaded
     retvalshouldbe 1
     contain "Sorry, couldn't resolve the host you specified"
 
-    success scp upload scp -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file /etc/passwd $shellaccount@127.0.0.2:uptest
+    success scp_upload scp -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file /etc/passwd $shellaccount@127.0.0.2:uptest
     contain "through the bastion to"
     contain "Done,"
 
-    success scp download scp -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file $shellaccount@127.0.0.2:uptest /tmp/downloaded
+    success scp_download scp -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file $shellaccount@127.0.0.2:uptest /tmp/downloaded
     contain "through the bastion from"
     contain "Done,"
 
-    success accountAddPersonalAccess forscpremove1 $a0 --osh selfDelPersonalAccess --host 127.0.0.2 --scpup   --port 22
-    success accountAddPersonalAccess forscpremove2 $a0 --osh selfDelPersonalAccess --host 127.0.0.2 --scpdown --port 22
+    success forscpremove1 $a0 --osh selfDelPersonalAccess --host 127.0.0.2 --scpup   --port 22
+    success forscpremove2 $a0 --osh selfDelPersonalAccess --host 127.0.0.2 --scpdown --port 22
 
     # /scp
 
     # (forced commands)
 
     # ESCAPE HELL
-    success ssh escapehell1ae $a0 --always-escape $shellaccount@127.0.0.2 -- "\"echo 'test1;test1' ; id\""
+    success escapehell1ae $a0 --always-escape $shellaccount@127.0.0.2 -- "\"echo 'test1;test1' ; id\""
     contain "'test1"
     contain 'uid='
     contain REGEX "test1': (command )?not found"
     nocontain 'test1;test1'
     nocontain 'crazy'
 
-    success ssh escapehell2ae $a0 --always-escape $shellaccount@127.0.0.2 -- "'echo \"test1;test1\" ; id'"
+    success escapehell2ae $a0 --always-escape $shellaccount@127.0.0.2 -- "'echo \"test1;test1\" ; id'"
     contain "test1;test1"
     contain 'uid='
     nocontain 'not found'
     nocontain 'crazy'
 
-    success ssh escapehell3ae $a0 --always-escape $shellaccount@127.0.0.2 -- "'echo \\\"test1;test1\\\" ; id'"
+    success escapehell3ae $a0 --always-escape $shellaccount@127.0.0.2 -- "'echo \\\"test1;test1\\\" ; id'"
     contain '"test1'
     contain 'uid='
     contain REGEX 'test1": (command )?not found'
     nocontain 'crazy'
 
-    success ssh escapehell4ae $a0 --always-escape $shellaccount@127.0.0.2 -- "\"echo \\\"test1;test1\\\" ; id\""
+    success escapehell4ae $a0 --always-escape $shellaccount@127.0.0.2 -- "\"echo \\\"test1;test1\\\" ; id\""
     contain 'test1;test1'
     contain 'uid='
     nocontain 'not found'
     nocontain 'crazy'
 
-    success ssh escapehell5ae $a0 --always-escape $shellaccount@127.0.0.2 -- "\"echo \\\"test1';'test1\\\" ; id\""
+    success escapehell5ae $a0 --always-escape $shellaccount@127.0.0.2 -- "\"echo \\\"test1';'test1\\\" ; id\""
     contain "test1\\';\\'test1"
     contain 'uid='
     nocontain 'not found'
     nocontain 'crazy'
 
-    success ssh escapehell1ne $a0 --never-escape $shellaccount@127.0.0.2 -- "\"echo 'test1;test1' ; id\""
+    success escapehell1ne $a0 --never-escape $shellaccount@127.0.0.2 -- "\"echo 'test1;test1' ; id\""
     contain "test1;test1"
     contain 'uid='
     nocontain 'not found'
     nocontain 'crazy'
 
-    success ssh escapehell2ne $a0 --never-escape $shellaccount@127.0.0.2 -- "'echo \"test1;test1\" ; id'"
+    success escapehell2ne $a0 --never-escape $shellaccount@127.0.0.2 -- "'echo \"test1;test1\" ; id'"
     contain "test1;test1"
     contain 'uid='
     nocontain 'not found'
     nocontain 'crazy'
 
-    success ssh escapehell3ne $a0 --never-escape $shellaccount@127.0.0.2 -- "'echo \\\"test1;test1\\\" ; id'"
+    success escapehell3ne $a0 --never-escape $shellaccount@127.0.0.2 -- "'echo \\\"test1;test1\\\" ; id'"
     contain '"test1'
     contain 'uid='
     contain REGEX 'test1": (command )?not found'
     nocontain 'crazy'
 
-    success ssh escapehell4ne $a0 --never-escape $shellaccount@127.0.0.2 -- "\"echo \\\"test1;test1\\\" ; id\""
+    success escapehell4ne $a0 --never-escape $shellaccount@127.0.0.2 -- "\"echo \\\"test1;test1\\\" ; id\""
     contain 'test1;test1'
     contain 'uid='
     nocontain 'not found'
     nocontain 'crazy'
 
-    success ssh escapehell5ne $a0 --never-escape $shellaccount@127.0.0.2 -- "\"echo \\\"test1';'test1\\\" ; id\""
+    success escapehell5ne $a0 --never-escape $shellaccount@127.0.0.2 -- "\"echo \\\"test1';'test1\\\" ; id\""
     contain "test1';'test1"
     contain 'uid='
     nocontain 'not found'
     nocontain 'crazy'
 
-    success ssh escapehellnoprotect1ae $a0 --always-escape $shellaccount@127.0.0.2 "\"echo 'test1;test1' ; id\""
+    success escapehellnoprotect1ae $a0 --always-escape $shellaccount@127.0.0.2 "\"echo 'test1;test1' ; id\""
     contain "test1"
     contain 'uid='
     contain REGEX "test1: (command )?not found"
     nocontain 'test1;test1'
     contain 'crazy'
 
-    success ssh escapehellnoprotect2ae $a0 --always-escape $shellaccount@127.0.0.2 "'echo \"test1;test1\" ; id'"
+    success escapehellnoprotect2ae $a0 --always-escape $shellaccount@127.0.0.2 "'echo \"test1;test1\" ; id'"
     contain "test1"
     contain 'uid='
     contain REGEX 'test1: (command )?not found'
     nocontain 'test1;test1'
     contain 'crazy'
 
-    success ssh escapehellnoprotect3ae $a0 --always-escape $shellaccount@127.0.0.2 "'echo \\\"test1;test1\\\" ; id'"
+    success escapehellnoprotect3ae $a0 --always-escape $shellaccount@127.0.0.2 "'echo \\\"test1;test1\\\" ; id'"
     contain 'test1;test1'
     contain 'uid='
     nocontain REGEX ': (command )?not found'
     contain 'crazy'
 
-    success ssh escapehellnoprotect4ae $a0 --always-escape $shellaccount@127.0.0.2 "\"echo \\\"test1;test1\\\" ; id\""
+    success escapehellnoprotect4ae $a0 --always-escape $shellaccount@127.0.0.2 "\"echo \\\"test1;test1\\\" ; id\""
     contain "test1"
     contain 'uid='
     contain REGEX 'test1: (command )?not found'
     nocontain 'test1;test1'
     contain 'crazy'
 
-    success ssh escapehellnoprotect5ae $a0 --always-escape $shellaccount@127.0.0.2 "\"echo \\\"test1';'test1\\\" ; id\""
+    success escapehellnoprotect5ae $a0 --always-escape $shellaccount@127.0.0.2 "\"echo \\\"test1';'test1\\\" ; id\""
     contain 'test1;test1'
     contain 'uid='
     nocontain 'not found'
     contain 'crazy'
 
-    success ssh escapehellnoprotect1ne $a0 --never-escape $shellaccount@127.0.0.2 "\"echo 'test1;test1' ; id\""
+    success escapehellnoprotect1ne $a0 --never-escape $shellaccount@127.0.0.2 "\"echo 'test1;test1' ; id\""
     contain "test1"
     contain 'uid='
     contain REGEX 'test1: (command )?not found'
     nocontain 'test1;test1'
     contain 'crazy'
 
-    success ssh escapehellnoprotect2ne $a0 --never-escape $shellaccount@127.0.0.2 "'echo \"test1;test1\" ; id'"
+    success escapehellnoprotect2ne $a0 --never-escape $shellaccount@127.0.0.2 "'echo \"test1;test1\" ; id'"
     contain "test1"
     contain 'uid='
     contain REGEX 'test1: (command )?not found'
     nocontain 'test1;test1'
     contain 'crazy'
 
-    success ssh escapehellnoprotect3ne $a0 --never-escape $shellaccount@127.0.0.2 "'echo \\\"test1;test1\\\" ; id'"
+    success escapehellnoprotect3ne $a0 --never-escape $shellaccount@127.0.0.2 "'echo \\\"test1;test1\\\" ; id'"
     contain 'test1;test1'
     contain 'uid='
     nocontain 'not found'
     contain 'crazy'
 
-    success ssh escapehellnoprotect4ne $a0 --never-escape $shellaccount@127.0.0.2 "\"echo \\\"test1;test1\\\" ; id\""
+    success escapehellnoprotect4ne $a0 --never-escape $shellaccount@127.0.0.2 "\"echo \\\"test1;test1\\\" ; id\""
     contain "test1"
     contain 'uid='
     contain REGEX 'test1: (command )?not found'
     nocontain 'test1;test1'
     contain 'crazy'
 
-    success ssh escapehellnoprotect5ne $a0 --never-escape $shellaccount@127.0.0.2 "\"echo \\\"test1';'test1\\\" ; id\""
+    success escapehellnoprotect5ne $a0 --never-escape $shellaccount@127.0.0.2 "\"echo \\\"test1';'test1\\\" ; id\""
     contain 'test1;test1'
     contain 'uid='
     nocontain 'not found'
     contain 'crazy'
 
-    run ssh shellaccountatlo_badport $a0 $shellaccount@127.0.0.2 -p 223 -- echo $randomstr
+    run shellaccountatlo_badport $a0 $shellaccount@127.0.0.2 -p 223 -- echo $randomstr
     retvalshouldbe 107
     contain "Access denied for"
     nocontain "$randomstr"
     json .command null .value null .error_code KO_ACCESS_DENIED
 
-    run ssh shellaccountatlo_badip $a0 $shellaccount@127.0.0.1 -- echo $randomstr
+    run shellaccountatlo_badip $a0 $shellaccount@127.0.0.1 -- echo $randomstr
     retvalshouldbe 107
     contain "Access denied for"
     nocontain "$randomstr"
     json .command null .value null .error_code KO_ACCESS_DENIED
 
-    run ssh shellaccountatlo_badroot $a0 root@127.0.0.2 -- echo $randomstr
+    run shellaccountatlo_badroot $a0 root@127.0.0.2 -- echo $randomstr
     retvalshouldbe 107
     contain "Access denied for"
     nocontain "$randomstr"
     json .command null .value null .error_code KO_ACCESS_DENIED
 
-    run selfDelPersonalAccess mustfailnosudo $a1 -osh selfDelPersonalAccess -h 127.0.0.2 -u $shellaccount -p 22
+    run mustfailnosudo $a1 -osh selfDelPersonalAccess -h 127.0.0.2 -u $shellaccount -p 22
     retvalshouldbe 106
     contain "you to be specifically granted"
     json .command null .value null .error_code KO_RESTRICTED_COMMAND
 
     #sudo usermod -a -G osh-selfDelPersonalAccess $account1
-    success selfDelPersonalAccess mustwork $a0 -osh selfDelPersonalAccess -h 127.0.0.2 -u $shellaccount -p 22
+    success mustwork $a0 -osh selfDelPersonalAccess -h 127.0.0.2 -u $shellaccount -p 22
     contain "Access to $shellaccount@127.0.0.2:22"
     json  .command selfDelPersonalAccess .error_code OK .value.ip 127.0.0.2 .value.user $shellaccount .value.port 22
 
-    run ssh shellaccountatlo2_mustfail   $a1 $shellaccount@127.0.0.2 -- echo $randomstr
+    run shellaccountatlo2_mustfail   $a1 $shellaccount@127.0.0.2 -- echo $randomstr
     retvalshouldbe 107
     contain "Access denied for"
     nocontain "$randomstr"
     json .command null .value null .error_code KO_ACCESS_DENIED
 
-    success selfAddPersonalAccess mustwork $a0 -osh selfAddPersonalAccess -h 127.0.0.2 -u $shellaccount -p 226
+    success mustwork $a0 -osh selfAddPersonalAccess -h 127.0.0.2 -u $shellaccount -p 226
     nocontain "already"
     json .command selfAddPersonalAccess .error_code OK .value.ip 127.0.0.2 .value.user $shellaccount .value.port 226
 
     # shouldn't work
 
-    run ssh shellaccountatlo2_badport2   $a0 $shellaccount@127.0.0.2 -- echo $randomstr
+    run shellaccountatlo2_badport2   $a0 $shellaccount@127.0.0.2 -- echo $randomstr
     retvalshouldbe 107
     contain "Access denied for"
     nocontain "$randomstr"
@@ -380,66 +380,66 @@ testsuite_selfaccesses()
 
     # should
 
-    success ssh shellaccountatlo2_mustwork226   $a0 $shellaccount@127.0.0.2 -p 226 -- echo $randomstr
+    success shellaccountatlo2_mustwork226   $a0 $shellaccount@127.0.0.2 -p 226 -- echo $randomstr
     contain REGEX "$shellaccount@[a-zA-Z0-9._-]+:226"
     contain "allowed ... log on"
     nocontain "Permission denied"
     contain "$randomstr"
 
-    success selfDelPersonalAccess mustwork $a0 -osh selfDelPersonalAccess -h 127.0.0.2 -u $shellaccount -p 226
+    success mustwork $a0 -osh selfDelPersonalAccess -h 127.0.0.2 -u $shellaccount -p 226
     contain "Access to $shellaccount@127.0.0.2:226"
     json .command selfDelPersonalAccess .error_code OK .value.ip 127.0.0.2 .value.user $shellaccount .value.port 226
 
-    run ssh shellaccountatlo2_mustfailnow   $a0 $shellaccount@127.0.0.2 -p 226 -- echo $randomstr
+    run shellaccountatlo2_mustfailnow   $a0 $shellaccount@127.0.0.2 -p 226 -- echo $randomstr
     retvalshouldbe 107
     contain "Access denied for"
     nocontain "$randomstr"
     json .command   null .value      null .error_code KO_ACCESS_DENIED
 
-    plgfail selfAddPersonalAccess nousernoportnoforce $a0 -osh selfAddPersonalAccess -h 127.0.0.4
+    plgfail nousernoportnoforce $a0 -osh selfAddPersonalAccess -h 127.0.0.4
     nocontain "already"
     contain REGEX "Couldn't connect to $account0@127.0.0.4 \\(ssh returned error (255|124)\\)"
     json .command selfAddPersonalAccess .error_code ERR_CONNECTION_FAILED .value      null
 
-    success selfAddPersonalAccess nousernoport $a0 -osh selfAddPersonalAccess -h 127.0.0.4 --force
+    success nousernoport $a0 -osh selfAddPersonalAccess -h 127.0.0.4 --force
     nocontain "already"
     contain "Forcing add as asked"
     json .command selfAddPersonalAccess .error_code OK .value.ip 127.0.0.4 .value.port null .value.user null
 
-    run ssh rootport22 $a0 root@127.0.0.4 -- echo $randomstr
+    run rootport22 $a0 root@127.0.0.4 -- echo $randomstr
     retvalshouldbe 255
     contain "allowed ... log on"
     contain "Permission denied"
     nocontain "$randomstr"
 
-    run ssh anyuserport22 $a0 whatevaah@127.0.0.4 -- echo $randomstr
+    run anyuserport22 $a0 whatevaah@127.0.0.4 -- echo $randomstr
     retvalshouldbe 255
     contain "allowed ... log on"
     contain "Permission denied"
     nocontain "$randomstr"
 
-    success ssh gooduserport22 $a0 $shellaccount@127.0.0.4 -- echo $randomstr
+    success gooduserport22 $a0 $shellaccount@127.0.0.4 -- echo $randomstr
     contain "allowed ... log on"
     contain "$randomstr"
 
-    run ssh exitcode $a0 $shellaccount@127.0.0.4 -- exit 43
+    run exitcode $a0 $shellaccount@127.0.0.4 -- exit 43
     retvalshouldbe 43
     contain "allowed ... log on"
 
-    success ssh gooduserport226 $a0 $shellaccount@127.0.0.4 -p 226 -- echo $randomstr
+    success gooduserport226 $a0 $shellaccount@127.0.0.4 -p 226 -- echo $randomstr
     contain "allowed ... log on"
     contain "$randomstr"
 
-    run ssh anyuseaarrport226 $a0 pokpozkpab@127.0.0.4 -p 226 -- echo $randomstr
+    run anyuseaarrport226 $a0 pokpozkpab@127.0.0.4 -p 226 -- echo $randomstr
     retvalshouldbe 255
     contain "allowed ... log on"
     nocontain "$randomstr"
 
-    success selfDelPersonalAccess nousernoport $a0 -osh selfDelPersonalAccess -h 127.0.0.4
+    success nousernoport $a0 -osh selfDelPersonalAccess -h 127.0.0.4
     contain "Access to 127.0.0.4 "
     json .command selfDelPersonalAccess .error_code OK .value.ip 127.0.0.4 .value.port null .value.user null
 
-    success selfDelPersonalAccess nousernoport_dupe $a0 -osh selfDelPersonalAccess -h 127.0.0.4
+    success nousernoport_dupe $a0 -osh selfDelPersonalAccess -h 127.0.0.4
     nocontain "no longer has a personal access"
     json .command selfDelPersonalAccess .error_code OK_NO_CHANGE .value      null
 
@@ -447,7 +447,7 @@ testsuite_selfaccesses()
     # ... then try to ssh with all combinations
 
     # TODO try partial group thing, and try to ssh to ip pertaining to group
-    success selfListAccesses oka0 $a0 --osh selfListAccesses
+    success oka0 $a0 --osh selfListAccesses
     contain 'no registered accesses'
     nocontain 'personal'
     nocontain 'group-member'
@@ -455,60 +455,60 @@ testsuite_selfaccesses()
     json .command selfListAccesses .error_code OK_EMPTY .value          null
 
     # FIXME with bastion config => auto-added private accesses ?
-    success selfListAccesses oka1 $a1 --osh selfListAccesses
+    success oka1 $a1 --osh selfListAccesses
     contain 'no registered accesses'
     nocontain 'personal'
     nocontain 'group-member'
     nocontain 'group-guest'
     json .command selfListAccesses .error_code OK_EMPTY .value          null
 
-    success   selfForgetHostKey   loportnomatch   $a0 --osh selfForgetHostKey --host 127.0.0.1 --port 1234
+    success   loportnomatch   $a0 --osh selfForgetHostKey --host 127.0.0.1 --port 1234
     json .command selfForgetHostKey .error_code OK '.value."[127.0.0.1]:1234".action' OK_NO_MATCH
 
-    success   selfForgetHostKey   lonomatch   $a0 --osh selfForgetHostKey --host 127.0.0.1
+    success   lonomatch   $a0 --osh selfForgetHostKey --host 127.0.0.1
     json .command selfForgetHostKey .error_code OK '.value."127.0.0.1".action'   OK_NO_MATCH
 
-    success   selfForgetHostKey   lonofile   $a1 --osh selfForgetHostKey --host 127.0.0.1
+    success   lonofile   $a1 --osh selfForgetHostKey --host 127.0.0.1
     json .command selfForgetHostKey .error_code OK_NO_CHANGE .value      null
 
-    success   selfForgetHostKey   works   $a0 --osh selfForgetHostKey --host 127.0.0.2
+    success   works   $a0 --osh selfForgetHostKey --host 127.0.0.2
     json .command selfForgetHostKey .error_code OK '.value."127.0.0.2".action'   OK_DELETED
 
-    success   selfForgetHostKey   dupe   $a0 --osh selfForgetHostKey --host 127.0.0.2
+    success   dupe   $a0 --osh selfForgetHostKey --host 127.0.0.2
     json .command selfForgetHostKey .error_code OK '.value."127.0.0.2".action'   OK_NO_MATCH
 
     grant accountUnexpire
 
-    success accountUnexpire nochange $a0 --osh accountUnexpire --account $account1
+    success nochange $a0 --osh accountUnexpire --account $account1
     json .command accountUnexpire .error_code OK_NO_CHANGE
 
     # artificially expire account1
     configchg 's=^\\\\x22accountMaxInactiveDays\\\\x22.+=\\\\x22accountMaxInactiveDays\\\\x22:2,='
-    success bastion manuallyExpireAccount1 $r0 "touch -t 201501010101 /home/$account1/lastlog"
+    success manuallyExpireAccount1 $r0 "touch -t 201501010101 /home/$account1/lastlog"
 
-    run account expired $a1 --osh info
+    run expired $a1 --osh info
     retvalshouldbe 113
 
-    success accountUnexpire works $a0 --osh accountUnexpire --account $account1
+    success works $a0 --osh accountUnexpire --account $account1
     json .command accountUnexpire .error_code OK
 
-    success account unexpired $a1 --osh info
+    success unexpired $a1 --osh info
     json .error_code OK
 
-    success accountUnexpire worksnochange $a0 --osh accountUnexpire --account $account1
+    success worksnochange $a0 --osh accountUnexpire --account $account1
     json .command accountUnexpire .error_code OK_NO_CHANGE
 
     # try on never logged-in account (different code path)
-    success bastion manuallyRemoveLastlog $r0 "rm -f /home/$account1/lastlog"
+    success manuallyRemoveLastlog $r0 "rm -f /home/$account1/lastlog"
 
-    success accountUnexpire worksnochange $a0 --osh accountUnexpire --account $account1
+    success worksnochange $a0 --osh accountUnexpire --account $account1
     json .command accountUnexpire .error_code OK_NO_CHANGE
 
     revoke accountUnexpire
 
     # delete account1
     grant accountDelete
-    script accountDelete cleanup $a0 --osh accountDelete --account $account1 "<<< \"Yes, do as I say and delete $account1, kthxbye\""
+    script cleanup $a0 --osh accountDelete --account $account1 "<<< \"Yes, do as I say and delete $account1, kthxbye\""
     retvalshouldbe 0
     revoke accountDelete
 }

--- a/tests/functional/tests.d/350-groups.sh
+++ b/tests/functional/tests.d/350-groups.sh
@@ -10,7 +10,7 @@ testsuite_groups()
     grant accountCreate
 
     # first we need to create account1, account2 and account3
-    success accountCreate a0_create_a1 $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key "\"$(cat $account1key1file.pub)\""
+    success a0_create_a1 $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key "\"$(cat $account1key1file.pub)\""
     json .error_code OK .command accountCreate .value null
 
     #grant accountModify
@@ -18,41 +18,41 @@ testsuite_groups()
     #success realm modify_account1 $a0 --osh accountModify --pam-auth-bypass yes --account $account1
     #json .error_code OK .command accountModify
 
-    run accountCreate a1_fail_to_create_a2_because_not_granted $a1 --osh accountCreate --always-active --account $account2 --uid $uid2
+    run a1_fail_to_create_a2_because_not_granted $a1 --osh accountCreate --always-active --account $account2 --uid $uid2
     retvalshouldbe 106
     contain "you to be specifically granted"
     json .command null .value null .error_code KO_RESTRICTED_COMMAND
 
-    run account2access a2_cannot_connect_because_does_not_exist $a2 --osh info
+    run a2_cannot_connect_because_does_not_exist $a2 --osh info
     retvalshouldbe 255
     nocontain "Your alias to connect"
     contain "Permission denied"
 
     # account with no key
-    success accountCreate a0_create_a2_nokey $a0 --osh accountCreate --always-active --account $account2 --uid $uid2 --no-key
+    success a0_create_a2_nokey $a0 --osh accountCreate --always-active --account $account2 --uid $uid2 --no-key
     contain "info"
     json .command accountCreate .error_code OK .value      null
 
     grant accountListIngressKeys
 
-    success accountListIngressKeys a0_check_a2_ingress_keys $a0 --osh accountListIngressKeys --account $account2
+    success a0_check_a2_ingress_keys $a0 --osh accountListIngressKeys --account $account2
     json .command accountListIngressKeys .error_code OK .value.account "$account2" .value.keys '[]'
 
     revoke accountListIngressKeys
 
     grant accountDelete
-    script accountDelete a0_delete_a2 $a0 --osh accountDelete --account $account2 "<<< \"Yes, do as I say and delete $account2, kthxbye\""
+    script a0_delete_a2 $a0 --osh accountDelete --account $account2 "<<< \"Yes, do as I say and delete $account2, kthxbye\""
     retvalshouldbe 0
     json .command accountDelete .error_code OK
     revoke accountDelete
     # /account with no key
 
-    script accountCreate a0_create_a2 $a0 --osh accountCreate --always-active --account $account2 --uid $uid2 \< $account2key1file.pub
+    script a0_create_a2 $a0 --osh accountCreate --always-active --account $account2 --uid $uid2 \< $account2key1file.pub
     retvalshouldbe 0
     contain "info"
     json .command accountCreate .error_code OK .value      null
 
-    script accountCreate a0_fail_to_create_a2_already_exists $a0 --osh accountCreate --always-active --account $account2 --uid $uid2 \< $account2key1file.pub
+    script a0_fail_to_create_a2_already_exists $a0 --osh accountCreate --always-active --account $account2 --uid $uid2 \< $account2key1file.pub
     retvalshouldbe 100
     contain "already exists"
     json .command accountCreate .error_code KO_ALREADY_EXISTING .value      null
@@ -60,12 +60,12 @@ testsuite_groups()
     #success realm modify_account1 $a0 --osh accountModify --pam-auth-bypass yes --account $account2
     #json .error_code OK .command accountModify
 
-    success account2access a2_can_access_the_bastion $a2 --osh info
+    success a2_can_access_the_bastion $a2 --osh info
     contain "Your alias to connect"
     json .command info .error_code OK .value.account $account2
 
     # now create a3 directly, we'll need it to test groups
-    script accountCreate a0_create_a3 $a0 --osh accountCreate --always-active --account $account3 --uid $uid3 \< $account3key1file.pub
+    script a0_create_a3 $a0 --osh accountCreate --always-active --account $account3 --uid $uid3 \< $account3key1file.pub
     retvalshouldbe 0
     contain "info"
     json .command accountCreate .error_code OK .value      null
@@ -73,7 +73,7 @@ testsuite_groups()
     #success realm modify_account1 $a0 --osh accountModify --pam-auth-bypass yes --account $account3
     #json .error_code OK .command accountModify
 
-    success account3access a3_can_access_the_bastion $a3 --osh info
+    success a3_can_access_the_bastion $a3 --osh info
     contain "Your alias to connect"
     json .command info .error_code OK .value.account $account3
 
@@ -83,22 +83,22 @@ testsuite_groups()
 
     grant groupCreate
 
-    run groupCreate a2_fail_to_create_g1_with_a1_as_owner_because_not_granted $a2 --osh groupCreate --group $group1 --algo rsa --size 2048 --owner $account1
+    run a2_fail_to_create_g1_with_a1_as_owner_because_not_granted $a2 --osh groupCreate --group $group1 --algo rsa --size 2048 --owner $account1
     retvalshouldbe 106
     contain "you to be specifically granted"
     json .command   null .value      null .error_code KO_RESTRICTED_COMMAND
 
-    plgfail groupCreate a0_fail_to_create_g1_with_a1_as_owner_because_bad_key_size $a0 --osh groupCreate --group $group1 --algo rsa --size 1024 --owner $account1
+    plgfail a0_fail_to_create_g1_with_a1_as_owner_because_bad_key_size $a0 --osh groupCreate --group $group1 --algo rsa --size 1024 --owner $account1
     contain "minimum configured key size"
     json .command groupCreate .error_code KO_KEY_SIZE_TOO_SMALL .value      null
 
-    plgfail groupCreate a0_fail_create_group_reserved_1 $a0 --osh groupCreate --group key --no-key --owner $account1
+    plgfail a0_fail_create_group_reserved_1 $a0 --osh groupCreate --group key --no-key --owner $account1
     json .command groupCreate .error_code ERR_INVALID_PARAMETER
 
-    plgfail groupCreate a0_fail_create_group_reserved_2 $a0 --osh groupCreate --group keytothegate --no-key --owner $account1
+    plgfail a0_fail_create_group_reserved_2 $a0 --osh groupCreate --group keytothegate --no-key --owner $account1
     json .command groupCreate .error_code ERR_INVALID_PARAMETER
 
-    success groupCreate a0_create_g1_with_a1_as_owner $a0 --osh groupCreate --group $group1 --algo rsa --size 4096 --owner $account1
+    success a0_create_g1_with_a1_as_owner $a0 --osh groupCreate --group $group1 --algo rsa --size 4096 --owner $account1
     contain "The public key of this group is"
     json $(cat <<EOS
     .command groupCreate
@@ -111,67 +111,67 @@ EOS
     # new state: g1[a1(ow,gk,acl,member)]
 
     # create g3 with a3 as owner to test key generation of a group a3 is not an owner of, without getting the early no-owner deny
-    success 350-groups a0_create_g3_with_a3_as_owner $a0 --osh groupCreate --group $group3 --algo ed25519 --owner $account3
+    success a0_create_g3_with_a3_as_owner $a0 --osh groupCreate --group $group3 --algo ed25519 --owner $account3
 
     # test egress key generation as an owner
-    run 350-groups a0_generate_key_g1_fail $a0 --osh groupGenerateEgressKey --group $group1 --algo ed25519
+    run a0_generate_key_g1_fail $a0 --osh groupGenerateEgressKey --group $group1 --algo ed25519
     retvalshouldbe 106
     json .command null .error_code KO_RESTRICTED_COMMAND .value null
 
-    plgfail 350-groups a3_generate_key_help $a3 --osh groupGenerateEgressKey
+    plgfail a3_generate_key_help $a3 --osh groupGenerateEgressKey
     json .command groupGenerateEgressKey .error_code ERR_MISSING_PARAMETER
 
-    plgfail 350-groups a3_generate_key_g1_fail $a3 --osh groupGenerateEgressKey --group $group1 --algo ed25519
+    plgfail a3_generate_key_g1_fail $a3 --osh groupGenerateEgressKey --group $group1 --algo ed25519
     json .command groupGenerateEgressKey .error_code ERR_NOT_GROUP_OWNER
 
-    success 350-groups a1_generate_key_g1 $a1 --osh groupGenerateEgressKey --group $group1 --algo ed25519
+    success a1_generate_key_g1 $a1 --osh groupGenerateEgressKey --group $group1 --algo ed25519
     json .command groupGenerateEgressKey .error_code OK .value.typecode ssh-ed25519
     local key1id
     local key1fp
     key1id=$(get_json | $jq .value.id)
     key1fp=$(get_json | $jq .value.fingerprint)
 
-    success 350-groups a0_list_group_keys_g1 $a0 --osh groupInfo --group $group1
+    success a0_list_group_keys_g1 $a0 --osh groupInfo --group $group1
     json .command groupInfo .error_code OK ".value.keys.\"$key1fp\".typecode" ssh-ed25519
 
-    run 350-groups a0_del_key_g1 $a0 --osh groupDelEgressKey --group $group1 --id $key1id
+    run a0_del_key_g1 $a0 --osh groupDelEgressKey --group $group1 --id $key1id
     retvalshouldbe 106
     json .command null .error_code KO_RESTRICTED_COMMAND .value null
 
-    plgfail 350-groups a3_del_key_g1 $a3 --osh groupDelEgressKey --group $group1 --id $key1id
+    plgfail a3_del_key_g1 $a3 --osh groupDelEgressKey --group $group1 --id $key1id
     json .command groupDelEgressKey .error_code ERR_NOT_GROUP_OWNER
 
-    success 350-groups a1_del_key_g1 $a1 --osh groupDelEgressKey --group $group1 --id $key1id
+    success a1_del_key_g1 $a1 --osh groupDelEgressKey --group $group1 --id $key1id
     json .command groupDelEgressKey .error_code OK .value.id "$key1id" .value.fingerprint "$key1fp"
     unset key1id
     unset key1fp
 
     grant groupDelete
-    script 350-groups a0_delete_g3 $a0 --osh groupDelete --group $group3 '<<<' "$group3"
+    script a0_delete_g3 $a0 --osh groupDelete --group $group3 '<<<' "$group3"
     retvalshouldbe 0
     revoke groupDelete
     # /egress key generation
 
     # now test all group-* commands from a2 to grant a3 on g1 => should get an early deny
 
-    run groupAddOwner a2_fail_to_addowner_a3_on_g1_early_deny_owner_cmd $a2 --osh groupAddOwner --group $group1 --account $account3
+    run a2_fail_to_addowner_a3_on_g1_early_deny_owner_cmd $a2 --osh groupAddOwner --group $group1 --account $account3
     retvalshouldbe 106
     contain "owner"
     json .command    null .value      null .error_code KO_RESTRICTED_COMMAND
 
-    run groupAddMember a2_fail_to_addmember_a3_on_g1_early_deny_gatekeeper_cmd $a2 --osh groupAddMember --group $group1 --account $account3
+    run a2_fail_to_addmember_a3_on_g1_early_deny_gatekeeper_cmd $a2 --osh groupAddMember --group $group1 --account $account3
     retvalshouldbe 106
     contain "gatekeeper"
     json .command    null .value      null .error_code KO_RESTRICTED_COMMAND
 
-    run groupAddOwner a2_fail_to_addserver_on_g1_early_deny_aclkeeper_cmd $a2 --osh groupAddServer --group $group1 --host 1.2.3.4 --port 1234 --user nobody
+    run a2_fail_to_addserver_on_g1_early_deny_aclkeeper_cmd $a2 --osh groupAddServer --group $group1 --host 1.2.3.4 --port 1234 --user nobody
     retvalshouldbe 106
     contain "aclkeeper"
     json .command    null .value      null .error_code KO_RESTRICTED_COMMAND
 
     # a0: create g3 and set a0, a2 and a3 as owner/gatekeeper/aclkeeper to rule out early denies for next tests
     # >>>BEGIN
-    success groupCreate a0_create_g3_with_a0_as_owner $a0 --osh groupCreate --group $group3 --algo ecdsa --size 256 --owner $account0
+    success a0_create_g3_with_a0_as_owner $a0 --osh groupCreate --group $group3 --algo ecdsa --size 256 --owner $account0
     json .error_code OK .command groupCreate .value.group $group3 .value.owner $account0
     json .value.public_key.family ECDSA .value.public_key.typecode ecdsa-sha2-nistp256 .value.public_key.size 256
     #g3_pubkey=$(get_json | $jq .value.public_key.line)
@@ -179,7 +179,7 @@ EOS
 
     revoke groupCreate
 
-    success groupInfo   a0_info_on_g3_after_create $a0 --osh groupInfo --group $group3
+    success   a0_info_on_g3_after_create $a0 --osh groupInfo --group $group3
     json .error_code OK .command groupInfo .value.group $group3
     json --arg want "$account0" '.value.owners|sort      == ($want|split(" ")|sort)' true
     json --arg want "$account0" '.value.gatekeepers|sort == ($want|split(" ")|sort)' true
@@ -191,13 +191,13 @@ EOS
     # ... we always try to remove a3 and fail, then add it, then add it again and fail, then remove it, then remove it and fail, then add it back
 
     # ...... for owner
-    success groupDelOwner      a0_del_a3_as_g3_owner_no_change      $a0 --osh groupDelOwner      --group $group3 --account $account3
+    success      a0_del_a3_as_g3_owner_no_change      $a0 --osh groupDelOwner      --group $group3 --account $account3
     json .error_code OK_NO_CHANGE .command groupDelOwner .value null
 
-    success groupAddOwner      a0_add_a3_as_g3_owner      $a0 --osh groupAddOwner      --group $group3 --account $account3
+    success      a0_add_a3_as_g3_owner      $a0 --osh groupAddOwner      --group $group3 --account $account3
     json .error_code OK           .command groupAddOwner .value null
 
-    success groupInfo          a0_info_on_g3_after_owneradd    $a0 --osh groupInfo --group $group3
+    success          a0_info_on_g3_after_owneradd    $a0 --osh groupInfo --group $group3
     json .error_code OK           .command groupInfo     .value.group $group3
     json --arg want "$account0 $account3" '.value.owners|sort      == ($want|split(" ")|sort)' true
     json --arg want "$account0"           '.value.gatekeepers|sort == ($want|split(" ")|sort)' true
@@ -205,13 +205,13 @@ EOS
     json --arg want "$account0"           '.value.members|sort     == ($want|split(" ")|sort)' true
     json .value.guests '[]'
 
-    success groupAddOwner      a0_add_a3_as_g3_owner_no_change      $a0 --osh groupAddOwner      --group $group3 --account $account3
+    success      a0_add_a3_as_g3_owner_no_change      $a0 --osh groupAddOwner      --group $group3 --account $account3
     json .error_code OK_NO_CHANGE .command groupAddOwner .value null
 
-    success groupDelOwner      a0_del_a3_as_g3_owner      $a0 --osh groupDelOwner      --group $group3 --account $account3
+    success      a0_del_a3_as_g3_owner      $a0 --osh groupDelOwner      --group $group3 --account $account3
     json .error_code OK .command groupDelOwner .value null
 
-    success groupInfo   a0_info_on_g3_after_ownerdel $a0 --osh groupInfo --group $group3
+    success   a0_info_on_g3_after_ownerdel $a0 --osh groupInfo --group $group3
     json .error_code OK .command groupInfo .value.group $group3
     json --arg want "$account0" '.value.owners|sort      == ($want|split(" ")|sort)' true
     json --arg want "$account0" '.value.gatekeepers|sort == ($want|split(" ")|sort)' true
@@ -219,10 +219,10 @@ EOS
     json --arg want "$account0" '.value.members|sort     == ($want|split(" ")|sort)' true
     json .value.guests '[]'
 
-    success groupAddOwner      a0_add_a3_as_g3_owner      $a0 --osh groupAddOwner      --group $group3 --account $account3
+    success      a0_add_a3_as_g3_owner      $a0 --osh groupAddOwner      --group $group3 --account $account3
     json .error_code OK           .command groupAddOwner .value null
 
-    success groupInfo          a0_info_on_g3_after_owneradd2   $a0 --osh groupInfo --group $group3
+    success          a0_info_on_g3_after_owneradd2   $a0 --osh groupInfo --group $group3
     json .error_code OK           .command groupInfo     .value.group $group3
     json --arg want "$account0 $account3" '.value.owners|sort      == ($want|split(" ")|sort)' true
     json --arg want "$account0"           '.value.gatekeepers|sort == ($want|split(" ")|sort)' true
@@ -231,13 +231,13 @@ EOS
     json .value.guests '[]'
 
     # ...... for gatekeeper
-    success groupDelGatekeeper      a0_del_a3_as_g3_gatekeeper_no_change      $a0 --osh groupDelGatekeeper      --group $group3 --account $account3
+    success      a0_del_a3_as_g3_gatekeeper_no_change      $a0 --osh groupDelGatekeeper      --group $group3 --account $account3
     json .error_code OK_NO_CHANGE .command groupDelGatekeeper .value null
 
-    success groupAddGatekeeper      a0_add_a3_as_g3_gatekeeper      $a0 --osh groupAddGatekeeper      --group $group3 --account $account3
+    success      a0_add_a3_as_g3_gatekeeper      $a0 --osh groupAddGatekeeper      --group $group3 --account $account3
     json .error_code OK           .command groupAddGatekeeper .value null
 
-    success groupInfo          a0_info_on_g3_after_gatekeeperadd    $a0 --osh groupInfo --group $group3
+    success          a0_info_on_g3_after_gatekeeperadd    $a0 --osh groupInfo --group $group3
     json .error_code OK           .command groupInfo     .value.group $group3
     json --arg want "$account0 $account3" '.value.owners|sort      == ($want|split(" ")|sort)' true
     json --arg want "$account0 $account3" '.value.gatekeepers|sort == ($want|split(" ")|sort)' true
@@ -245,13 +245,13 @@ EOS
     json --arg want "$account0"           '.value.members|sort     == ($want|split(" ")|sort)' true
     json .value.guests '[]'
 
-    success groupAddGatekeeper      a0_add_a3_as_g3_gatekeeper_no_change      $a0 --osh groupAddGatekeeper      --group $group3 --account $account3
+    success      a0_add_a3_as_g3_gatekeeper_no_change      $a0 --osh groupAddGatekeeper      --group $group3 --account $account3
     json .error_code OK_NO_CHANGE .command groupAddGatekeeper .value null
 
-    success groupDelGatekeeper      a0_del_a3_as_g3_gatekeeper      $a0 --osh groupDelGatekeeper      --group $group3 --account $account3
+    success      a0_del_a3_as_g3_gatekeeper      $a0 --osh groupDelGatekeeper      --group $group3 --account $account3
     json .error_code OK .command groupDelGatekeeper .value null
 
-    success groupInfo   a0_info_on_g3_after_gatekeeperdel $a0 --osh groupInfo --group $group3
+    success   a0_info_on_g3_after_gatekeeperdel $a0 --osh groupInfo --group $group3
     json .error_code OK .command groupInfo .value.group $group3
     json --arg want "$account0 $account3" '.value.owners|sort      == ($want|split(" ")|sort)' true
     json --arg want "$account0"           '.value.gatekeepers|sort == ($want|split(" ")|sort)' true
@@ -259,10 +259,10 @@ EOS
     json --arg want "$account0"           '.value.members|sort     == ($want|split(" ")|sort)' true
     json .value.guests '[]'
 
-    success groupAddGatekeeper      a0_add_a3_as_g3_gatekeeper      $a0 --osh groupAddGatekeeper      --group $group3 --account $account3
+    success      a0_add_a3_as_g3_gatekeeper      $a0 --osh groupAddGatekeeper      --group $group3 --account $account3
     json .error_code OK           .command groupAddGatekeeper .value null
 
-    success groupInfo          a0_info_on_g3_after_gatekeeperadd2   $a0 --osh groupInfo --group $group3
+    success          a0_info_on_g3_after_gatekeeperadd2   $a0 --osh groupInfo --group $group3
     json .error_code OK           .command groupInfo     .value.group $group3
     json --arg want "$account0 $account3" '.value.owners|sort      == ($want|split(" ")|sort)' true
     json --arg want "$account0 $account3" '.value.gatekeepers|sort == ($want|split(" ")|sort)' true
@@ -271,27 +271,27 @@ EOS
     json .value.guests '[]'
 
     # ...... for aclkeeper
-    success groupDelAclkeeper      a0_del_a3_as_g3_aclkeeper_no_change      $a0 --osh groupDelAclkeeper      --group $group3 --account $account3
+    success      a0_del_a3_as_g3_aclkeeper_no_change      $a0 --osh groupDelAclkeeper      --group $group3 --account $account3
     json .error_code OK_NO_CHANGE .command groupDelAclkeeper .value null
 
-    success groupAddAclkeeper      a0_add_a3_as_g3_aclkeeper      $a0 --osh groupAddAclkeeper      --group $group3 --account $account3
+    success      a0_add_a3_as_g3_aclkeeper      $a0 --osh groupAddAclkeeper      --group $group3 --account $account3
     json .error_code OK           .command groupAddAclkeeper .value null
 
     #success postreq a0_g3_removembr  $a0 --osh groupDelMember --group $group3 --account $account0
-    success postreq a0_g3_removeaclk $a0 --osh groupDelAclkeeper --group $group3 --account $account0
-    success postreq a0_g3_removegk   $a0 --osh groupDelGatekeeper --group $group3 --account $account0
+    success a0_g3_removeaclk $a0 --osh groupDelAclkeeper --group $group3 --account $account0
+    success a0_g3_removegk   $a0 --osh groupDelGatekeeper --group $group3 --account $account0
 
     # START egress passwords
 
     # ... for groups
 
-    success groupGeneratePassword works1 $a0 --osh groupGeneratePassword --group $group3 --size 17 --do-it
+    success works1 $a0 --osh groupGeneratePassword --group $group3 --size 17 --do-it
     json .command groupGeneratePassword .error_code OK .value.group $group3
     md5a=$(get_json | $jq '.value.hashes.md5crypt')
     sha256a=$(get_json | $jq '.value.hashes.sha256crypt')
     sha512a=$(get_json | $jq '.value.hashes.sha512crypt')
 
-    success groupListPasswords works $a0 --osh groupListPasswords --group $group3
+    success works $a0 --osh groupListPasswords --group $group3
     json $(cat <<EOS
     .command groupListPasswords
     .error_code OK
@@ -303,13 +303,13 @@ EOS
 EOS
     )
 
-    success groupGeneratePassword works2 $a0 --osh groupGeneratePassword --group $group3 --size 17 --do-it
+    success works2 $a0 --osh groupGeneratePassword --group $group3 --size 17 --do-it
     json .command groupGeneratePassword .error_code OK .value.group $group3
     md5b=$(get_json | $jq '.value.hashes.md5crypt')
     sha256b=$(get_json | $jq '.value.hashes.sha256crypt')
     sha512b=$(get_json | $jq '.value.hashes.sha512crypt')
 
-    success groupListPasswords works $a0 --osh groupListPasswords --group $group3
+    success works $a0 --osh groupListPasswords --group $group3
     json $(cat <<EOS
     .command groupListPasswords
     .error_code OK
@@ -330,7 +330,7 @@ EOS
 
     grant accountGeneratePassword
 
-    success accountGeneratePassword works1 $a0 --osh accountGeneratePassword --account $account1 --do-it
+    success works1 $a0 --osh accountGeneratePassword --account $account1 --do-it
     json .command accountGeneratePassword .error_code OK .value.account $account1
     md5a=$(get_json | $jq '.value.hashes.md5crypt')
     sha256a=$(get_json | $jq '.value.hashes.sha256crypt')
@@ -339,7 +339,7 @@ EOS
     revoke accountGeneratePassword
     grant accountListPasswords
 
-    success accountListPasswords works $a0 --osh accountListPasswords --account $account1
+    success works $a0 --osh accountListPasswords --account $account1
     json $(cat <<EOS
     .command accountListPasswords
     .error_code OK
@@ -353,13 +353,13 @@ EOS
 
     revoke accountListPasswords
 
-    success selfGeneratePassword works2 $a1 --osh selfGeneratePassword --do-it
+    success works2 $a1 --osh selfGeneratePassword --do-it
     json .command selfGeneratePassword .error_code OK
     md5b=$(get_json | $jq '.value.hashes.md5crypt')
     sha256b=$(get_json | $jq '.value.hashes.sha256crypt')
     sha512b=$(get_json | $jq '.value.hashes.sha512crypt')
 
-    success selfListPasswords works $a1 --osh selfListPasswords
+    success works $a1 --osh selfListPasswords
     json $(cat <<EOS
     .command selfListPasswords
     .error_code OK
@@ -380,7 +380,7 @@ EOS
 
     # END egress passwords
 
-    success groupInfo          a0_info_on_g3_after_aclkeeperadd    $a0 --osh groupInfo --group $group3
+    success          a0_info_on_g3_after_aclkeeperadd    $a0 --osh groupInfo --group $group3
     json .error_code OK           .command groupInfo     .value.group $group3
     json --argjson want "[\"$account0\",\"$account3\"]" '.value.owners|sort      == ($want|sort)' true
     json --argjson want "[              \"$account3\"]" '.value.gatekeepers|sort == ($want|sort)' true
@@ -388,13 +388,13 @@ EOS
     json --argjson want "[\"$account0\"]"               '.value.members|sort     == ($want|sort)' true
     json --argjson want "[]"                            '.value.guests|sort      == ($want|sort)' true
 
-    success groupAddAclkeeper      a0_add_a3_as_g3_aclkeeper_no_change      $a0 --osh groupAddAclkeeper      --group $group3 --account $account3
+    success      a0_add_a3_as_g3_aclkeeper_no_change      $a0 --osh groupAddAclkeeper      --group $group3 --account $account3
     json .error_code OK_NO_CHANGE .command groupAddAclkeeper .value null
 
-    success groupDelAclkeeper      a0_del_a3_as_g3_aclkeeper      $a0 --osh groupDelAclkeeper      --group $group3 --account $account3
+    success      a0_del_a3_as_g3_aclkeeper      $a0 --osh groupDelAclkeeper      --group $group3 --account $account3
     json .error_code OK .command groupDelAclkeeper .value null
 
-    success groupInfo   a0_info_on_g3_after_aclkeeperdel $a0 --osh groupInfo --group $group3
+    success   a0_info_on_g3_after_aclkeeperdel $a0 --osh groupInfo --group $group3
     json .error_code OK .command groupInfo .value.group $group3
     json --argjson want "[\"$account0\",\"$account3\"]" '.value.owners|sort      == ($want|sort)' true
     json --argjson want "[              \"$account3\"]" '.value.gatekeepers|sort == ($want|sort)' true
@@ -402,10 +402,10 @@ EOS
     json --argjson want "[\"$account0\"]"               '.value.members|sort     == ($want|sort)' true
     json --argjson want "[]"                            '.value.guests|sort      == ($want|sort)' true
 
-    success groupAddAclkeeper      a0_add_a3_as_g3_aclkeeper      $a0 --osh groupAddAclkeeper      --group $group3 --account $account3
+    success      a0_add_a3_as_g3_aclkeeper      $a0 --osh groupAddAclkeeper      --group $group3 --account $account3
     json .error_code OK           .command groupAddAclkeeper .value null
 
-    success groupInfo          a0_info_on_g3_after_aclkeeperadd2   $a0 --osh groupInfo --group $group3
+    success          a0_info_on_g3_after_aclkeeperadd2   $a0 --osh groupInfo --group $group3
     json .error_code OK           .command groupInfo     .value.group $group3
     json --argjson want "[\"$account0\",\"$account3\"]" '.value.owners|sort      == ($want|sort)' true
     json --argjson want "[              \"$account3\"]" '.value.gatekeepers|sort == ($want|sort)' true
@@ -414,13 +414,13 @@ EOS
     json --argjson want "[]"                            '.value.guests|sort      == ($want|sort)' true
 
     # ...... for member
-    success groupDelMember      a3_del_a3_as_g3_member_no_change      $a3 --osh groupDelMember      --group $group3 --account $account3
+    success      a3_del_a3_as_g3_member_no_change      $a3 --osh groupDelMember      --group $group3 --account $account3
     json .error_code OK_NO_CHANGE .command groupDelMember .value null
 
-    success groupAddMember      a3_add_a3_as_g3_member      $a3 --osh groupAddMember      --group $group3 --account $account3
+    success      a3_add_a3_as_g3_member      $a3 --osh groupAddMember      --group $group3 --account $account3
     json .error_code OK           .command groupAddMember .value null
 
-    success groupInfo          a0_info_on_g3_after_memberadd    $a0 --osh groupInfo --group $group3
+    success          a0_info_on_g3_after_memberadd    $a0 --osh groupInfo --group $group3
     json .error_code OK           .command groupInfo     .value.group $group3
     json --argjson want "[\"$account0\",\"$account3\"]" '.value.owners|sort      == ($want|sort)' true
     json --argjson want "[              \"$account3\"]" '.value.gatekeepers|sort == ($want|sort)' true
@@ -428,13 +428,13 @@ EOS
     json --argjson want "[\"$account0\",\"$account3\"]" '.value.members|sort     == ($want|sort)' true
     json --argjson want "[]"                            '.value.guests|sort      == ($want|sort)' true
 
-    success groupAddMember      a3_add_a3_as_g3_member_no_change      $a3 --osh groupAddMember      --group $group3 --account $account3
+    success      a3_add_a3_as_g3_member_no_change      $a3 --osh groupAddMember      --group $group3 --account $account3
     json .error_code OK_NO_CHANGE .command groupAddMember .value null
 
-    success groupDelMember      a3_del_a3_as_g3_member      $a3 --osh groupDelMember      --group $group3 --account $account3
+    success      a3_del_a3_as_g3_member      $a3 --osh groupDelMember      --group $group3 --account $account3
     json .error_code OK .command groupDelMember .value null
 
-    success groupInfo   a0_info_on_g3_after_memberdel $a0 --osh groupInfo --group $group3
+    success   a0_info_on_g3_after_memberdel $a0 --osh groupInfo --group $group3
     json .error_code OK .command groupInfo .value.group $group3
     json --argjson want "[\"$account0\",\"$account3\"]" '.value.owners|sort      == ($want|sort)' true
     json --argjson want "[              \"$account3\"]" '.value.gatekeepers|sort == ($want|sort)' true
@@ -442,10 +442,10 @@ EOS
     json --argjson want "[\"$account0\"]"               '.value.members|sort     == ($want|sort)' true
     json --argjson want "[]"                            '.value.guests|sort      == ($want|sort)' true
 
-    success groupAddMember      a3_add_a3_as_g3_member      $a3 --osh groupAddMember      --group $group3 --account $account3
+    success      a3_add_a3_as_g3_member      $a3 --osh groupAddMember      --group $group3 --account $account3
     json .error_code OK           .command groupAddMember .value null
 
-    success groupInfo          a0_info_on_g3_after_memberadd2   $a0 --osh groupInfo --group $group3
+    success          a0_info_on_g3_after_memberadd2   $a0 --osh groupInfo --group $group3
     json .error_code OK           .command groupInfo     .value.group $group3
     json --argjson want "[\"$account0\",\"$account3\"]" '.value.owners|sort      == ($want|sort)' true
     json --argjson want "[              \"$account3\"]" '.value.gatekeepers|sort == ($want|sort)' true
@@ -455,14 +455,14 @@ EOS
 
     # ...... ok now resume to just adding a2 to avoid early denies as stated above
 
-    success groupAddOwner      a3_add_a2_as_g3_owner           $a3 --osh groupAddOwner      --group $group3 --account $account2
-    success groupAddGatekeeper a2_add_himself_as_g3_gatekeeper $a2 --osh groupAddGatekeeper --group $group3 --account $account2
-    success groupAddAclkeeper  a2_add_himself_as_g3_aclkeeper  $a2 --osh groupAddAclkeeper  --group $group3 --account $account2
+    success      a3_add_a2_as_g3_owner           $a3 --osh groupAddOwner      --group $group3 --account $account2
+    success a2_add_himself_as_g3_gatekeeper $a2 --osh groupAddGatekeeper --group $group3 --account $account2
+    success  a2_add_himself_as_g3_aclkeeper  $a2 --osh groupAddAclkeeper  --group $group3 --account $account2
 
     # new state: g1[a1(ow,gk,acl,member)] g3[a0,a2,a3(ow,gk,acl,member)]
     # check with groupInfo that the data is correct
 
-    success groupInfo          a0_info_on_g3_after_a2_add   $a0 --osh groupInfo --group $group3
+    success          a0_info_on_g3_after_a2_add   $a0 --osh groupInfo --group $group3
     json .error_code OK           .command groupInfo     .value.group $group3
     json --argjson want "[\"$account0\",\"$account3\",\"$account2\"]" '.value.owners|sort      == ($want|sort)' true
     json --argjson want "[              \"$account3\",\"$account2\"]" '.value.gatekeepers|sort == ($want|sort)' true
@@ -472,119 +472,119 @@ EOS
 
     # now come gatekeeper tests, first check that a2 can't do anything privileged on g1
 
-    plgfail groupAddOwner       a2_fail_add_a3_as_g1_owner      $a2 --osh groupAddOwner        --group $group1 --account $account3
+    plgfail       a2_fail_add_a3_as_g1_owner      $a2 --osh groupAddOwner        --group $group1 --account $account3
     json .command groupAddOwner .error_code ERR_NOT_GROUP_OWNER .value null
 
-    plgfail groupAddGatekeeper  a2_fail_add_a3_as_g1_gatekeeper $a2 --osh groupAddGatekeeper   --group $group1 --account $account3
+    plgfail  a2_fail_add_a3_as_g1_gatekeeper $a2 --osh groupAddGatekeeper   --group $group1 --account $account3
     json .command groupAddGatekeeper .error_code ERR_NOT_GROUP_OWNER .value null
 
-    plgfail groupAddAclkeeper  a2_fail_add_a3_as_g1_aclkeeper $a2 --osh groupAddAclkeeper      --group $group1 --account $account3
+    plgfail  a2_fail_add_a3_as_g1_aclkeeper $a2 --osh groupAddAclkeeper      --group $group1 --account $account3
     json .command groupAddAclkeeper .error_code ERR_NOT_GROUP_OWNER .value null
 
-    plgfail groupAddMember      a2_fail_add_a3_as_g1_member     $a2 --osh groupAddMember       --group $group1 --account $account3
+    plgfail      a2_fail_add_a3_as_g1_member     $a2 --osh groupAddMember       --group $group1 --account $account3
     json .command groupAddMember .error_code ERR_NOT_GROUP_GATEKEEPER .value null
 
-    plgfail groupAddGuestAccess a2_fail_add_a3_as_g1_guest      $a2 --osh groupAddGuestAccess  --group $group1 --account $account3 --host 1.2.3.7 --port 15487 --user username
+    plgfail a2_fail_add_a3_as_g1_guest      $a2 --osh groupAddGuestAccess  --group $group1 --account $account3 --host 1.2.3.7 --port 15487 --user username
     json .command groupAddGuestAccess .error_code ERR_NOT_GROUP_GATEKEEPER .value null
 
-    plgfail groupAddServer      a2_fail_add_server_to_g1        $a2 --osh groupAddServer       --group $group1 --host 1.2.3.7 --port 15487 --user username
+    plgfail      a2_fail_add_server_to_g1        $a2 --osh groupAddServer       --group $group1 --host 1.2.3.7 --port 15487 --user username
     json .command groupAddServer .error_code ERR_NOT_GROUP_ACLKEEPER .value null
 
     # ... then grant a2 as g1 aclkeeper
 
-    success groupAddAclkeeper a1_add_a2_as_g1_aclkeeper $a1 --osh groupAddAclkeeper --group $group1 --account $account2
+    success a1_add_a2_as_g1_aclkeeper $a1 --osh groupAddAclkeeper --group $group1 --account $account2
     json .command groupAddAclkeeper .error_code OK .value null
 
     # new state: g1[a1(ow,gk,acl,member) a2(acl)] g3[a0,a2,a3(ow,gk,acl,member)]
 
     # then check that owner/gatekeeper commands still don't work
 
-    plgfail groupAddOwner       a2_fail_add_a3_as_g1_owner      $a2 --osh groupAddOwner        --group $group1 --account $account3
+    plgfail       a2_fail_add_a3_as_g1_owner      $a2 --osh groupAddOwner        --group $group1 --account $account3
     json .command groupAddOwner .error_code ERR_NOT_GROUP_OWNER .value null
 
-    plgfail groupAddGatekeeper  a2_fail_add_a3_as_g1_gatekeeper $a2 --osh groupAddGatekeeper   --group $group1 --account $account3
+    plgfail  a2_fail_add_a3_as_g1_gatekeeper $a2 --osh groupAddGatekeeper   --group $group1 --account $account3
     json .command groupAddGatekeeper .error_code ERR_NOT_GROUP_OWNER .value null
 
-    plgfail groupAddAclkeeper   a2_fail_add_a3_as_g1_aclkeeper  $a2 --osh groupAddAclkeeper    --group $group1 --account $account3
+    plgfail   a2_fail_add_a3_as_g1_aclkeeper  $a2 --osh groupAddAclkeeper    --group $group1 --account $account3
     json .command groupAddAclkeeper .error_code ERR_NOT_GROUP_OWNER .value null
 
-    plgfail groupAddMember      a2_fail_add_a3_as_g1_member     $a2 --osh groupAddMember       --group $group1 --account $account3
+    plgfail      a2_fail_add_a3_as_g1_member     $a2 --osh groupAddMember       --group $group1 --account $account3
     json .command groupAddMember .error_code ERR_NOT_GROUP_GATEKEEPER .value null
 
-    plgfail groupAddGuestAccess a2_fail_add_a3_as_g1_guest      $a2 --osh groupAddGuestAccess  --group $group1 --account $account3 --host 1.2.3.7 --port 15487 --user username
+    plgfail a2_fail_add_a3_as_g1_guest      $a2 --osh groupAddGuestAccess  --group $group1 --account $account3 --host 1.2.3.7 --port 15487 --user username
     json .command groupAddGuestAccess .error_code ERR_NOT_GROUP_GATEKEEPER .value null
 
     # and see that aclkeeper command now works from a2 on g1
     # TODO test elsewhere the syntax/good functioning of those commands with all combinations of parameters allowed. here we test the RIGHTS.
 
-    success groupAddServer a2_add_server_to_g1_works $a2 --osh groupAddServer --group $group1 --host 127.0.0.1 --port 22 --user g1
+    success a2_add_server_to_g1_works $a2 --osh groupAddServer --group $group1 --host 127.0.0.1 --port 22 --user g1
     json .command groupAddServer .error_code OK .value.ip 127.0.0.1 .value.group $group1 .value.port 22 .value.user g1
     contain "have access to yourself"
 
-    success groupAddServer a2_add_server_to_g1_force_but_dup               $a2 --osh groupAddServer --group $group1 --host 127.0.0.1 --port 22 --user g1 --force
+    success a2_add_server_to_g1_force_but_dup               $a2 --osh groupAddServer --group $group1 --host 127.0.0.1 --port 22 --user g1 --force
     json .command groupAddServer .error_code OK_NO_CHANGE .value null
 
-    success groupAddServer a2_add_server_to_g1               $a2 --osh groupAddServer --group $group1 --host 127.0.0.2 --port 22 --user g2 --force --comment '"\"this is a comment\""'
+    success a2_add_server_to_g1               $a2 --osh groupAddServer --group $group1 --host 127.0.0.2 --port 22 --user g2 --force --comment '"\"this is a comment\""'
     json .command groupAddServer .error_code OK .value.ip 127.0.0.2 .value.group $group1 .value.user g2 .value.comment "this is a comment"
 
     # new state: g1[a1(ow,gk,acl,member) a2(acl) acl(g1@127.0.0.1:22,g2@127.0.0.2:22)] g3[a0,a2,a3(ow,gk,acl,member)]
 
     # ... then grant a2 as g1 gatekeeper and remove it as aclkeeper
 
-    success groupAddGatekeeper a1_add_a2_as_g1_gatekeeper $a1 --osh groupAddGatekeeper --group $group1 --account $account2
+    success a1_add_a2_as_g1_gatekeeper $a1 --osh groupAddGatekeeper --group $group1 --account $account2
     json .command groupAddGatekeeper .error_code OK .value null
 
-    success groupDelAclkeeper  a1_del_a2_as_g1_aclkeeper  $a1 --osh groupDelAclkeeper  --group $group1 --account $account2
+    success  a1_del_a2_as_g1_aclkeeper  $a1 --osh groupDelAclkeeper  --group $group1 --account $account2
     json .command groupDelAclkeeper .error_code OK .value null
 
     # new state: g1[a1(ow,gk,acl,member) a2(gk) acl(g1@127.0.0.1:22,g2@127.0.0.2:22)] g3[a0,a2,a3(ow,gk,acl,member)]
 
     # then check that owner/aclkeeper commands still don't work
 
-    plgfail groupAddOwner       a2_fail_add_a3_as_g1_owner      $a2 --osh groupAddOwner        --group $group1 --account $account3
+    plgfail       a2_fail_add_a3_as_g1_owner      $a2 --osh groupAddOwner        --group $group1 --account $account3
     json .command groupAddOwner .error_code ERR_NOT_GROUP_OWNER .value null
 
-    plgfail groupAddGatekeeper  a2_fail_add_a3_as_g1_gatekeeper $a2 --osh groupAddGatekeeper   --group $group1 --account $account3
+    plgfail  a2_fail_add_a3_as_g1_gatekeeper $a2 --osh groupAddGatekeeper   --group $group1 --account $account3
     json .command groupAddGatekeeper .error_code ERR_NOT_GROUP_OWNER .value null
 
-    plgfail groupAddAclkeeper   a2_fail_add_a3_as_g1_aclkeeper  $a2 --osh groupAddAclkeeper    --group $group1 --account $account3
+    plgfail   a2_fail_add_a3_as_g1_aclkeeper  $a2 --osh groupAddAclkeeper    --group $group1 --account $account3
     json .command groupAddAclkeeper .error_code ERR_NOT_GROUP_OWNER .value null
 
-    plgfail groupAddServer      a2_fail_add_server_to_g1        $a2 --osh groupAddServer       --group $group1 --host 1.2.3.7 --port 15487 --user username
+    plgfail      a2_fail_add_server_to_g1        $a2 --osh groupAddServer       --group $group1 --host 1.2.3.7 --port 15487 --user username
     json .command groupAddServer .error_code ERR_NOT_GROUP_ACLKEEPER .value null
 
     # ... and now try working gatekeeper commands
 
-    run ssh a3_noaccess_not_a_member_of_g1 $a3 g1@127.0.0.1
+    run a3_noaccess_not_a_member_of_g1 $a3 g1@127.0.0.1
     retvalshouldbe 107
 
-    success groupAddMember a2_add_a3_as_g1_member $a2 --osh groupAddMember --group $group1 --account $account3
+    success a2_add_a3_as_g1_member $a2 --osh groupAddMember --group $group1 --account $account3
 
     # new state: g1[a1(ow,gk,acl,member) a2(gk) a3(member) acl(g1@127.0.0.1:22,g2@127.0.0.2:22)] g3[a0,a2,a3(ow,gk,acl,member)]
 
     # a3 is now a member of g1 so should be able to access the 2 added user@ip:port of g1
     # (err255 because the pubkey is not there, but we're only testing if the bastion code allows the connection)
 
-    run ssh a3_access_g1_as_member_a $a3 g1@127.0.0.1
+    run a3_access_g1_as_member_a $a3 g1@127.0.0.1
     retvalshouldbe 255
     contain "allowed ... log on"
     contain 'Permission denied (publickey'
 
-    run ssh a3_access_g1_as_member_b $a3 g2@127.0.0.2
+    run a3_access_g1_as_member_b $a3 g2@127.0.0.2
     retvalshouldbe 255
     contain "allowed ... log on"
     contain 'Permission denied (publickey'
 
     # ttyrec: take the opportunity to test selfListSessions/selfPlaySession as we just recorded a ttyrec
-    success ssh a3_selfListSessions $a3 --osh selfListSessions --host 127.0.0.2 --user g2 --type ssh
+    success a3_selfListSessions $a3 --osh selfListSessions --host 127.0.0.2 --user g2 --type ssh
     json .command selfListSessions .error_code OK .value[0].allowed 1
     local sessionid
     sessionid=$(get_json | $jq '.value[0].id')
 
-    plgfail ssh a3_selfPlaySession_nonexisting $a3 --osh selfPlaySession --id 123456
+    plgfail a3_selfPlaySession_nonexisting $a3 --osh selfPlaySession --id 123456
     json .command selfPlaySession .error_code ERR_NOT_FOUND
 
-    script ssh a3_selfPlaySession_existing $a3 --osh selfPlaySession --id $sessionid '< /dev/null'
+    script a3_selfPlaySession_existing $a3 --osh selfPlaySession --id $sessionid '< /dev/null'
     retvalshouldbe 0
     json .command selfPlaySession .error_code OK
     contain 'Total Recall'
@@ -592,96 +592,96 @@ EOS
     nocontain 'n/a'
     # /ttyrec
 
-    run ssh a3_access_g1_as_member_but_ip_not_in_group $a3 g1@127.0.0.3
+    run a3_access_g1_as_member_but_ip_not_in_group $a3 g1@127.0.0.3
     retvalshouldbe 107
     json .error_code KO_ACCESS_DENIED
 
     # try to add a3 as a guest of g1, should not work because already a member
-    plgfail groupAddGuestAccess a1_add_a3_guest_of_g1_fail_already_member $a1 --osh groupAddGuestAccess --group $group1 --account $account3 --user g2 --host 127.0.0.2 --port 22
+    plgfail a1_add_a3_guest_of_g1_fail_already_member $a1 --osh groupAddGuestAccess --group $group1 --account $account3 --user g2 --host 127.0.0.2 --port 22
     json .command groupAddGuestAccess .error_code ERR_MEMBER_CANNOT_BE_GUEST
 
     # now remove membership of a3
 
-    success groupDelMember a2_del_a3_as_g1_member $a2 --osh groupDelMember --group $group1 --account $account3
+    success a2_del_a3_as_g1_member $a2 --osh groupDelMember --group $group1 --account $account3
     json .command groupDelMember .error_code OK .value null
 
     # add a guest access to a3...
-    success groupAddGuestAccess a1_add_a3_guest_of_g1 $a1 --osh groupAddGuestAccess --group $group1 --account $account3 --user g2 --host 127.0.0.2 --port 22
+    success a1_add_a3_guest_of_g1 $a1 --osh groupAddGuestAccess --group $group1 --account $account3 --user g2 --host 127.0.0.2 --port 22
     json .command groupAddGuestAccess .error_code OK
 
     # ... then add it as member again: it should remove the guest access we've added just above...
-    success groupAddMember a1_add_a3_member_of_g1 $a1 --osh groupAddMember --group $group1 --account $account3
+    success a1_add_a3_member_of_g1 $a1 --osh groupAddMember --group $group1 --account $account3
     contain "Cleaning these guest accesses"
     json .command groupAddMember .error_code OK
 
     # ... then remove its membership
-    success groupDelMember a2_del_a3_as_g1_member_2 $a2 --osh groupDelMember --group $group1 --account $account3
+    success a2_del_a3_as_g1_member_2 $a2 --osh groupDelMember --group $group1 --account $account3
     json .command groupDelMember .error_code OK .value null
 
     # ... and verify there's no ghost guest access remaining
-    success groupListGuestAccesses a2_list_a3_guest_access_g1_empty $a2 --osh groupListGuestAccesses --group $group1 --account $account3
+    success a2_list_a3_guest_access_g1_empty $a2 --osh groupListGuestAccesses --group $group1 --account $account3
     json .command groupListGuestAccesses .error_code OK_EMPTY .value null
 
     # new state: g1[a1(ow,gk,acl,member) a2(gk) acl(g1@127.0.0.1:22,g2@127.0.0.2:22)] g3[a0,a2,a3(ow,gk,acl,member)]
 
     # check that a3 can no longer access the ips
-    run ssh a3_fail_access_g1_as_member_a $a3 g1@127.0.0.1
+    run a3_fail_access_g1_as_member_a $a3 g1@127.0.0.1
     retvalshouldbe 107
     json .error_code KO_ACCESS_DENIED
 
-    run ssh a3_fail_access_g1_as_member_b $a3 g2@127.0.0.2
+    run a3_fail_access_g1_as_member_b $a3 g2@127.0.0.2
     retvalshouldbe 107
     json .error_code KO_ACCESS_DENIED
 
     # and now we add a3 as guest of g1 with only access to 127.0.0.2 and not 127.0.0.1
 
-    plgfail groupAddGuestAccess a2_fail_add_a3_as_g1_guest_invalid_tuple $a2 --osh groupAddGuestAccess --group $group1 --account $account3 --host 1.2.3.7 --port 15487 --user username
+    plgfail a2_fail_add_a3_as_g1_guest_invalid_tuple $a2 --osh groupAddGuestAccess --group $group1 --account $account3 --host 1.2.3.7 --port 15487 --user username
     json .command groupAddGuestAccess .error_code ERR_GROUP_HAS_NO_ACCESS
 
-    plgfail groupAddGuestAccess a2_add_a3_as_g1_guest_1 $a2 --osh groupAddGuestAccess --group $group1 --account $account3 --host 127.0.0.1 --user g1 --port 222
+    plgfail a2_add_a3_as_g1_guest_1 $a2 --osh groupAddGuestAccess --group $group1 --account $account3 --host 127.0.0.1 --user g1 --port 222
     json .command groupAddGuestAccess .error_code ERR_GROUP_HAS_NO_ACCESS
 
-    plgfail groupAddGuestAccess a2_add_a3_as_g1_guest_2 $a2 --osh groupAddGuestAccess --group $group1 --account $account3 --host 127.0.0.1 --user g1 --port-any
+    plgfail a2_add_a3_as_g1_guest_2 $a2 --osh groupAddGuestAccess --group $group1 --account $account3 --host 127.0.0.1 --user g1 --port-any
     json .command groupAddGuestAccess .error_code ERR_GROUP_HAS_NO_ACCESS
 
-    plgfail groupAddGuestAccess a2_add_a3_as_g1_guest_3 $a2 --osh groupAddGuestAccess --group $group1 --account $account3 --host 127.0.0.1 --user g9 --port 22
+    plgfail a2_add_a3_as_g1_guest_3 $a2 --osh groupAddGuestAccess --group $group1 --account $account3 --host 127.0.0.1 --user g9 --port 22
     json .command groupAddGuestAccess .error_code ERR_GROUP_HAS_NO_ACCESS
 
-    plgfail groupAddGuestAccess a2_add_a3_as_g1_guest_4 $a2 --osh groupAddGuestAccess --group $group1 --account $account3 --host 127.0.0.9 --user g1 --port 22
+    plgfail a2_add_a3_as_g1_guest_4 $a2 --osh groupAddGuestAccess --group $group1 --account $account3 --host 127.0.0.9 --user g1 --port 22
     json .command groupAddGuestAccess .error_code ERR_GROUP_HAS_NO_ACCESS
 
-    success groupAddGuestAccess a2_add_a3_as_g1_guest_and_works $a2 --osh groupAddGuestAccess --group $group1 --account $account3 --host 127.0.0.1 --user g1 --port 22
+    success a2_add_a3_as_g1_guest_and_works $a2 --osh groupAddGuestAccess --group $group1 --account $account3 --host 127.0.0.1 --user g1 --port 22
     json .error_code OK
 
     # new state: g1[a1(ow,gk,acl,member) a2(gk) a3(g1@127.0.0.1:22) acl(g1@127.0.0.1:22,g2@127.0.0.2:22)] g3[a0,a2,a3(ow,gk,acl,member)]
 
-    success groupAddGuestAccess a2_add_a3_as_g1_guest_and_dupe $a2 --osh groupAddGuestAccess --group $group1 --account $account3 --host 127.0.0.1 --user g1 --port 22
+    success a2_add_a3_as_g1_guest_and_dupe $a2 --osh groupAddGuestAccess --group $group1 --account $account3 --host 127.0.0.1 --user g1 --port 22
     json .error_code OK_NO_CHANGE
 
-    run ssh a3_noaccess_guest_but_not_to_this_g1_tuple $a3 g2@127.0.0.2
+    run a3_noaccess_guest_but_not_to_this_g1_tuple $a3 g2@127.0.0.2
     retvalshouldbe 107
 
-    run ssh a3_access_because_guest $a3 g1@127.0.0.1
+    run a3_access_because_guest $a3 g1@127.0.0.1
     retvalshouldbe 255
     contain "allowed ... log on"
     contain 'Permission denied (publickey'
 
     # now we want to try selfListAccesses, work with a3 that has a groupguest access to g1: add a server to g3 (he's a member of it), and a personal access
 
-    success groupAddServer a3_add_server_to_g3 $a3 --osh groupAddServer --group $group3 --host 10.20.0.0/17 --port-any --user-any
+    success a3_add_server_to_g3 $a3 --osh groupAddServer --group $group3 --host 10.20.0.0/17 --port-any --user-any
 
     grant accountAddPersonalAccess
 
-    run accountAddPersonalAccess a0_add_personal_access_to_a3_works_slash_1 $a0 --osh accountAddPersonalAccess --account $account3 --host 77.66.55.0/24
+    run a0_add_personal_access_to_a3_works_slash_1 $a0 --osh accountAddPersonalAccess --account $account3 --host 77.66.55.0/24
     json .command accountAddPersonalAccess .error_code OK .value.ip 77.66.55.0/24 .value.port null .value.user null
 
-    run accountAddPersonalAccess a0_add_personal_access_to_a3_fail_badslash $a0 --osh accountAddPersonalAccess --account $account3 --host 77.66.55.0/23
+    run a0_add_personal_access_to_a3_fail_badslash $a0 --osh accountAddPersonalAccess --account $account3 --host 77.66.55.0/23
     json .command null .error_code KO_INVALID_IP .value null
 
-    run accountAddPersonalAccess a0_add_personal_access_to_a3_works_slash_2 $a0 --osh accountAddPersonalAccess --account $account3 --host 1.2.3.4/32
+    run a0_add_personal_access_to_a3_works_slash_2 $a0 --osh accountAddPersonalAccess --account $account3 --host 1.2.3.4/32
     json .command accountAddPersonalAccess .error_code OK .value.ip 1.2.3.4 .value.port null .value.user null
 
-    success accountAddPersonalAccess a0_add_personal_access_to_a3_works $a0 --osh accountAddPersonalAccess --account $account3 --host 77.66.55.4
+    success a0_add_personal_access_to_a3_works $a0 --osh accountAddPersonalAccess --account $account3 --host 77.66.55.4
 
     (( todo_inc=1 ))
     for todo_port in --port-any "--port 33"
@@ -691,7 +691,7 @@ EOS
             (( todo_inc++ ))
             for todo_ip in 2.2.$todo_inc.2 2.2.$todo_inc.3/32 2.2.$todo_inc.0/24 2.$todo_inc.5.0/23
             do
-                run accountAddPersonalAccess a0a3_add_personalxs_batch $a0 --osh  accountAddPersonalAccess --account $account3 --host $todo_ip $todo_port $todo_user
+                run a0a3_add_personalxs_batch $a0 --osh  accountAddPersonalAccess --account $account3 --host $todo_ip $todo_port $todo_user
                 if [ "$todo_ip" = "2.$todo_inc.5.0/23" ]; then
                     retvalshouldbe 100
                 else
@@ -702,7 +702,7 @@ EOS
             (( todo_inc++ ))
             for todo_ip in 2.2.$todo_inc.2 2.2.$todo_inc.3/32 2.2.$todo_inc.0/24 2.$todo_inc.5.0/23
             do
-                run groupAddServer a2g3_add_server_batch $a2 --osh  groupAddServer --group $group3 --host $todo_ip $todo_port $todo_user --force
+                run a2g3_add_server_batch $a2 --osh  groupAddServer --group $group3 --host $todo_ip $todo_port $todo_user --force
                 if [ "$todo_ip" = "2.$todo_inc.5.0/23" ]; then
                     retvalshouldbe 100
                 else
@@ -711,15 +711,15 @@ EOS
             done
 
             (( todo_inc++ ))
-            success groupAddServer a1g1_add_server_batch $a1 --osh  groupAddServer --group $group1 --host 2.2.$todo_inc.0/24 $todo_port $todo_user --force
-            success groupAddGuestAccess a2g1a3_add_guestxs_batch $a2 --osh  groupAddGuestAccess --group $group1 --account $account3 --host 2.2.$todo_inc.66 $todo_port $todo_user
-            plgfail groupAddGuestAccess a2g1a3_add_guestxs_batch $a2 --osh  groupAddGuestAccess --group $group1 --account $account3 --host 2.3.$todo_inc.1 $todo_port $todo_user
+            success a1g1_add_server_batch $a1 --osh  groupAddServer --group $group1 --host 2.2.$todo_inc.0/24 $todo_port $todo_user --force
+            success a2g1a3_add_guestxs_batch $a2 --osh  groupAddGuestAccess --group $group1 --account $account3 --host 2.2.$todo_inc.66 $todo_port $todo_user
+            plgfail a2g1a3_add_guestxs_batch $a2 --osh  groupAddGuestAccess --group $group1 --account $account3 --host 2.3.$todo_inc.1 $todo_port $todo_user
         done
     done
 
     # TODO check after removing a group access that the guest access no longer works
 
-    success selfListAccesses a3_list_own_accesses $a3 --osh selfListAccesses
+    success a3_list_own_accesses $a3 --osh selfListAccesses
     json .command selfListAccesses .error_code OK
     json --splitsort '[.value[]|.type]' "group-member group-guest personal"
     json --splitsort '[.value[]|.group]' "$group3 $group1 null"
@@ -750,7 +750,7 @@ EOS
             (( todo_inc++ ))
             for todo_ip in 2.2.$todo_inc.2 2.2.$todo_inc.3/32 2.2.$todo_inc.0/24 2.$todo_inc.5.0/23
             do
-                run accountDelPersonalAccess a0a3_del_personalxs_batch $a0 --osh  accountDelPersonalAccess --account $account3 --host $todo_ip $todo_port $todo_user
+                run a0a3_del_personalxs_batch $a0 --osh  accountDelPersonalAccess --account $account3 --host $todo_ip $todo_port $todo_user
                 if [ "$todo_ip" = "2.$todo_inc.5.0/23" ]; then
                     retvalshouldbe 100
                 else
@@ -761,7 +761,7 @@ EOS
             (( todo_inc++ ))
             for todo_ip in 2.2.$todo_inc.2 2.2.$todo_inc.3/32 2.2.$todo_inc.0/24 2.$todo_inc.5.0/23
             do
-                run groupDelServer a2g3_del_server_batch $a2 --osh  groupDelServer --group $group3 --host $todo_ip $todo_port $todo_user --force
+                run a2g3_del_server_batch $a2 --osh  groupDelServer --group $group3 --host $todo_ip $todo_port $todo_user --force
                 if [ "$todo_ip" = "2.$todo_inc.5.0/23" ]; then
                     retvalshouldbe 100
                 else
@@ -770,17 +770,17 @@ EOS
             done
 
             (( todo_inc++ ))
-            success groupDelServer a1g1_del_server_batch $a1 --osh  groupDelServer --group $group1 --host 2.2.$todo_inc.0/24 $todo_port $todo_user --force
-            success groupDelGuestAccess a2g1a3_del_guestxs_batch_1 $a2 --osh  groupDelGuestAccess --group $group1 --account $account3 --host 2.2.$todo_inc.66 $todo_port $todo_user
+            success a1g1_del_server_batch $a1 --osh  groupDelServer --group $group1 --host 2.2.$todo_inc.0/24 $todo_port $todo_user --force
+            success a2g1a3_del_guestxs_batch_1 $a2 --osh  groupDelGuestAccess --group $group1 --account $account3 --host 2.2.$todo_inc.66 $todo_port $todo_user
             # TODO next line should be OK_NO_CHANGE
-            success groupDelGuestAccess a2g1a3_del_guestxs_batch_2 $a2 --osh  groupDelGuestAccess --group $group1 --account $account3 --host 2.3.$todo_inc.1 $todo_port $todo_user
+            success a2g1a3_del_guestxs_batch_2 $a2 --osh  groupDelGuestAccess --group $group1 --account $account3 --host 2.3.$todo_inc.1 $todo_port $todo_user
         done
     done
 
     revoke accountDelPersonalAccess
     grant accountAddPersonalAccess
 
-    success selfListAccesses a3_list_own_accesses $a3 --osh selfListAccesses
+    success a3_list_own_accesses $a3 --osh selfListAccesses
     json .command selfListAccesses .error_code OK
     contain REGEX '77\.66\.55\.0/24[[:space:]]+\(any\)[[:space:]]+\(any\)[[:space:]]+personal[[:space:]]+'$account0'[[:space:]]'
     contain REGEX '1\.2\.3\.4[[:space:]]+\(any\)[[:space:]]+\(any\)[[:space:]]+personal[[:space:]]+'$account0'[[:space:]]'
@@ -789,7 +789,7 @@ EOS
     contain REGEX '10\.20\.0\.0/17[[:space:]]+\(any\)[[:space:]]+\(any\)[[:space:]]+'$group3'\(group-member\)[[:space:]]+'$account3'[[:space:]]'
     contain "5 accesses listed"
 
-    run accountDelete notingroup $a1 --osh accountDelete --account $account2
+    run notingroup $a1 --osh accountDelete --account $account2
     retvalshouldbe 106
     contain "you to be specifically granted"
     nocontain "attempting to continue"
@@ -797,18 +797,18 @@ EOS
 
     #sudo usermod -a -G osh-accountDelete $account1
     grant accountDelete
-    script accountDelete sudookbadconfirm $a0 --osh accountDelete --account $account2 "<<<" "foobar"
+    script sudookbadconfirm $a0 --osh accountDelete --account $account2 "<<<" "foobar"
     retvalshouldbe 100
     contain "aborted"
     nocontain "attempting to continue"
     json .command accountDelete .value      null .error_code ERR_OPERATOR_IS_DRUNK
 
-    script accountDelete sudook $a0 --osh accountDelete --account $account2 "<<< \"Yes, do as I say and delete $account2, kthxbye\""
+    script sudook $a0 --osh accountDelete --account $account2 "<<< \"Yes, do as I say and delete $account2, kthxbye\""
     retvalshouldbe 0
     nocontain "attempting to continue"
     json .command accountDelete .error_code OK .value.account $account2
 
-    script accountDelete sudooknotexists $a0 --osh accountDelete --account $account2 "<<< \"Yes, do as I say and delete $account2, kthxbye\""
+    script sudooknotexists $a0 --osh accountDelete --account $account2 "<<< \"Yes, do as I say and delete $account2, kthxbye\""
     retvalshouldbe 100
     contain "Account '$account2' doesn't exist"
     nocontain "attempting to continue"
@@ -816,14 +816,14 @@ EOS
 
     revoke accountDelete
 
-    run info nosuchaccount $a2 --osh info
+    run nosuchaccount $a2 --osh info
     retvalshouldbe 255
     contain "Permission denied"
     nocontain "Your alias to connect"
 
     grant accountCreate
 
-    script accountCreate sudookrecreate $a0 --osh accountCreate --always-active --account $account2 --uid $uid2 \< $account2key1file.pub
+    script sudookrecreate $a0 --osh accountCreate --always-active --account $account2 --uid $uid2 \< $account2key1file.pub
     retvalshouldbe 0
     contain "info"
     json .command accountCreate .error_code OK .value      null
@@ -835,14 +835,14 @@ EOS
     #json .error_code OK .command accountModify
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2() servers()
-    plgfail groupCreate dup $a0 --osh groupCreate --group $group1 --algo rsa --size 4096 --owner $account2
+    plgfail dup $a0 --osh groupCreate --group $group1 --algo rsa --size 4096 --owner $account2
     contain "The group $group1 already exists"
     json .command groupCreate .error_code KO_ALREADY_EXISTING .value      null
 
     revoke groupCreate
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2() servers()
-    success groupList noaccess $a2 --osh groupList --all
+    success noaccess $a2 --osh groupList --all
     json $(cat <<EOS
     .command groupList
     .error_code OK
@@ -855,68 +855,68 @@ EOS
 
     # early deny for group-gatekeeper plugins
     # group1:a1(owner,aclkeeper,gatekeeper,member)
-    run groupAddGatekeeperkeeper earlydeny $a2 --osh groupAddGatekeeper --group $group1 --account $account1
+    run earlydeny $a2 --osh groupAddGatekeeper --group $group1 --account $account1
     retvalshouldbe 106
     json .command   null .value      null .error_code KO_RESTRICTED_COMMAND
 
     # early deny for group-aclkeeper plugins
     # group1:a1(owner,aclkeeper,gatekeeper,member)
-    run groupAddAclkeeper earlydeny $a2 --osh groupAddAclkeeper --group $group1 --account $account1
+    run earlydeny $a2 --osh groupAddAclkeeper --group $group1 --account $account1
     retvalshouldbe 106
     json .command   null .value      null .error_code KO_RESTRICTED_COMMAND
 
     # early deny for group-owner plugins
     # group1:a1(owner,aclkeeper,gatekeeper,member)
-    run groupAddOwner earlydeny $a2 --osh groupAddOwner --group $group1 --account $account1
+    run earlydeny $a2 --osh groupAddOwner --group $group1 --account $account1
     retvalshouldbe 106
     json .command   null .value      null .error_code KO_RESTRICTED_COMMAND
 
     # early deny for restricted plugins
     # group1:a1(owner,aclkeeper,gatekeeper,member)
-    run accountListAccesses earlydeny $a2 --osh accountListAccesses --account $account1
+    run earlydeny $a2 --osh accountListAccesses --account $account1
     retvalshouldbe 106
     json .command   null .value      null .error_code KO_RESTRICTED_COMMAND
 
     # now just add a2 as aclk/groupk of group3, we won't use but it's just so that for other tests it won't get early-denied for group cmds
-    success groupAddGatekeeper a0_add_gatekeeper_g3_a2 $a0 --osh groupAddGatekeeper --account $account2 --group $group3
-    success groupAddAclkeeper  a0_add_aclkeeper_g3_a2  $a0 --osh groupAddAclkeeper  --account $account2 --group $group3
+    success a0_add_gatekeeper_g3_a2 $a0 --osh groupAddGatekeeper --account $account2 --group $group3
+    success  a0_add_aclkeeper_g3_a2  $a0 --osh groupAddAclkeeper  --account $account2 --group $group3
 
     # done with group3
 
     # ---
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2() servers()
-    plgfail groupAddServer notanaclkeeper $a2 --osh groupAddServer --group $group1 --host 127.0.0.10 --port-any --user-any
+    plgfail notanaclkeeper $a2 --osh groupAddServer --group $group1 --host 127.0.0.10 --port-any --user-any
     contain "an aclkeeper"
     json .command   groupAddServer .error_code ERR_NOT_GROUP_ACLKEEPER .value null
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2() servers()
-    plgfail groupAddServer firstadd $a1 --osh groupAddServer --group $group1 --host 127.0.0.10 --port-any --user-any
+    plgfail firstadd $a1 --osh groupAddServer --group $group1 --host 127.0.0.10 --port-any --user-any
     contain "you still want to add"
     json .command groupAddServer .error_code ERR_CONNECTION_FAILED .value      null
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2() servers()
-    success groupAddServer firstadd_ok $a1 --osh groupAddServer --group $group1 --host 127.0.0.10 --port-any --user-any --force
+    success firstadd_ok $a1 --osh groupAddServer --group $group1 --host 127.0.0.10 --port-any --user-any --force
     contain "was added to group"
     json .command groupAddServer .error_code OK .value.group $group1 .value.ip 127.0.0.10 .value.port null .value.user null
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2() servers(127.0.0.10)
-    success groupAddServer firstadd_dup $a1 --osh groupAddServer --group $group1 --host 127.0.0.10 --port-any --user-any --force
+    success firstadd_dup $a1 --osh groupAddServer --group $group1 --host 127.0.0.10 --port-any --user-any --force
     json .command groupAddServer .error_code OK_NO_CHANGE .value      null
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2() servers(127.0.0.10)
-    success groupAddServer secondadd $a1 --osh groupAddServer --group $group1 --host 127.0.0.11 --port-any --user-any --force
+    success secondadd $a1 --osh groupAddServer --group $group1 --host 127.0.0.11 --port-any --user-any --force
     contain "was added to group"
     json .command groupAddServer .error_code OK .value.group $group1 .value.ip 127.0.0.11 .value.port null .value.user null
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2() servers(127.0.0.10,127.0.0.11)
-    success groupAddServer thirdaddttl $a1 --osh groupAddServer --group $group1 --host 127.0.0.12 --port-any --user-any --force --ttl 0w19s0d
+    success thirdaddttl $a1 --osh groupAddServer --group $group1 --host 127.0.0.12 --port-any --user-any --force --ttl 0w19s0d
     contain "was added to group"
     contain "expires in 00:00:"
     json .command groupAddServer .error_code OK .value.group $group1 .value.ip 127.0.0.12 .value.port null .value.user null .value.ttl 19
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2() servers(127.0.0.10,127.0.0.11,127.0.0.12-TTL)
-    success groupListServers list   $a1 --osh groupListServers --group $group1
+    success list   $a1 --osh groupListServers --group $group1
     json .command groupListServers .error_code OK
     contain REGEX '127\.0\.0\.1[[:space:]]+22[[:space:]]+g1[[:space:]]+'$group1'\(group\)[[:space:]]+'$account2'[[:space:]]'
     contain REGEX '127\.0\.0\.2[[:space:]]+22[[:space:]]+g2[[:space:]]+'$group1'\(group\)[[:space:]]+'$account2'[[:space:]]'
@@ -929,7 +929,7 @@ EOS
     [ "$COUNTONLY" != 1 ] && sleep 20
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2() servers(127.0.0.10,127.0.0.11)
-    success groupListServers listttlexpired   $a1 --osh groupListServers --group $group1
+    success listttlexpired   $a1 --osh groupListServers --group $group1
     json .command groupListServers .error_code OK
     contain REGEX '127\.0\.0\.1[[:space:]]+22[[:space:]]+g1[[:space:]]+'$group1'\(group\)[[:space:]]+'$account2'[[:space:]]'
     contain REGEX '127\.0\.0\.2[[:space:]]+22[[:space:]]+g2[[:space:]]+'$group1'\(group\)[[:space:]]+'$account2'[[:space:]]'
@@ -938,89 +938,89 @@ EOS
     nocontain REGEX '127\.0\.0\.12[[:space:]]+\(any\)[[:space:]]+\(any\)[[:space:]]+'$group1'\(group\)[[:space:]]+'$account1'[[:space:]]'
     contain '4 accesses listed'
 
-    success groupListServers include $a1 --osh groupListServers --group $group1 --include 127.0.0.1
+    success include $a1 --osh groupListServers --group $group1 --include 127.0.0.1
     json .command groupListServers .error_code OK
     contain REGEX '127\.0\.0\.1[[:space:]]+22[[:space:]]+g1[[:space:]]+'$group1'\(group\)[[:space:]]+'$account2'[[:space:]]'
     contain REGEX '127\.0\.0\.10[[:space:]]+\(any\)[[:space:]]+\(any\)[[:space:]]+'$group1'\(group\)[[:space:]]+'$account1'[[:space:]]'
     contain REGEX '127\.0\.0\.11[[:space:]]+\(any\)[[:space:]]+\(any\)[[:space:]]+'$group1'\(group\)[[:space:]]+'$account1'[[:space:]]'
     contain '3 accesses listed'
 
-    success groupListServers include_exclude $a1 --osh groupListServers --group $group1 --include 127.0.0.1 --exclude 127.0.0.10 --exclude 127.?.0.11
+    success include_exclude $a1 --osh groupListServers --group $group1 --include 127.0.0.1 --exclude 127.0.0.10 --exclude 127.?.0.11
     json .command groupListServers .error_code OK
     contain REGEX '127\.0\.0\.1[[:space:]]+22[[:space:]]+g1[[:space:]]+'$group1'\(group\)[[:space:]]+'$account2'[[:space:]]'
     contain '1 accesses listed'
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2() servers(127.0.0.10,127.0.0.11)
-    plgfail groupListServers list   $a2 --osh groupListServers --group $group1
+    plgfail list   $a2 --osh groupListServers --group $group1
     json .command groupListServers .error_code KO_ACCESS_DENIED .value      null
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2() servers(127.0.0.10,127.0.0.11)
-    run ssh a2_noaccess $a2 127.0.0.10
+    run a2_noaccess $a2 127.0.0.10
     retvalshouldbe 107
     contain "Access denied for"
     json .command    null .error_code KO_ACCESS_DENIED
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2() servers(127.0.0.10,127.0.0.11)
-    run ssh a2_noaccess2 $a2 127.0.0.11
+    run a2_noaccess2 $a2 127.0.0.11
     retvalshouldbe 107
     contain "Access denied for"
     json .command    null .error_code KO_ACCESS_DENIED
 
     # owner sets a max ttl guest access policy
-    success groupModify guest_ttl_limit $a1 --osh groupModify --group $group1 --guest-ttl-limit 15s
+    success guest_ttl_limit $a1 --osh groupModify --group $group1 --guest-ttl-limit 15s
     contain "with maximum allowed duration of 00:00:15"
     json .command groupModify .error_code OK .value.guest_ttl_limit.error_code OK
 
     # try to add a guest without a ttl (should fail)
-    plgfail groupAddGuestAccess guest_add_fail_nottl $a1 --osh groupAddGuestAccess --group $group1 --account $account2 --port-any --user-any --host 127.0.0.10
+    plgfail guest_add_fail_nottl $a1 --osh groupAddGuestAccess --group $group1 --account $account2 --port-any --user-any --host 127.0.0.10
     json .command groupAddGuestAccess .error_code ERR_INVALID_PARAMETER .error_message "This group requires guest accesses to have a TTL set, to a duration of 00:00:15 or less"
 
     # try to add a guest with a too big ttl (should fail)
-    plgfail groupAddGuestAccess guest_add_fail_bigttl $a1 --osh groupAddGuestAccess --group $group1 --account $account2 --port-any --user-any --host 127.0.0.10 --ttl 14d
+    plgfail guest_add_fail_bigttl $a1 --osh groupAddGuestAccess --group $group1 --account $account2 --port-any --user-any --host 127.0.0.10 --ttl 14d
     json .command groupAddGuestAccess .error_code ERR_INVALID_PARAMETER .error_message "The TTL you specified is invalid, this group requires guest accesses to have a TTL of 00:00:15 maximum"
 
     # try to add a guest with a low ttl (should work)
-    success groupAddGuestAccess guest_add_ok_lowttl $a1 --osh groupAddGuestAccess --group $group1 --account $account2 --port-any --user-any --host 127.0.0.10 --ttl 1s
+    success guest_add_ok_lowttl $a1 --osh groupAddGuestAccess --group $group1 --account $account2 --port-any --user-any --host 127.0.0.10 --ttl 1s
     json .command groupAddGuestAccess .error_code OK
 
     # remove ttl policy
-    success groupModify guest_ttl_limit $a1 --osh groupModify --group $group1 --guest-ttl-limit 0
+    success guest_ttl_limit $a1 --osh groupModify --group $group1 --guest-ttl-limit 0
     json .command groupModify .error_code OK
 
     # if we're just counting the number of tests, don't sleep
     [ "$COUNTONLY" != 1 ] && sleep 1
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2() servers(127.0.0.10,127.0.0.11)
-    success groupAddGuestAccess works $a1 --osh groupAddGuestAccess --group $group1 --account $account2 --port-any --user-any --host 127.0.0.10
+    success works $a1 --osh groupAddGuestAccess --group $group1 --account $account2 --port-any --user-any --host 127.0.0.10
     contain "has now access"
     json .command groupAddGuestAccess .error_code OK
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2(guest(127.0.0.10)) servers(127.0.0.10,127.0.0.11)
-    plgfail groupAddGuestAccess nosuchserver $a1 --osh groupAddGuestAccess --group $group1 --account $account2 --port-any --user-any --host 127.9.0.10
+    plgfail nosuchserver $a1 --osh groupAddGuestAccess --group $group1 --account $account2 --port-any --user-any --host 127.9.0.10
     nocontain "has now access"
     json .command groupAddGuestAccess .error_code ERR_GROUP_HAS_NO_ACCESS
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2(guest(127.0.0.10)) servers(127.0.0.10,127.0.0.11)
-    run ssh a2_partialxs $a2 127.0.0.10
+    run a2_partialxs $a2 127.0.0.10
     retvalshouldbe 255
     contain "allowed ... log on"
     contain "group-guest of $group1"
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2(guest(127.0.0.10)) servers(127.0.0.10,127.0.0.11)
-    plgfail a2_partial_groupaddserver shouldfail $a2 --osh groupAddServer --group $group1 --port-any --user-any --host 127.0.0.10
+    plgfail shouldfail $a2 --osh groupAddServer --group $group1 --port-any --user-any --host 127.0.0.10
     nocontain "was added to group"
     nocontain "you still want to add"
     contain "must be an aclkeeper"
     json .command groupAddServer .error_code ERR_NOT_GROUP_ACLKEEPER .value      null
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2(guest(127.0.0.10)) servers(127.0.0.10,127.0.0.11)
-    run ssh a2_noxsnofull $a2 127.0.0.11
+    run a2_noxsnofull $a2 127.0.0.11
     retvalshouldbe 107
     contain "Access denied for"
     nocontain "$group1 group key"
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2(guest(127.0.0.10)) servers(127.0.0.10,127.0.0.11)
-    success groupDelGuestAccess works $a1 --osh groupDelGuestAccess --group $group1 --account $account2 --port-any --user-any --host 127.0.0.10
+    success works $a1 --osh groupDelGuestAccess --group $group1 --account $account2 --port-any --user-any --host 127.0.0.10
     contain "removed group key access"
     json .command groupDelGuestAccess .error_code OK .value      null
 
@@ -1030,19 +1030,19 @@ EOS
     grant accountAddPersonalAccess
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2(guest(127.0.0.10)) servers(127.0.0.10,127.0.0.11)
-    success accountAddPersonalAccess own11 $a0 --osh accountAddPersonalAccess --account $account2 --host 127.0.0.11 --user $account2 --port 22
+    success own11 $a0 --osh accountAddPersonalAccess --account $account2 --host 127.0.0.11 --user $account2 --port 22
     contain "adding the access blindly"
     json .command accountAddPersonalAccess .error_code OK .value.account $account2 .value.ip 127.0.0.11 .value.user $account2 .value.port 22
 
     # just try the ttl param
-    success accountAddPersonalAccess own11_ttl $a0 --osh accountAddPersonalAccess --account $account2 --host 127.7.0.11 --user $account2 --port 22 --ttl 3
+    success own11_ttl $a0 --osh accountAddPersonalAccess --account $account2 --host 127.7.0.11 --user $account2 --port 22 --ttl 3
     contain "adding the access blindly"
     contain "expires in 00:00:0"
     json .command accountAddPersonalAccess .error_code OK .value.account $account2 .value.ip 127.7.0.11 .value.user $account2 .value.port 22 .value.ttl 3
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2(guest(127.0.0.10)) servers(127.0.0.10,127.0.0.11)
     # account1: perso(account1@127.0.0.11:22)
-    run ssh a2_noxsnofullevenprivate $a2 127.0.0.11
+    run a2_noxsnofullevenprivate $a2 127.0.0.11
     retvalshouldbe 255
     contain "allowed ... log on"
     nocontain "$group1"
@@ -1050,19 +1050,19 @@ EOS
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2(guest(127.0.0.10)) servers(127.0.0.10,127.0.0.11)
     # account1: perso(account1@127.0.0.11:22)
-    plgfail groupTransmitOwnership noright1 $a0 --osh groupTransmitOwnership --group $group1 --account $account1
+    plgfail noright1 $a0 --osh groupTransmitOwnership --group $group1 --account $account1
     json .command groupTransmitOwnership .error_code ERR_NOT_GROUP_OWNER .value null
 
     # group1: a1(owner,aclkeeper,gatekeeper,member) a2(guest(127.0.0.10)) servers(127.0.0.10,127.0.0.11)
     # account1: perso(account1@127.0.0.11:22)
-    plgfail groupTransmitOwnership noright2 $a1 --osh groupTransmitOwnership --group $group2 --account $account0
+    plgfail noright2 $a1 --osh groupTransmitOwnership --group $group2 --account $account0
     json .command groupTransmitOwnership .error_code KO_GROUP_NOT_FOUND
 
     grant groupCreate
-    success groupCreate works      $a0  --osh groupCreate --group $group2 --owner $account2 --algo ecdsa --size 521
+    success works      $a0  --osh groupCreate --group $group2 --owner $account2 --algo ecdsa --size 521
     revoke groupCreate
 
-    success groupInfo owner $a2 --osh groupInfo --group $group2
+    success owner $a2 --osh groupInfo --group $group2
     tmpfp=$(get_json | $jq '.value.keys|keys[0]')
     json $(cat <<EOS
     .command groupInfo
@@ -1084,20 +1084,20 @@ EOS
     )
     unset tmpfp
 
-    plgfail groupTransmitOwnership nope     $a2 --osh groupTransmitOwnership --group $group1 --account $account0
+    plgfail nope     $a2 --osh groupTransmitOwnership --group $group1 --account $account0
     json .command groupTransmitOwnership .error_code ERR_NOT_GROUP_OWNER .value          null
 
-    success groupTransmitOwnership oknochg  $a1 --osh groupTransmitOwnership --group $group1 --account $account1
+    success oknochg  $a1 --osh groupTransmitOwnership --group $group1 --account $account1
     json .command groupTransmitOwnership .error_code OK_NO_CHANGE .value          null
 
-    success groupTransmitOwnership ok       $a1 --osh groupTransmitOwnership --group $group1 --account $account2
+    success ok       $a1 --osh groupTransmitOwnership --group $group1 --account $account2
     json .command groupTransmitOwnership .error_code OK .value          null
 
-    run     groupTransmitOwnership nopedup  $a1 --osh groupTransmitOwnership --group $group1 --account $account2
+    run     nopedup  $a1 --osh groupTransmitOwnership --group $group1 --account $account2
     retvalshouldbe 106
     json .command   null .error_code KO_RESTRICTED_COMMAND .value      null
 
-    run   groupInfo notmember $a0 --osh groupInfo --group $group1
+    run   notmember $a0 --osh groupInfo --group $group1
     tmpfp=$(get_json | $jq '.value.keys|keys[0]')
     json $(cat <<EOS
     .command groupInfo
@@ -1116,14 +1116,14 @@ EOS
 EOS
     )
 
-    run groupAddGatekeeper notOwner $a1 --osh groupAddGatekeeper --group $group1 --account $account2
+    run notOwner $a1 --osh groupAddGatekeeper --group $group1 --account $account2
     retvalshouldbe 106
     json .command   null .error_code KO_RESTRICTED_COMMAND .value      null
 
-    success groupAddGatekeeper add $a2 --osh groupAddGatekeeper --group $group1 --account $account2
+    success add $a2 --osh groupAddGatekeeper --group $group1 --account $account2
     json .command groupAddGatekeeper .error_code OK .value          null
 
-    run groupAddGatekeeper shouldBeGK $a0 --osh groupInfo --group $group1
+    run shouldBeGK $a0 --osh groupInfo --group $group1
     tmpfp=$(get_json | $jq '.value.keys|keys[0]')
     json $(cat <<EOS
     .command groupInfo
@@ -1143,14 +1143,14 @@ EOS
 EOS
     )
 
-    run groupDelGatekeeper notOwner $a1 --osh groupDelGatekeeper --group $group1 --account $account1
+    run notOwner $a1 --osh groupDelGatekeeper --group $group1 --account $account1
     retvalshouldbe 106
     json .command   null .error_code KO_RESTRICTED_COMMAND .value      null
 
-    success groupDelGatekeeper add $a2 --osh groupDelGatekeeper --group $group1 --account $account1
+    success add $a2 --osh groupDelGatekeeper --group $group1 --account $account1
     json .command groupDelGatekeeper .error_code OK .value          null
 
-    run groupDelGatekeeper shouldNotBeGK $a0 --osh groupInfo --group $group1
+    run shouldNotBeGK $a0 --osh groupInfo --group $group1
     tmpfp=$(get_json | $jq '.value.keys|keys[0]')
     json $(cat <<EOS
     .command groupInfo
@@ -1170,32 +1170,32 @@ EOS
     )
     unset tmpfp
 
-    plgfail  end   groupDestroy_fail   $a2 --osh groupDestroy --group $group3 --no-confirm
+    plgfail  groupDestroy_fail   $a2 --osh groupDestroy --group $group3 --no-confirm
     retvalshouldbe 100
     json .command groupDestroy .error_code ERR_NOT_GROUP_OWNER
 
-    success  end   groupDestroy   $a3 --osh groupDestroy --group $group3 --no-confirm
+    success  groupDestroy   $a3 --osh groupDestroy --group $group3 --no-confirm
     json .command groupDestroy .error_code OK
 
-    success  end   groupDestroy   $a2 --osh groupDestroy --group $group2 --no-confirm
+    success  groupDestroy   $a2 --osh groupDestroy --group $group2 --no-confirm
     json .command groupDestroy .error_code OK
 
-    success  end   groupDestroy   $a2 --osh groupDestroy --group $group1 --no-confirm
+    success  groupDestroy   $a2 --osh groupDestroy --group $group1 --no-confirm
     json .command groupDestroy .error_code OK
 
     grant accountDelete
 
-    script   end   accountDelete   $a0 --osh accountDelete --account $account3 "<<< \"Yes, do as I say and delete $account3, kthxbye\""
+    script   accountDelete   $a0 --osh accountDelete --account $account3 "<<< \"Yes, do as I say and delete $account3, kthxbye\""
     retvalshouldbe 0
     nocontain "attempting to continue"
     json .command accountDelete .error_code OK
 
-    script   end   accountDelete   $a0 --osh accountDelete --account $account2 "<<< \"Yes, do as I say and delete $account2, kthxbye\""
+    script   accountDelete   $a0 --osh accountDelete --account $account2 "<<< \"Yes, do as I say and delete $account2, kthxbye\""
     retvalshouldbe 0
     nocontain "attempting to continue"
     json .command accountDelete .error_code OK
 
-    script   end   accountDelete   $a0 --osh accountDelete --account $account1 "<<< \"Yes, do as I say and delete $account1, kthxbye\""
+    script   accountDelete   $a0 --osh accountDelete --account $account1 "<<< \"Yes, do as I say and delete $account1, kthxbye\""
     retvalshouldbe 0
     nocontain "attempting to continue"
     json .command accountDelete .error_code OK

--- a/tests/functional/tests.d/360-plugins.sh
+++ b/tests/functional/tests.d/360-plugins.sh
@@ -7,7 +7,7 @@
 
 testsuite_plugins()
 {
-    success plugin-ping withHost $a0 --osh ping -w 2 --host 127.0.0.1 -c 2
+    success withHost $a0 --osh ping -w 2 --host 127.0.0.1 -c 2
     json .command     ping .error_code  OK
     # in some tests environments, ping is not allowed...
     _sysret=$(get_json | $jq .value.sysret)
@@ -20,7 +20,7 @@ testsuite_plugins()
     fi
     unset _sysret
 
-    success plugin-ping withoutHost $a0 --osh ping -c 1 127.0.0.1 -w 1
+    success withoutHost $a0 --osh ping -c 1 127.0.0.1 -w 1
     json .command    ping .error_code  OK
     _sysret=$(get_json | $jq .value.sysret)
     if [ "$_sysret" = 0 ]; then
@@ -32,7 +32,7 @@ testsuite_plugins()
     fi
     unset _sysret
 
-    success plugin-ping loss $a0 --osh ping 192.0.2.1 -w 1 -c 1
+    success loss $a0 --osh ping 192.0.2.1 -w 1 -c 1
     json .command ping .error_code OK
     _sysret=$(get_json | $jq .value.sysret)
     if [ "$_sysret" = 1 ]; then
@@ -44,7 +44,7 @@ testsuite_plugins()
     fi
     unset _sysret
 
-    success plugin-nc withHost $a0 --osh nc --port 22 --host 127.0.0.1 --timeout 1
+    success withHost $a0 --osh nc --port 22 --host 127.0.0.1 --timeout 1
     json $(cat <<EOS
     .command nc
     .error_code OK
@@ -55,7 +55,7 @@ testsuite_plugins()
 EOS
     )
 
-    success plugin-nc withoutHost $a0 --osh nc 127.0.0.1 22 --timeout 1
+    success withoutHost $a0 --osh nc 127.0.0.1 22 --timeout 1
     json $(cat <<EOS
     .command nc
     .error_code OK
@@ -66,7 +66,7 @@ EOS
 EOS
     )
 
-    success plugin-nc closed $a0 --osh nc 127.0.0.1 1 --timeout 1
+    success closed $a0 --osh nc 127.0.0.1 1 --timeout 1
     json $(cat <<EOS
     .command nc
     .error_code OK
@@ -77,7 +77,7 @@ EOS
 EOS
     )
 
-    success plugin-nc timeout $a0 --osh nc --timeout 1 192.0.2.1 22
+    success timeout $a0 --osh nc --timeout 1 192.0.2.1 22
     json $(cat <<EOS
     .command nc
     .error_code OK
@@ -89,12 +89,12 @@ EOS
     )
 
     # tests can fail under e.g. OpenSUSE + docker because of raw sockets: ignore those cases
-    success plugin-alive withHost $a0 --osh alive --host 127.0.0.1
+    success withHost $a0 --osh alive --host 127.0.0.1
     if ! get_stdout | grep -q "can't create raw socket"; then
         json .command alive .error_code OK .value.waited_for 0
     fi
 
-    success plugin-alive withoutHost $a0 --osh alive 127.0.0.1
+    success withoutHost $a0 --osh alive 127.0.0.1
     json .command alive .error_code OK .value.waited_for 0
     if ! get_stdout | grep -q "can't create raw socket"; then
         json .command alive .error_code OK .value.waited_for 0

--- a/tests/functional/tests.d/390-mfa-realm.sh
+++ b/tests/functional/tests.d/390-mfa-realm.sh
@@ -12,7 +12,7 @@ testsuite_mfa_realm()
     grant accountCreate
 
     # create account4
-    success mfarealm a0_create_a4 $a0 --osh accountCreate --always-active --account $account4 --uid $uid4 --public-key "\"$(cat $account4key1file.pub)\""
+    success a0_create_a4 $a0 --osh accountCreate --always-active --account $account4 --uid $uid4 --public-key "\"$(cat $account4key1file.pub)\""
     json .error_code OK .command accountCreate .value null
 
     revoke accountCreate
@@ -21,54 +21,54 @@ testsuite_mfa_realm()
     grant groupCreate
 
     # create realm-egress group on local bastion
-    success realm create_support_group $a0 --osh groupCreate --group $realm_egress_group --owner $account4 --algo ed25519
+    success create_support_group $a0 --osh groupCreate --group $realm_egress_group --owner $account4 --algo ed25519
     local realm_group_key
     realm_group_key=$(get_json | $jq '.value.public_key.line')
 
     grant realmCreate
 
     # create shared realm-account on remote bastion
-    success realm create_shared_account $a0 --osh realmCreate --realm $realm_shared_account --public-key \"$realm_group_key\" --from 0.0.0.0/0
+    success create_shared_account $a0 --osh realmCreate --realm $realm_shared_account --public-key \"$realm_group_key\" --from 0.0.0.0/0
 
     revoke realmCreate
 
     # add remote bastion ip on group of local bastion
-    success realm add_remote_bastion_to_group $a4 --osh groupAddServer --host 127.0.0.1 --user realm_$realm_shared_account --port 22 --group $realm_egress_group --kbd-interactive
+    success add_remote_bastion_to_group $a4 --osh groupAddServer --host 127.0.0.1 --user realm_$realm_shared_account --port 22 --group $realm_egress_group --kbd-interactive
 
     # attempt inter-realm connection
-    success realm firstconnect1 $a4 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js --osh info
+    success firstconnect1 $a4 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js --osh info
     json .value.account $account4 .value.realm $realm_shared_account
 
     # create a remote-group on which we'll add the realm user
-    success mfarealm remote_group_create $a0 --osh groupCreate --group remotegrp --owner $account0 --algo ed25519
+    success remote_group_create $a0 --osh groupCreate --group remotegrp --owner $account0 --algo ed25519
     revoke groupCreate
 
-    success mfarealm remote_group_add_server $a0 --osh groupAddServer --group remotegrp --host 127.0.0.5 --port 22 --user nevermind --force
+    success remote_group_add_server $a0 --osh groupAddServer --group remotegrp --host 127.0.0.5 --port 22 --user nevermind --force
 
     # try to connect, as a realm user, to 127.0.0.5 through the realm: won't work
-    run mfarealm realm_user_fail_connect_not_member $a4 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js nevermind@127.0.0.5
+    run realm_user_fail_connect_not_member $a4 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js nevermind@127.0.0.5
     retvalshouldbe 107
     json .error_code KO_ACCESS_DENIED .error_message "Access denied for $realm_shared_account/$account4 to nevermind@127.0.0.5:22"
 
     # now add the realm user and retry
-    success mfarealm remote_group_add_user $a0 --osh groupAddMember --group remotegrp --account $realm_shared_account/$account4
+    success remote_group_add_user $a0 --osh groupAddMember --group remotegrp --account $realm_shared_account/$account4
 
-    run mfarealm realm_user_fail_connect_not_member $a4 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js nevermind@127.0.0.5
+    run realm_user_fail_connect_not_member $a4 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js nevermind@127.0.0.5
     retvalshouldbe 255
     contain "group-member of remotegrp"
     contain "Permission denied (publickey)"
 
     # now setup mandatory MFA on the group
-    success mfarealm remote_group_set_mfa $a0 --osh groupModify --group remotegrp --mfa-required password
+    success remote_group_set_mfa $a0 --osh groupModify --group remotegrp --mfa-required password
 
     # try to connect won't work
-    run mfarealm realm_user_fail_connect_no_mfa $a4 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js nevermind@127.0.0.5
+    run realm_user_fail_connect_no_mfa $a4 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js nevermind@127.0.0.5
     retvalshouldbe 122
     json .error_code KO_MFA_PASSWORD_SETUP_REQUIRED
 
     # setup our MFA
     # setup our password, step1
-    run mfa a4_setup_pass_step1of2 $a4f --osh selfMFASetupPassword --yes
+    run a4_setup_pass_step1of2 $a4f --osh selfMFASetupPassword --yes
     retvalshouldbe 124
     contain 'enter this:'
     local a4_password_tmp
@@ -76,7 +76,7 @@ testsuite_mfa_realm()
 
     # setup our password, step2
     local a4_password='Hfv$!OKiG:(xl>Th8Kv!alz4436BFt~'
-    script mfa a4_setup_pass_step2of2 "echo 'set timeout 30; \
+    script a4_setup_pass_step2of2 "echo 'set timeout 30; \
         spawn $a4 --osh selfMFASetupPassword --yes; \
         expect \":\" { sleep 0.2; send \"$a4_password_tmp\\n\"; }; \
         expect \":\" { sleep 0.2; send \"$a4_password\\n\"; }; \
@@ -94,22 +94,22 @@ testsuite_mfa_realm()
     # set account4 as nopam, to only use JIT MFA because that's what we want to test
     grant accountModify
 
-    success mfarealm a4_set_nopam $a0 --osh accountModify --account $account4 --pam-auth-bypass yes
+    success a4_set_nopam $a0 --osh accountModify --account $account4 --pam-auth-bypass yes
     json .command accountModify .error_code OK
 
     revoke accountModify
 
     # try to connect will still not work because we have MFA but we're asked for it on our first bastion
-    run mfarealm realm_user_still_fail_connect_no_mfa $a4 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js nevermind@127.0.0.5
+    run realm_user_still_fail_connect_no_mfa $a4 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js nevermind@127.0.0.5
     retvalshouldbe 122
     json .error_code KO_MFA_PASSWORD_SETUP_REQUIRED
 
     # force MFA for the support group
-    success mfarealm set_mfa_for_support_group $a4 --osh groupModify --group $realm_egress_group --mfa-required password
+    success set_mfa_for_support_group $a4 --osh groupModify --group $realm_egress_group --mfa-required password
     json .command groupModify .error_code OK
 
     # try to connect, this one will finally work
-    script mfarealm a4_connect_success_realm_with_remote_mfa "echo 'set timeout 30; \
+    script a4_connect_success_realm_with_remote_mfa "echo 'set timeout 30; \
         spawn $a4 realm_$realm_shared_account@127.0.0.1 --kbd-interactive -- $js nevermind@127.0.0.5; \
         expect \"word:\" { sleep 0.2; send \"$a4_password\\n\"; }; \
         expect eof; \
@@ -122,19 +122,19 @@ testsuite_mfa_realm()
     # cleanup
     grant realmDelete
 
-    success mfarealm realmDelete $a0 --osh realmDelete --realm $realm_shared_account "<<< \"Yes, do as I say and delete $realm_shared_account, kthxbye\""
+    success realmDelete $a0 --osh realmDelete --realm $realm_shared_account "<<< \"Yes, do as I say and delete $realm_shared_account, kthxbye\""
 
     revoke realmDelete
     grant accountDelete
 
-    script mfarealm a0_delete_a4 $a0 --osh accountDelete --account $account4 "<<< \"Yes, do as I say and delete $account4, kthxbye\""
+    script a0_delete_a4 $a0 --osh accountDelete --account $account4 "<<< \"Yes, do as I say and delete $account4, kthxbye\""
     retvalshouldbe 0
     json .command accountDelete .error_code OK
 
     revoke accountDelete
     grant groupDelete
 
-    success mfarealm groupDelete $a0 --osh groupDelete --group $realm_egress_group --no-confirm
+    success groupDelete $a0 --osh groupDelete --group $realm_egress_group --no-confirm
 
     revoke groupDelete
 }

--- a/tests/functional/tests.d/400-piv.sh
+++ b/tests/functional/tests.d/400-piv.sh
@@ -57,7 +57,7 @@ EOF
 
     grant accountCreate
 
-    success osh accountCreate $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key \""$(cat $account1key1file.pub)"\"
+    success accountCreate $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key \""$(cat $account1key1file.pub)"\"
     json .error_code OK .command accountCreate .value null
 
     revoke accountCreate
@@ -65,7 +65,7 @@ EOF
     grant accountPIV
     grant accountListIngressKeys
 
-    script selfAddIngressKey piv_nopivspecified $a1 --osh selfAddIngressKey --piv "< $account2key1file.pub"
+    script piv_nopivspecified $a1 --osh selfAddIngressKey --piv "< $account2key1file.pub"
     retvalshouldbe 100
     json .command selfAddIngressKey .error_code ERR_NO_PEM_START_MARKER
 
@@ -73,73 +73,73 @@ EOF
     configchg 's=^\\\\x22minimumIngressRsaKeySize\\\\x22.+=\\\\x22minimumIngressRsaKeySize\\\\x22:2048,='
 
     # add a key which doesn't match the certs
-    script selfAddIngressKey piv_badcert "( cat $account2key1file.pub; echo \"$piv_attestation\"; echo \"$piv_certificate\" ) | $a1 --osh selfAddIngressKey --piv"
+    script piv_badcert "( cat $account2key1file.pub; echo \"$piv_attestation\"; echo \"$piv_certificate\" ) | $a1 --osh selfAddIngressKey --piv"
     retvalshouldbe 100
     json .command selfAddIngressKey .error_code ERR_PIV_VALIDATION_FAILED
 
     # add a proper PIV key
-    script selfAddIngressKey piv_ok "( echo \"$piv_pub\"; echo \"$piv_attestation\"; echo \"$piv_certificate\" ) | $a1 --osh selfAddIngressKey --piv"
+    script piv_ok "( echo \"$piv_pub\"; echo \"$piv_attestation\"; echo \"$piv_certificate\" ) | $a1 --osh selfAddIngressKey --piv"
     retvalshouldbe 0
     json .command selfAddIngressKey .error_code OK .value.key.isPiv 1 .value.key.pivInfo.SSHKey.FingerprintMD5 '01:de:fa:fd:0a:3e:9d:45:d2:0c:a1:9c:1b:97:79:dd'
 
     # we should see it here
-    success selfListIngressKeys piv_list $a1 --osh selfListIngressKeys
+    success piv_list $a1 --osh selfListIngressKeys
     json .command selfListIngressKeys .error_code OK .value.keys[1].isPiv 1 .value.keys[1].pivInfo.Yubikey.SerialNumber 10595103
     # save the fp for later
     local piv_fp
     piv_fp=$(get_json | $jq '.value.keys[1].fingerprint')
 
     # add a third normal key (needed for a test few lines below)
-    success selfAddIngressKey normalkey $a1 --osh selfAddIngressKey "< $account1key2file.pub"
+    success normalkey $a1 --osh selfAddIngressKey "< $account1key2file.pub"
     json .command selfAddIngressKey .error_code OK
     # save the fp for later too
     local other_fp
     other_fp=$(get_json | $jq '.value.key.fingerprint')
 
     # enforce PIV only on account1
-    success accountPIV a0_piv_enforce_a1 $a0 --osh accountPIV --policy enforce --account $account1
+    success a0_piv_enforce_a1 $a0 --osh accountPIV --policy enforce --account $account1
     json .command accountPIV .error_code OK
 
     # account1 can no longer connect because only its PIV key is active, and this testcase doesn't have the corresponding private key (obviously)
-    run selfListIngressKeys a1_listkeys $a1 --osh selfListIngressKeys
+    run a1_listkeys $a1 --osh selfListIngressKeys
     retvalshouldbe 255
     contain "Permission denied"
 
     # account0 checks the ingress keys of account1, only the PIV key must remain.
-    success accountListIngressKeys a0_listkeys_a1 $a0 --osh accountListIngressKeys --account $account1
+    success a0_listkeys_a1 $a0 --osh accountListIngressKeys --account $account1
     json .command accountListIngressKeys .error_code OK .value.keys[1] null .value.keys[0].isPiv 1 .value.keys[0].pivInfo.Yubikey.SerialNumber 10595103
 
     # account0 sudo account1 to try to add a non-piv key. this must not work.
     # for this trick, a0 needs to use adminSudo hence needs to be an admin
     configchg 's=^\\\\x22adminAccounts\\\\x22.+=\\\\x22adminAccounts\\\\x22:[\\\\x22'"$account0"'\\\\x22],='
 
-    success root set_a0_as_admin $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; add_user_to_group_compat $account0 osh-admin\""
+    success set_a0_as_admin $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; add_user_to_group_compat $account0 osh-admin\""
 
-    script sudo-selfListIngressKeys a0_sudo_a1_selfaddnonpiv $a0 --osh adminSudo -- --sudo-as $account1 --sudo-cmd selfAddIngressKey -- $js "< $account2key1file.pub"
+    script a0_sudo_a1_selfaddnonpiv $a0 --osh adminSudo -- --sudo-as $account1 --sudo-cmd selfAddIngressKey -- $js "< $account2key1file.pub"
     retvalshouldbe 0
     json .command adminSudo .error_code OK_NON_ZERO_EXIT .value.status 100
     contain ERR_NO_PEM_START_MARKER
 
     # account0 sudo account1 remove the PIV key
-    script sudo-selfDelIngressKey a0_sudo_a1_selfdelpiv $a0 --osh adminSudo -- --sudo-as $account1 --sudo-cmd selfDelIngressKey -- --fingerprint-to-delete "$piv_fp" $js
+    script a0_sudo_a1_selfdelpiv $a0 --osh adminSudo -- --sudo-as $account1 --sudo-cmd selfDelIngressKey -- --fingerprint-to-delete "$piv_fp" $js
     retvalshouldbe 0
     json .command adminSudo .error_code OK
 
     # account0 list the keys of account1; no key must remain because all non-PIV keys are disabled and the PIV key is gone
-    success accountListIngressKeys a0_listkeys_a1_empty $a0 --osh accountListIngressKeys --account $account1
+    success a0_listkeys_a1_empty $a0 --osh accountListIngressKeys --account $account1
     json .command accountListIngressKeys .error_code OK '.value.keys|length' 0
 
     # account1 still can't connect
-    run info a1_noconnect $a1 --osh info
+    run a1_noconnect $a1 --osh info
     retvalshouldbe 255
     contain "Permission denied"
 
     # set PIV grace on account1
-    success accountPIV a0_piv_grace_a1 $a0 --osh accountPIV --policy grace --ttl 10 --account $account1
+    success a0_piv_grace_a1 $a0 --osh accountPIV --policy grace --ttl 10 --account $account1
     json .command accountPIV .error_code OK
 
     # account1 should be able to connect now
-    success selfListIngressKeys a1_listkeys_after_piv_grace $a1 --osh selfListIngressKeys
+    success a1_listkeys_after_piv_grace $a1 --osh selfListIngressKeys
     json .command selfListIngressKeys .error_code OK '.value.keys|length' 2
 
     # sleep to ensure grace expires
@@ -148,27 +148,27 @@ EOF
 
     # manually launch the grace reaper (normally done by cron)
     echo "manually launching piv grace reaper..."
-    success root grace_reaper $r0 $opt_remote_basedir/bin/cron/osh-piv-grace-reaper.pl
+    success grace_reaper $r0 $opt_remote_basedir/bin/cron/osh-piv-grace-reaper.pl
 
     # account1 should no longer be able to connect, as PIV grace expired
-    run info a1_noconnect_grace_expired $a1 --osh info
+    run a1_noconnect_grace_expired $a1 --osh info
     retvalshouldbe 255
     contain "Permission denied"
 
     # remove PIV only from account1
-    success accountPIV a0_piv_none_a1 $a0 --osh accountPIV --policy default --account $account1
+    success a0_piv_none_a1 $a0 --osh accountPIV --policy default --account $account1
     json .command accountPIV .error_code OK
 
     # account1 can connect
-    success selfListIngressKeys a1_listkeys_piv_none $a1 --osh selfListIngressKeys
+    success a1_listkeys_piv_none $a1 --osh selfListIngressKeys
     json .command selfListIngressKeys .error_code OK '.value.keys|length' 2
 
     # remove the test key
-    success selfDelIngressKey a1_delkey_test $a1 --osh selfDelIngressKey --fingerprint-to-delete $other_fp
+    success a1_delkey_test $a1 --osh selfDelIngressKey --fingerprint-to-delete $other_fp
     json .command selfDelIngressKey .error_code OK
 
     # remove a0 from admins
-    success root del_a0_as_admin $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; del_user_from_group_compat $account0 osh-admin\""
+    success del_a0_as_admin $r0 "\". $opt_remote_basedir/lib/shell/functions.inc; del_user_from_group_compat $account0 osh-admin\""
 
     revoke accountListIngressKeys
     revoke accountPIV
@@ -176,13 +176,13 @@ EOF
 
     # delete account1
     grant accountDelete
-    script accountDelete cleanup $a0 --osh accountDelete --account $account1 "<<< \"Yes, do as I say and delete $account1, kthxbye\""
+    script cleanup $a0 --osh accountDelete --account $account1 "<<< \"Yes, do as I say and delete $account1, kthxbye\""
     retvalshouldbe 0
 
     revoke accountDelete
 
     # restore default config
-    success bastion configrestore $r0 "dd if=$opt_remote_etc_bastion/bastion.conf.bak.$now of=$opt_remote_etc_bastion/bastion.conf"
+    success configrestore $r0 "dd if=$opt_remote_etc_bastion/bastion.conf.bak.$now of=$opt_remote_etc_bastion/bastion.conf"
 }
 
 if [ "${capabilities[piv]}" = 1 ]; then

--- a/tests/functional/tests.d/500-http-proxy.sh
+++ b/tests/functional/tests.d/500-http-proxy.sh
@@ -11,12 +11,12 @@ testsuite_proxy()
     # as a --no-color or similar option doesn't seem to exist for curl.
 
     # check that the proxy is up
-    script 500-http-proxy monitoring "curl -ski https://$remote_ip:$remote_proxy_port/bastion-health-check | cat; exit \${PIPESTATUS[0]}"
+    script monitoring "curl -ski https://$remote_ip:$remote_proxy_port/bastion-health-check | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'running nominally'
 
     # and let's go
-    script 500-http-proxy noauth "curl -ski https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script noauth "curl -ski https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 401 Authorization required (no auth provided)'
     contain 'Server: The Bastion'
@@ -26,7 +26,7 @@ testsuite_proxy()
     contain 'Content-Type: text/plain'
     contain 'No authentication provided, and authentication is mandatory'
 
-    script 500-http-proxy bad_auth_format "curl -ski -u test:test https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script bad_auth_format "curl -ski -u test:test https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 400 Bad Request (bad login format)'
     contain 'Server: The Bastion'
@@ -36,7 +36,7 @@ testsuite_proxy()
     contain 'Content-Type: text/plain'
     contain 'Expected an Authorization line with credentials of the form'
 
-    script 500-http-proxy bad_auth "curl -ski -u test@test@test:test https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script bad_auth "curl -ski -u test@test@test:test https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 403 Access Denied'
     contain 'Server: The Bastion'
@@ -47,13 +47,13 @@ testsuite_proxy()
     contain 'Incorrect username (test) or password (#REDACTED#, length=4)'
 
     # create valid credentials
-    success 500-http-proxy generate_proxy_password $a0 --osh selfGenerateProxyPassword --do-it
+    success generate_proxy_password $a0 --osh selfGenerateProxyPassword --do-it
     json .command selfGenerateProxyPassword .error_code OK
     local proxy_password
     proxy_password=$(get_json | jq -r '.value.password')
 
     # now try to use these
-    script 500-http-proxy good_auth_bad_host "curl -ski -u '$account0@test@test.invalid:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script good_auth_bad_host "curl -ski -u '$account0@test@test.invalid:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 400 Bad Request (host not resolved)'
     contain 'Server: The Bastion'
@@ -68,13 +68,13 @@ testsuite_proxy()
     contain "Specified remote host couldn't be resolved through the DNS"
 
     # change credentials again
-    success 500-http-proxy generate_proxy_password2 $a0 --osh selfGenerateProxyPassword --do-it
+    success generate_proxy_password2 $a0 --osh selfGenerateProxyPassword --do-it
     json .command selfGenerateProxyPassword .error_code OK
     local proxy_password2
     proxy_password2=$(get_json | jq -r '.value.password')
 
     # attempt to use the previous credentials (and fail)
-    script 500-http-proxy bad_auth2 "curl -ski -u test@test@test:test https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script bad_auth2 "curl -ski -u test@test@test:test https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 403 Access Denied'
     contain 'Server: The Bastion'
@@ -86,7 +86,7 @@ testsuite_proxy()
 
     proxy_password="$proxy_password2"
 
-    script 500-http-proxy good_auth_no_access "curl -ski -u '$account0@test@127.0.0.1:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script good_auth_no_access "curl -ski -u '$account0@test@127.0.0.1:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 403 Access Denied (access denied to remote)'
     contain 'Server: The Bastion'
@@ -101,7 +101,7 @@ testsuite_proxy()
     contain 'Content-Type: text/plain'
     contain "This account doesn't have access to this user@host tuple (Access denied for $account0 to test@127.0.0.1:443)"
 
-    script 500-http-proxy good_auth_no_access_other_port "curl -ski -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script good_auth_no_access_other_port "curl -ski -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 403 Access Denied (access denied to remote)'
     contain 'Server: The Bastion'
@@ -119,12 +119,12 @@ testsuite_proxy()
     # add ourselves access
     grant selfAddPersonalAccess
 
-    success 500-http-proxy add_personal_access $a0 --osh selfAddPersonalAccess --host 127.0.0.1 --port 9443 --user test --force
+    success add_personal_access $a0 --osh selfAddPersonalAccess --host 127.0.0.1 --port 9443 --user test --force
     json .command selfAddPersonalAccess .error_code OK
 
     revoke selfAddPersonalAccess
 
-    script 500-http-proxy missing_egress_pwd "curl -ski -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script missing_egress_pwd "curl -ski -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 412 Precondition Failed (egress password missing)'
     contain 'Server: The Bastion'
@@ -140,11 +140,11 @@ testsuite_proxy()
     contain "Unable to find (or read) a password file in context 'self' and name '$account0'"
 
     # generate an egress password
-    success 500-http-proxy generate_egress_pwd $a0 --osh selfGeneratePassword --do-it
+    success generate_egress_pwd $a0 --osh selfGeneratePassword --do-it
     json .command selfGeneratePassword .error_code OK .value.account $account0 .value.context account
 
     # and retry
-    script 500-http-proxy bad_certificate "curl -ski -H 'X-Bastion-Enforce-Secure: 1' -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script bad_certificate "curl -ski -H 'X-Bastion-Enforce-Secure: 1' -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     # not all versions of LWP add "(certificate verify failed)" at the end of the below error message, so omit it
     contain "HTTP/1.0 500 Can't connect to 127.0.0.1:9443"
@@ -160,7 +160,7 @@ testsuite_proxy()
     contain 'Content-Type: text/plain'
     contain "Can't connect to 127.0.0.1:9443"
 
-    script 500-http-proxy insecure "curl -ski -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script insecure "curl -ski -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain "HTTP/1.0 200 OK"
     contain 'Server: The Bastion'
@@ -181,7 +181,7 @@ testsuite_proxy()
     contain "Content-Length: 64"
 
     # generate 1MB of data
-    script 500-http-proxy one_megabyte "curl -ski -H 'X-Test-Add-Response-Header-Content-Type: application/json' -H 'X-Test-Wanted-Response-Size: 1000000' -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script one_megabyte "curl -ski -H 'X-Test-Add-Response-Header-Content-Type: application/json' -H 'X-Test-Wanted-Response-Size: 1000000' -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain "HTTP/1.0 200 OK"
     contain 'Server: The Bastion'
@@ -202,7 +202,7 @@ testsuite_proxy()
     contain "Content-Length: 1000000"
 
     # use a disallowed verb
-    script 500-http-proxy forbidden_verb "curl -ski -X OPTIONS -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script forbidden_verb "curl -ski -X OPTIONS -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 400 Bad Request (method forbidden)'
     contain 'Server: The Bastion'
@@ -213,7 +213,7 @@ testsuite_proxy()
     contain 'Only GET and POST methods are allowed'
 
     # post some data
-    script 500-http-proxy post_data "curl -ski -d somedata -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script post_data "curl -ski -d somedata -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain "HTTP/1.0 200 OK"
     contain 'Server: The Bastion'

--- a/tests/functional/tests.d/900-strict-checking.sh
+++ b/tests/functional/tests.d/900-strict-checking.sh
@@ -12,25 +12,25 @@ testsuite_strict_checking()
     grant accountCreate
 
     # first we need to create account1
-    success strict-checking a0_create_a1 $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key "\"$(cat $account1key1file.pub)\""
+    success a0_create_a1 $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key "\"$(cat $account1key1file.pub)\""
     json .error_code OK .command accountCreate .value null
 
     revoke accountCreate
     grant accountAddPersonalAccess
 
     # add access to root@127.0.0.1 (there are no keys deployed, but we don't care, connection should fail early due to the hostkey change)
-    success strict-checking add_local_access $a0 --osh accountAddPersonalAccess --account $account1 --host 127.0.0.1 --port 22 --user root
+    success add_local_access $a0 --osh accountAddPersonalAccess --account $account1 --host 127.0.0.1 --port 22 --user root
     json .command accountAddPersonalAccess .error_code OK
 
     revoke accountAddPersonalAccess
 
     # try to connect a first time, so that our bastion known_hosts is populated
-    run strict-checking connect_before $a1 root@127.0.0.1
+    run connect_before $a1 root@127.0.0.1
     retvalshouldbe 255
     contain "Permanently added"
 
     # change the remote hostkeys
-    success strict-checking change_host_keys $r0 "\"find /etc/ssh/ -type f -name 'ssh_host_*' -delete; ssh-keygen -A\""
+    success change_host_keys $r0 "\"find /etc/ssh/ -type f -name 'ssh_host_*' -delete; ssh-keygen -A\""
 
     # set bastion ssh_client config to StrictHostKeyChecking yes
     sshclientconfigchg 's=StrictHostKeyChecking.*=StrictHostKeyChecking\\\\x20yes=g'
@@ -42,7 +42,7 @@ testsuite_strict_checking()
     rm -f $HOME/.ssh/known_hosts
 
     # now try to connect again
-    run strict-checking connect_after $a1 root@127.0.0.1
+    run connect_after $a1 root@127.0.0.1
     retvalshouldbe 255
     contain NASTY
     contain "strict checking"
@@ -51,7 +51,7 @@ testsuite_strict_checking()
 
     # delete account1
     grant accountDelete
-    script strict-checking a0_delete_a1 $a0 --osh accountDelete --account $account1 "<<< \"Yes, do as I say and delete $account1, kthxbye\""
+    script a0_delete_a1 $a0 --osh accountDelete --account $account1 "<<< \"Yes, do as I say and delete $account1, kthxbye\""
     retvalshouldbe 0
     json .command accountDelete .error_code OK
     revoke accountDelete


### PR DESCRIPTION
As tests are now split by modules, the section is autodetected
and taken as the module name, hence a test now only needs a name,
instead of a section & a name.