### PR TITLE
add ``--proactive-mfa`` and mfa/nofa interactive commands

### DIFF
--- a/bin/dev/perlcriticrc
+++ b/bin/dev/perlcriticrc
@@ -42,6 +42,7 @@ packages = Data::Dumper File::Find FindBin Log::Log4perl DBI
 [-Subroutines::ProhibitExcessComplexity]
 [-ValuesAndExpressions::ProhibitConstantPragma]
 [-ValuesAndExpressions::ProhibitEmptyQuotes]
+[-ValuesAndExpressions::ProhibitEscapedCharacters]
 [-ValuesAndExpressions::ProhibitMagicNumbers]
 [-ValuesAndExpressions::ProhibitNoisyQuotes]
 [-Variables::ProhibitPunctuationVars]

--- a/bin/plugin/open/selfMFASetupPassword
+++ b/bin/plugin/open/selfMFASetupPassword
@@ -28,7 +28,7 @@ if (OVH::Bastion::config('accountMFAPolicy')->value eq 'disabled') {
     osh_exit('ERR_DISABLED_BY_POLICY', "Sorry, Multi-Factor Authentication has been disabled by policy on this bastion");
 }
 
-if ($ENV{'OSH_NO_INTERACTIVE'}) {
+if ($ENV{'OSH_IN_INTERACTIVE_SESSION'}) {
     osh_exit('ERR_PRECONDITIONS_FAILED',
         "For security reasons, this plugin can't be used in interactive mode.\nTo ensure you're the owner of the account, please call it the regular way (i.e. --osh $scriptName)");
 }

--- a/bin/plugin/open/selfMFASetupTOTP
+++ b/bin/plugin/open/selfMFASetupTOTP
@@ -30,7 +30,7 @@ if (OVH::Bastion::config('accountMFAPolicy')->value eq 'disabled') {
     osh_exit('ERR_DISABLED_BY_POLICY', "Sorry, Multi-Factor Authentication has been disabled by policy on this bastion");
 }
 
-if ($ENV{'OSH_NO_INTERACTIVE'}) {
+if ($ENV{'OSH_IN_INTERACTIVE_SESSION'}) {
     osh_exit('ERR_PRECONDITIONS_FAILED',
         "For security reasons, this plugin can't be used in interactive mode.\nTo ensure you're the owner of the account, please call it the regular way (i.e. --osh $scriptName)");
 }

--- a/bin/shell/osh.pl
+++ b/bin/shell/osh.pl
@@ -386,7 +386,7 @@ if (not defined $realOptions) {
     }
 }
 
-if (!$quiet && $realm && !$ENV{'OSH_NO_INTERACTIVE'}) {
+if (!$quiet && $realm && !$ENV{'OSH_IN_INTERACTIVE_SESSION'}) {
     my $welcome =
       "You are now connected to " . colored($bastionName, "yellow") . ". Welcome, " . colored($remoteself, "yellow") . ", citizen of the " . colored($realm, "yellow") . " realm!";
     print colored("-" x (length($welcome) - 3 * 9) . "\n", "bold yellow");
@@ -451,7 +451,7 @@ if ($bind) {
     }
 }
 
-if ($interactive and not $ENV{'OSH_NO_INTERACTIVE'}) {
+if ($interactive and not $ENV{'OSH_IN_INTERACTIVE_SESSION'}) {
     if (not $config->{'interactiveModeAllowed'}) {
         main_exit OVH::Bastion::EXIT_INTERACTIVE_DISABLED, "interactive_disabled", "Interactive mode has been disabled on this bastion";
     }

--- a/doc/sphinx/administration/configuration/bastion_conf.rst
+++ b/doc/sphinx/administration/configuration/bastion_conf.rst
@@ -94,6 +94,8 @@ Options to customize the established sessions behaviour
 - `interactiveModeAllowed`_
 - `interactiveModeTimeout`_
 - `interactiveModeByDefault`_
+- `interactiveModeProactiveMFAenabled`_
+- `interactiveModeProactiveMFAexpiration`_
 - `idleLockTimeout`_
 - `idleKillTimeout`_
 - `warnBeforeLockSeconds`_
@@ -657,6 +659,28 @@ interactiveModeByDefault
 :Default: ``true``
 
 If ``true``, drops the user to interactive mode if nothing is specified on the command line. If ``false``, displays the help and exits with an error. Note that for ``true`` to have the expected effect, interactive mode must be enabled (see the ``interactiveModeAllowed`` option above).
+
+.. _interactiveModeProactiveMFAenabled:
+
+interactiveModeProactiveMFAenabled
+**********************************
+
+:Type: ``boolean``
+
+:Default: ``true``
+
+If enabled, the ``mfa`` command is allowed in interactive mode, to trigger a proactive MFA challenge, so that subsequent commands normally requiring MFA won't ask for it again.
+
+.. _interactiveModeProactiveMFAexpiration:
+
+interactiveModeProactiveMFAexpiration
+*************************************
+
+:Type: ``int >= 0 (seconds)``
+
+:Default: ``900``
+
+If the above ``interactiveModeProactiveMFAenabled`` option is ``true``, then this is the amount of seconds after which the proactive MFA mode is automatically disengaged.
 
 .. _idleLockTimeout:
 

--- a/etc/bastion/bastion.conf.dist
+++ b/etc/bastion/bastion.conf.dist
@@ -286,6 +286,16 @@
 #  DEFAULT: true
 "interactiveModeByDefault": true,
 #
+# interactiveModeProactiveMFAenabled (boolean)
+#     DESC: If enabled, the ``mfa`` command is allowed in interactive mode, to trigger a proactive MFA challenge, so that subsequent commands normally requiring MFA won't ask for it again.
+#  DEFAULT: true
+"interactiveModeProactiveMFAenabled": true,
+#
+# interactiveModeProactiveMFAexpiration (int >= 0 (seconds))
+#     DESC: If the above ``interactiveModeProactiveMFAenabled`` option is ``true``, then this is the amount of seconds after which the proactive MFA mode is automatically disengaged.
+#  DEFAULT: 900
+"interactiveModeProactiveMFAexpiration": 900,
+#
 # idleLockTimeout (int >= 0 (seconds))
 #     DESC: If set to a positive value >0, the number of seconds of input idle time after which the session is locked. If ``false``, disabled.
 #  DEFAULT: 0

--- a/lib/perl/OVH/Bastion/configuration.inc
+++ b/lib/perl/OVH/Bastion/configuration.inc
@@ -163,26 +163,27 @@ sub load_configuration {
 
     # 2/6) Options that must be numbers, between min and max.
     foreach my $o (
-        {name => 'accountUidMin',            min => 100,  max => 999_999_999, default => 2000},
-        {name => 'accountUidMax',            min => 100,  max => 999_999_999, default => 99999},
-        {name => 'ttyrecGroupIdOffset',      min => 1,    max => 999_999_999, default => 100_000},
-        {name => 'minimumIngressRsaKeySize', min => 1024, max => 16384,       default => 2048},
-        {name => 'minimumEgressRsaKeySize',  min => 1024, max => 16384,       default => 2048},
-        {name => 'maximumIngressRsaKeySize', min => 1024, max => 32768,       default => 8192},
-        {name => 'maximumEgressRsaKeySize',  min => 1024, max => 32768,       default => 8192},
-        {name => 'moshTimeoutNetwork',       min => 0,    max => 86400 * 365, default => 86400},
-        {name => 'moshTimeoutSignal',        min => 0,    max => 86400 * 365, default => 30},
-        {name => 'idleLockTimeout',          min => 0,    max => 86400 * 365, default => 0},
-        {name => 'idleKillTimeout',          min => 0,    max => 86400 * 365, default => 0},
-        {name => 'warnBeforeLockSeconds',    min => 0,    max => 86400 * 365, default => 0},
-        {name => 'warnBeforeKillSeconds',    min => 0,    max => 86400 * 365, default => 0},
-        {name => 'MFAPasswordInactiveDays',  min => -1,   max => 365 * 5,     default => -1},
-        {name => 'MFAPasswordMinDays',       min => 0,    max => 365 * 5,     default => 0},
-        {name => 'MFAPasswordMaxDays',       min => 0,    max => 365 * 5,     default => 90},
-        {name => 'MFAPasswordWarnDays',      min => 0,    max => 365 * 5,     default => 15},
-        {name => 'sshClientDebugLevel',      min => 0,    max => 3,           default => 0},
-        {name => 'accountMaxInactiveDays',   min => 0,    max => 365 * 5,     default => 0},
-        {name => 'interactiveModeTimeout',   min => 0,    max => 86400 * 365, default => 15},
+        {name => 'accountUidMin',                         min => 100,  max => 999_999_999, default => 2000},
+        {name => 'accountUidMax',                         min => 100,  max => 999_999_999, default => 99999},
+        {name => 'ttyrecGroupIdOffset',                   min => 1,    max => 999_999_999, default => 100_000},
+        {name => 'minimumIngressRsaKeySize',              min => 1024, max => 16384,       default => 2048},
+        {name => 'minimumEgressRsaKeySize',               min => 1024, max => 16384,       default => 2048},
+        {name => 'maximumIngressRsaKeySize',              min => 1024, max => 32768,       default => 8192},
+        {name => 'maximumEgressRsaKeySize',               min => 1024, max => 32768,       default => 8192},
+        {name => 'moshTimeoutNetwork',                    min => 0,    max => 86400 * 365, default => 86400},
+        {name => 'moshTimeoutSignal',                     min => 0,    max => 86400 * 365, default => 30},
+        {name => 'idleLockTimeout',                       min => 0,    max => 86400 * 365, default => 0},
+        {name => 'idleKillTimeout',                       min => 0,    max => 86400 * 365, default => 0},
+        {name => 'warnBeforeLockSeconds',                 min => 0,    max => 86400 * 365, default => 0},
+        {name => 'warnBeforeKillSeconds',                 min => 0,    max => 86400 * 365, default => 0},
+        {name => 'MFAPasswordInactiveDays',               min => -1,   max => 365 * 5,     default => -1},
+        {name => 'MFAPasswordMinDays',                    min => 0,    max => 365 * 5,     default => 0},
+        {name => 'MFAPasswordMaxDays',                    min => 0,    max => 365 * 5,     default => 90},
+        {name => 'MFAPasswordWarnDays',                   min => 0,    max => 365 * 5,     default => 15},
+        {name => 'sshClientDebugLevel',                   min => 0,    max => 3,           default => 0},
+        {name => 'accountMaxInactiveDays',                min => 0,    max => 365 * 5,     default => 0},
+        {name => 'interactiveModeTimeout',                min => 0,    max => 86400 * 365, default => 15},
+        {name => 'interactiveModeProactiveMFAexpiration', min => 0,    max => 86400,       default => 900},
       )
     {
         if (not defined $C->{$o->{'name'}}) {
@@ -234,7 +235,7 @@ sub load_configuration {
             options => [
                 qw{
                   enableSyslog enableGlobalAccessLog enableAccountAccessLog enableGlobalSqlLog enableAccountSqlLog displayLastLogin
-                  interactiveModeByDefault
+                  interactiveModeByDefault interactiveModeProactiveMFAenabled
                   }
             ],
         },

--- a/lib/perl/OVH/Bastion/interactive.inc
+++ b/lib/perl/OVH/Bastion/interactive.inc
@@ -217,7 +217,7 @@ EOM
         }
 
         {
-            local $ENV{'OSH_NO_INTERACTIVE'} = 1;
+            local $ENV{'OSH_IN_INTERACTIVE_SESSION'} = 1;
             if ($line =~ /^ssh (.+)$/) {
                 system($0, '-c', "$realOptions $1");
             }

--- a/lib/perl/OVH/Bastion/interactive.inc
+++ b/lib/perl/OVH/Bastion/interactive.inc
@@ -8,19 +8,12 @@ use POSIX ();
 # autocompletion rules
 my @rules;
 
-sub interactive {
-    my %params         = @_;
-    my $realOptions    = $params{'realOptions'};
-    my $timeoutHandler = $params{'timeoutHandler'};
-    my $self           = $params{'self'};
-    my $fnret;
-
-    my $bastionName            = OVH::Bastion::config('bastionName')->value();
-    my $interactiveModeTimeout = OVH::Bastion::config('interactiveModeTimeout')->value() || 0;
-    my $slaveOrMaster          = (OVH::Bastion::config('readOnlySlaveMode')->value() ? 'slave' : 'master');
-
-    my $term = Term::ReadLine->new('Bastion Interactive');
-    ## no critic(ValuesAndExpressions::ProhibitEscapedCharacters)
+sub get_prompt {
+    my ($self, $bastionName, $slaveOrMaster) = @_;
+    my $mfaOk = "";
+    if ($ENV{'OSH_PROACTIVE_MFA'}) {
+        $mfaOk = "[" . "\001\033[33m\002" . "MFA-OK" . "\001\033[1;35m\002]";
+    }
     my $prompt = ""
       . "\001\033[0m\033[33m\002"
       . $self
@@ -31,11 +24,33 @@ sub interactive {
       . "\001\033[0m\033[36m\002"
       . $slaveOrMaster
       . "\001\033[1;35m\002" . ")"
+      . $mfaOk
       . "\001\033[0m\033[32m\002" . ">"
       . "\001\033[0m\002" . " ";
+    return $prompt;
+}
 
-    my $prompt_non_readline = $prompt;
+sub get_prompt_non_readline {
+    my %info                = @_;
+    my $prompt_non_readline = get_prompt(%info);
     $prompt_non_readline =~ s=\001|\002==g;
+    return $prompt_non_readline;
+}
+
+sub interactive {
+    my %params         = @_;
+    my $realOptions    = $params{'realOptions'};
+    my $timeoutHandler = $params{'timeoutHandler'};
+    my $self           = $params{'self'};
+    my $fnret;
+
+    my $bastionName                           = OVH::Bastion::config('bastionName')->value();
+    my $interactiveModeTimeout                = OVH::Bastion::config('interactiveModeTimeout')->value() || 0;
+    my $slaveOrMaster                         = (OVH::Bastion::config('readOnlySlaveMode')->value() ? 'slave' : 'master');
+    my $interactiveModeProactiveMFAexpiration = OVH::Bastion::config("interactiveModeProactiveMFAexpiration")->value;
+    my $proactiveMFAenabledTime               = 0;
+
+    my $term = Term::ReadLine->new('Bastion Interactive');
 
     print <<"EOM";
 
@@ -51,7 +66,7 @@ EOM
     $fnret or return ();
     my $pluginList = $fnret->value;
 
-    my @cmdlist = qw{ exit ssh };
+    my @cmdlist = qw{ exit ssh mfa enable nomfa end };
     foreach my $plugin (sort keys %$pluginList) {
         $fnret = OVH::Bastion::can_account_execute_plugin(plugin => $plugin, account => $self);
         next if !$fnret;
@@ -180,7 +195,7 @@ EOM
 
             # else, we just print stuff ourselves
             if ($item->{'pr'}) {
-                print "\n" . join("\n", @{$item->{'pr'}}) . "\n$prompt_non_readline$line";
+                print "\n" . join("\n", @{$item->{'pr'}}) . "\n" . get_prompt_non_readline($self, $bastionName, $slaveOrMaster) . $line;
                 return ();
             }
         }
@@ -203,9 +218,17 @@ EOM
 
     my $BASTION_USER = OVH::Bastion::get_user_from_env()->value;
     alarm($interactiveModeTimeout);
-    while (defined(my $line = $term->readline($prompt))) {
+    while (defined(my $line = $term->readline(get_prompt($self, $bastionName, $slaveOrMaster)))) {
         alarm(0);      # disable timeout
         $line =~ s/^\s+|\s+$//g;
+
+        # disable proactive MFA if it has expired. Even if the user just typed "enter" with no command.
+        if ($proactiveMFAenabledTime > 0 && $interactiveModeProactiveMFAexpiration && (time() - $proactiveMFAenabledTime) >= $interactiveModeProactiveMFAexpiration) {
+            print "MFA proactive mode has been disabled after " . OVH::Bastion::duration2human(seconds => $interactiveModeProactiveMFAexpiration)->value->{'duration'} . "\n";
+            $proactiveMFAenabledTime = 0;
+            delete $ENV{'OSH_PROACTIVE_MFA'};
+        }
+
         next if (length($line) == 0);                                    # ignore empty lines
         last if ($line eq 'exit' or $line eq 'quit' or $line eq 'q');    # break out of loop if asked
 
@@ -218,7 +241,46 @@ EOM
 
         {
             local $ENV{'OSH_IN_INTERACTIVE_SESSION'} = 1;
-            if ($line =~ /^ssh (.+)$/) {
+            if (lc($line) eq 'mfa' || $line =~ m{^en(a(b(le?)?)?)?$}) {
+                if (OVH::Bastion::config("interactiveModeProactiveMFAenabled")->value) {
+                    print "As proactive MFA validation has been requested, entering MFA phase.\n";
+                    $fnret = OVH::Bastion::is_bastion_account_valid_and_existing(account => $self);
+                    if (!$fnret) {
+                        warn_syslog("Couldn't get account details in interactive mode (" . $fnret->msg . ")");
+                        main_exit(OVH::Bastion::EXIT_ACCOUNT_INVALID(), "account_invalid", "Error while getting account details");
+                    }
+                    my $sysself = $fnret->value->{'sysaccount'};
+                    $fnret = OVH::Bastion::do_pamtester(self => $self, sysself => $sysself);
+                    if ($fnret) {
+                        print "Proactive MFA enabled, any command requiring MFA from now on will not ask you again.\n";
+                        if ($interactiveModeProactiveMFAexpiration > 0) {
+                            print "This mode will expire in " . OVH::Bastion::duration2human(seconds => $interactiveModeProactiveMFAexpiration)->value->{'human'} . "\n";
+                        }
+                        print "To exit this mode manually, type 'nomfa'.\n";
+                        $proactiveMFAenabledTime = time();
+                        $ENV{'OSH_PROACTIVE_MFA'} = 1;
+                    }
+                    else {
+                        print "MFA validation failed, as a consequence proactive MFA mode is NOT active.\n";
+                        $proactiveMFAenabledTime = 0;
+                        delete $ENV{'OSH_PROACTIVE_MFA'};
+                    }
+                }
+                else {
+                    print "Sorry, proactive MFA validation has been disabled in interactive mode by policy.\n";
+                }
+            }
+            elsif (lc($line) eq 'nomfa' || $line eq 'end') {
+                if ($ENV{'OSH_PROACTIVE_MFA'}) {
+                    print "Your proactive MFA validation has been forgotten.\n";
+                }
+                else {
+                    print "Nothing to do, you didn't proactively validate MFA.\n";
+                }
+                $proactiveMFAenabledTime = 0;
+                delete $ENV{'OSH_PROACTIVE_MFA'};
+            }
+            elsif ($line =~ /^ssh (.+)$/) {
                 system($0, '-c', "$realOptions $1");
             }
             else {


### PR DESCRIPTION
    For bastions using JIT MFA, where MFA can be requested when
    attempting to connect through specific groups, or when using
    some commands, with respect to MFA being enforced at connection
    time directly through the sshd authentication process, one can
    now request MFA validation in advance, to workaround problems
    in commands such as ``clush``  or ``batch``, and interactive mode.
