### PR TITLE
new access option: --force-password <HASH>, to only try one specific password

### DIFF
--- a/bin/helper/osh-accountModifyPersonalAccess
+++ b/bin/helper/osh-accountModifyPersonalAccess
@@ -46,19 +46,20 @@ if (not defined $self) {
 # Fetch command options
 my $fnret;
 my ($result, @optwarns);
-my ($account, $ip, $user, $port, $action, $ttl, $forceKey, $target, $comment);
+my ($account, $ip, $user, $port, $action, $ttl, $forceKey, $forcePassword, $target, $comment);
 eval {
     local $SIG{__WARN__} = sub { push @optwarns, shift };
     $result = GetOptions(
-        "account=s"   => sub { $account  //= $_[1] },
-        "ip=s"        => sub { $ip       //= $_[1] },
-        "user=s"      => sub { $user     //= $_[1] },
-        "port=i"      => sub { $port     //= $_[1] },
-        "action=s"    => sub { $action   //= $_[1] },
-        "ttl=i"       => sub { $ttl      //= $_[1] },
-        "force-key=s" => sub { $forceKey //= $_[1] },
-        "target=s"    => sub { $target   //= $_[1] },
-        "comment=s"   => sub { $comment  //= $_[1] },
+        "account=s"        => sub { $account       //= $_[1] },
+        "ip=s"             => sub { $ip            //= $_[1] },
+        "user=s"           => sub { $user          //= $_[1] },
+        "port=i"           => sub { $port          //= $_[1] },
+        "action=s"         => sub { $action        //= $_[1] },
+        "ttl=i"            => sub { $ttl           //= $_[1] },
+        "force-key=s"      => sub { $forceKey      //= $_[1] },
+        "force-password=s" => sub { $forcePassword //= $_[1] },
+        "target=s"         => sub { $target        //= $_[1] },
+        "comment=s"        => sub { $comment       //= $_[1] },
     );
 };
 if ($@) { die $@ }
@@ -97,15 +98,16 @@ $user and $machine = $user . '@' . $machine;
 
 # access_modify validates all its parameters, don't do it ourselves here for clarity
 $fnret = OVH::Bastion::access_modify(
-    way      => 'personal',
-    account  => $account,
-    action   => $action,
-    user     => $user,
-    ip       => $ip,
-    port     => $port,
-    ttl      => $ttl,
-    forceKey => $forceKey,
-    comment  => $comment,
+    way           => 'personal',
+    account       => $account,
+    action        => $action,
+    user          => $user,
+    ip            => $ip,
+    port          => $port,
+    ttl           => $ttl,
+    forceKey      => $forceKey,
+    forcePassword => $forcePassword,
+    comment       => $comment,
 );
 if ($fnret->err eq 'OK') {
     my $ttlmsg = $ttl ? ' (expires in ' . OVH::Bastion::duration2human(seconds => $ttl)->value->{'human'} . ')' : '';

--- a/bin/helper/osh-groupAddServer
+++ b/bin/helper/osh-groupAddServer
@@ -33,18 +33,20 @@ if (not defined $self) {
 # Fetch command options
 my $fnret;
 my ($result, @optwarns);
-my ($group, $user, $ip, $port, $action, $force, $ttl, $comment);
+my ($group, $user, $ip, $port, $action, $force, $forcePassword, $ttl, $comment);
 eval {
     local $SIG{__WARN__} = sub { push @optwarns, shift };
     $result = GetOptions(
-        "group=s"   => sub { $group   //= $_[1] },    # ignore subsequent --group on cmdline (anti-sudoers-override)
-        "user=s"    => sub { $user    //= $_[1] },
-        "ip=s"      => sub { $ip      //= $_[1] },
-        "port=i"    => sub { $port    //= $_[1] },
-        "action=s"  => sub { $action  //= $_[1] },
-        "force"     => sub { $force   //= $_[1] },
-        "ttl=i"     => sub { $ttl     //= $_[1] },
-        "comment=s" => sub { $comment //= $_[1] },
+        "group=s"          => sub { $group         //= $_[1] },    # ignore subsequent --group on cmdline (anti-sudoers-override)
+        "user=s"           => sub { $user          //= $_[1] },
+        "ip=s"             => sub { $ip            //= $_[1] },
+        "port=i"           => sub { $port          //= $_[1] },
+        "action=s"         => sub { $action        //= $_[1] },
+        "force"            => sub { $force         //= $_[1] },
+        "force-password=s" => sub { $forcePassword //= $_[1] },
+        "ttl=i"            => sub { $ttl           //= $_[1] },
+        "comment=s"        => sub { $comment       //= $_[1] },
+
     );
 };
 if ($@) { die $@ }
@@ -94,20 +96,21 @@ $user and $machine = $user . '@' . $machine;
 
 # access_modify validates all its parameters, don't do it ourselves here for clarity
 $fnret = OVH::Bastion::access_modify(
-    way     => 'group',
-    action  => $action,
-    group   => $group,
-    ip      => $ip,
-    user    => $user,
-    port    => $port,
-    ttl     => $ttl,
-    comment => $comment,
+    way           => 'group',
+    action        => $action,
+    group         => $group,
+    ip            => $ip,
+    user          => $user,
+    port          => $port,
+    forcePassword => $forcePassword,
+    ttl           => $ttl,
+    comment       => $comment,
 );
 if ($fnret->err eq 'OK') {
     my $ttlmsg = $ttl ? ' (expires in ' . OVH::Bastion::duration2human(seconds => $ttl)->value->{'human'} . ')' : '';
     HEXIT(
         'OK',
-        value => {action => $action, group => $shortGroup, ip => $ip, user => $user, port => $port, ttl => $ttl, comment => $comment},
+        value => {action => $action, group => $shortGroup, ip => $ip, user => $user, port => $port, forcePassword => $forcePassword, ttl => $ttl, comment => $comment},
         msg   => $action eq 'add' ? "Entry $machine was added to group $shortGroup$ttlmsg" : "Entry $machine was removed from group $shortGroup$ttlmsg"
     );
 }

--- a/bin/plugin/group-aclkeeper/groupAddServer
+++ b/bin/plugin/group-aclkeeper/groupAddServer
@@ -12,15 +12,16 @@ my $remainingOptions = OVH::Bastion::Plugin::begin(
     argv    => \@ARGV,
     header  => "adding a server to a group",
     options => {
-        "group=s"   => \my $group,
-        "user-any"  => \my $userAny,
-        "port-any"  => \my $portAny,
-        "scpup"     => \my $scpUp,
-        "scpdown"   => \my $scpDown,
-        "force"     => \my $force,      # for slashes, and/or for servers that are down (no connection test)
-        "force-key" => \my $forceKey,
-        "ttl=s"     => \my $ttl,
-        "comment=s" => \my $comment,
+        "group=s"          => \my $group,
+        "user-any"         => \my $userAny,
+        "port-any"         => \my $portAny,
+        "scpup"            => \my $scpUp,
+        "scpdown"          => \my $scpDown,
+        "force"            => \my $force,           # for slashes, and/or for servers that are down (no connection test)
+        "force-key"        => \my $forceKey,
+        "force-password=s" => \my $forcePassword,
+        "ttl=s"            => \my $ttl,
+        "comment=s"        => \my $comment,
     },
     helptext => <<'EOF',
 Add an IP or IP block to a group's servers list
@@ -38,6 +39,7 @@ Usage: --osh SCRIPT_NAME --group GROUP [OPTIONS]
   --scpdown                Allow SCP download, you<--bastion--server (omit --user in this case)
   --force                  Don't try the ssh connection, just add the host to the group blindly
   --force-key FINGERPRINT  Only use the key with the specified fingerprint to connect to the server (cf groupInfo)
+  --force-password HASH    Only use the password with the specified hash to connect to the server (cf groupListPasswords)
   --ttl SECONDS|DURATION   Specify a number of seconds (or a duration string, such as "1d7h8m") after which the access will automatically expire
   --comment '"ANY TEXT'"   Add a comment alongside this server
 
@@ -107,6 +109,12 @@ if ($forceKey) {
     $forceKey = $fnret->value->{'fingerprint'};
 }
 
+if ($forcePassword) {
+    $fnret = OVH::Bastion::is_valid_hash(hash => $forcePassword);
+    $fnret or osh_exit $fnret;
+    $forcePassword = $fnret->value->{'hash'};
+}
+
 #
 # Now do it
 #
@@ -115,7 +123,7 @@ $fnret = OVH::Bastion::is_group_aclkeeper(account => $self, group => $shortGroup
 $fnret or osh_exit 'ERR_NOT_GROUP_ACLKEEPER', "Sorry, you must be an aclkeeper of group $shortGroup to be able to add servers to it";
 
 if (not $force) {
-    $fnret = OVH::Bastion::ssh_test_access_way(group => $group, user => $user, port => $port, ip => $ip, forceKey => $forceKey);
+    $fnret = OVH::Bastion::ssh_test_access_way(group => $group, user => $user, port => $port, ip => $ip, forceKey => $forceKey, forcePassword => $forcePassword);
     if ($fnret->is_ok and $fnret->err ne 'OK') {
 
         # we have something to say, say it
@@ -138,13 +146,14 @@ if (!$comment && $host ne $ip) {
 
 my @command = qw{ sudo -n -u };
 push @command, ($group, '--', '/usr/bin/env', 'perl', '-T', $OVH::Bastion::BASEPATH . '/bin/helper/osh-groupAddServer');
-push @command, '--group',     $group;
-push @command, '--action',    'add';
-push @command, '--ip',        $ip;
-push @command, '--user',      $user if $user;
-push @command, '--port',      $port if $port;
-push @command, '--force-key', $forceKey if $forceKey;
-push @command, '--ttl',       $ttl if $ttl;
-push @command, '--comment',   $comment if $comment;
+push @command, '--group',          $group;
+push @command, '--action',         'add';
+push @command, '--ip',             $ip;
+push @command, '--user',           $user if $user;
+push @command, '--port',           $port if $port;
+push @command, '--force-key',      $forceKey if $forceKey;
+push @command, '--force-password', $forcePassword if $forcePassword;
+push @command, '--ttl',            $ttl if $ttl;
+push @command, '--comment',        $comment if $comment;
 
 osh_exit OVH::Bastion::helper(cmd => \@command);

--- a/bin/plugin/group-aclkeeper/groupAddServer.json
+++ b/bin/plugin/group-aclkeeper/groupAddServer.json
@@ -8,7 +8,10 @@
         "groupAddServer --group \\S+ --host \\S+ --port"                              , {"pr" : ["<PORT>"]},
         "groupAddServer --group \\S+ --host \\S+ --port(-any| \\d+)"                   , {"ac" : ["--user",  "--user-any"]},
         "groupAddServer --group \\S+ --host \\S+ --port(-any| \\d+) --user"            , {"pr" : ["<USER>"]},
-        "groupAddServer --group \\S+ --host \\S+ --port(-any| \\d+) --user(-any| \\S+)" , {"pr" : ["<enter>", "--force"]}
+        "groupAddServer --group \\S+ --host \\S+ --port(-any| \\d+) --user(-any| \\S+)" , {"ac" : ["<enter>", "--force-password", "--force"]},
+        "groupAddServer --group \\S+ --host \\S+ --port(-any| \\d+) --user(-any| \\S+) --force-password" , {"pr" : ["<HASH>"]},
+        "groupAddServer --group \\S+ --host \\S+ --port(-any| \\d+) --user(-any| \\S+) --force-password \\S+" , {"ac" : ["<enter>", "--force"]},
+        "groupAddServer --group \\S+ --host \\S+ --port(-any| \\d+) --user(-any| \\S+) --force-password \\S+ --force" , {"pr" : ["<enter>"]}
     ],
     "master_only": true
 }

--- a/bin/plugin/restricted/accountAddPersonalAccess
+++ b/bin/plugin/restricted/accountAddPersonalAccess
@@ -12,14 +12,15 @@ my $remainingOptions = OVH::Bastion::Plugin::begin(
     argv    => \@ARGV,
     header  => "adding personal access to a server on an account",
     options => {
-        "account=s"   => \my $account,
-        "user-any"    => \my $userAny,
-        "port-any"    => \my $portAny,
-        "scpup"       => \my $scpUp,
-        "scpdown"     => \my $scpDown,
-        "force-key=s" => \my $forceKey,
-        "ttl=s"       => \my $ttl,
-        "comment=s"   => \my $comment,
+        "account=s"        => \my $account,
+        "user-any"         => \my $userAny,
+        "port-any"         => \my $portAny,
+        "scpup"            => \my $scpUp,
+        "scpdown"          => \my $scpDown,
+        "force-key=s"      => \my $forceKey,
+        "force-password=s" => \my $forcePassword,
+        "ttl=s"            => \my $ttl,
+        "comment=s"        => \my $comment,
     },
     helptext => <<'EOF',
 Add a personal server access to an account
@@ -35,6 +36,7 @@ Usage: --osh SCRIPT_NAME --account ACCOUNT --host HOST [OPTIONS]
   --scpup                  Allow SCP upload, you--bastion-->server (omit --user in this case)
   --scpdown                Allow SCP download, you<--bastion--server (omit --user in this case)
   --force-key FINGERPRINT  Only use the key with the specified fingerprint to connect to the server (cf selfListEgressKeys)
+  --force-password HASH    Only use the password with the specified hash to connect to the server (cf accountListPasswords)
   --ttl SECONDS|DURATION   Specify a number of seconds (or a duration string, such as "1d7h8m") after which the access will automatically expire
   --comment "'ANY TEXT'"   Add a comment alongside this server. Quote it twice as shown if you're under a shell.
 
@@ -107,6 +109,12 @@ if ($forceKey) {
     $forceKey = $fnret->value->{'fingerprint'};
 }
 
+if ($forcePassword) {
+    $fnret = OVH::Bastion::is_valid_hash(hash => $forcePassword);
+    $fnret or osh_exit $fnret;
+    $forcePassword = $fnret->value->{'hash'};
+}
+
 osh_info "Can't verify if $account\'s personal key have been installed to the remote server, as you don't have access to his private keys, adding the access blindly";
 
 my @command = qw{ sudo -n -u allowkeeper -- /usr/bin/env perl -T };
@@ -118,6 +126,7 @@ push @command, '--ip', $ip;
 push @command, '--user', $user if $user;
 push @command, '--port', $port if $port;
 push @command, '--force-key', $forceKey if $forceKey;
+push @command, '--force-password', $forcePassword if $forcePassword;
 push @command, '--ttl', $ttl if $ttl;
 push @command, '--comment', $comment if $comment;
 

--- a/bin/plugin/restricted/accountAddPersonalAccess.json
+++ b/bin/plugin/restricted/accountAddPersonalAccess.json
@@ -9,14 +9,21 @@
         "accountAddPersonalAccess --account \\S+ --host \\S+ .*--port" , {"pr" : ["<PORT>"]},
         "accountAddPersonalAccess --account \\S+ --host \\S+ --user \\S+"                          , {"ac" : ["<enter>", "--port"]},
         "accountAddPersonalAccess --account \\S+ --host \\S+ --port \\S+"                          , {"ac" : ["<enter>", "--user"]},
-        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+" , {"ac" : ["--force-key","--ttl","<enter>"]},
+        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+" , {"ac" : ["--force-key","--force-password","--ttl","<enter>"]},
         "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl" , {"pr" : ["<SECONDS>"]},
-        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+" , {"ac" : ["--force-key","<enter>"]},
-        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-key" , {"pr" : ["<enter>"]},
+        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+" , {"ac" : ["--force-key","--force-password","<enter>"]},
+        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-key" , {"pr" : ["<FINGERPRINT>"]},
+        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-key \\S+" , {"pr" : ["<enter>"]},
+        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-password" , {"pr" : ["<HASH>"]},
+        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-password \\S+" , {"pr" : ["<enter>"]},
         "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key" , {"pr" : ["<FINGERPRINT>"]},
         "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key \\S+" , {"ac" : ["--ttl","<enter>"]},
         "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key \\S+ --ttl" , {"pr" : ["<SECONDS>"]},
-        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key \\S+ --ttl \\S+" , {"pr" : ["<enter>"]}
+        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key \\S+ --ttl \\S+" , {"pr" : ["<enter>"]},
+        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password" , {"pr" : ["<HASH>"]},
+        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password \\S+" , {"ac" : ["--ttl","<enter>"]},
+        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password \\S+ --ttl" , {"pr" : ["<SECONDS>"]},
+        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password \\S+ --ttl \\S+" , {"pr" : ["<enter>"]}
     ],
     "master_only": true
 }

--- a/bin/plugin/restricted/accountAddPersonalAccess.json
+++ b/bin/plugin/restricted/accountAddPersonalAccess.json
@@ -13,17 +13,13 @@
         "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl" , {"pr" : ["<SECONDS>"]},
         "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+" , {"ac" : ["--force-key","--force-password","<enter>"]},
         "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-key" , {"pr" : ["<FINGERPRINT>"]},
-        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-key \\S+" , {"pr" : ["<enter>"]},
         "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-password" , {"pr" : ["<HASH>"]},
-        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-password \\S+" , {"pr" : ["<enter>"]},
+        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-(key|password) \\S+" , {"pr" : ["<enter>"]},
         "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key" , {"pr" : ["<FINGERPRINT>"]},
-        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key \\S+" , {"ac" : ["--ttl","<enter>"]},
-        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key \\S+ --ttl" , {"pr" : ["<SECONDS>"]},
-        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key \\S+ --ttl \\S+" , {"pr" : ["<enter>"]},
         "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password" , {"pr" : ["<HASH>"]},
-        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password \\S+" , {"ac" : ["--ttl","<enter>"]},
-        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password \\S+ --ttl" , {"pr" : ["<SECONDS>"]},
-        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password \\S+ --ttl \\S+" , {"pr" : ["<enter>"]}
+        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-(key|password) \\S+" , {"ac" : ["--ttl","<enter>"]},
+        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-(key|password) \\S+ --ttl" , {"pr" : ["<SECONDS>"]},
+        "accountAddPersonalAccess --account \\S+ --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-(key|password) \\S+ --ttl \\S+" , {"pr" : ["<enter>"]}
     ],
     "master_only": true
 }

--- a/bin/plugin/restricted/selfAddPersonalAccess
+++ b/bin/plugin/restricted/selfAddPersonalAccess
@@ -12,14 +12,15 @@ my $remainingOptions = OVH::Bastion::Plugin::begin(
     argv    => \@ARGV,
     header  => "adding personal access to a server on your account",
     options => {
-        "user-any"    => \my $userAny,
-        "port-any"    => \my $portAny,
-        "scpup"       => \my $scpUp,
-        "scpdown"     => \my $scpDown,
-        "force-key=s" => \my $forceKey,
-        "force"       => \my $force,
-        "ttl=s"       => \my $ttl,
-        "comment=s"   => \my $comment,
+        "user-any"         => \my $userAny,
+        "port-any"         => \my $portAny,
+        "scpup"            => \my $scpUp,
+        "scpdown"          => \my $scpDown,
+        "force-key=s"      => \my $forceKey,
+        "force-password=s" => \my $forcePassword,
+        "force"            => \my $force,
+        "ttl=s"            => \my $ttl,
+        "comment=s"        => \my $comment,
     },
     helptext => <<'EOF',
 Add a personal server access on your account
@@ -35,6 +36,7 @@ Usage: --osh SCRIPT_NAME --host HOST [OPTIONS]
   --scpdown                Allow SCP download, you<--bastion--server (omit --user in this case)
   --force                  Add the access without checking that the public SSH key is properly installed remotely
   --force-key FINGERPRINT  Only use the key with the specified fingerprint to connect to the server (cf selfListEgressKeys)
+  --force-password HASH    Only use the password with the specified hash to connect to the server (cf selfListPasswords)
   --ttl SECONDS|DURATION   Specify a number of seconds (or a duration string, such as "1d7h8m") after which the access will automatically expire
   --comment "'ANY TEXT'"   Add a comment alongside this server. Quote it twice as shown if you're under a shell.
 EOF
@@ -95,8 +97,14 @@ if ($forceKey) {
     $forceKey = $fnret->value->{'fingerprint'};
 }
 
+if ($forcePassword) {
+    $fnret = OVH::Bastion::is_valid_hash(hash => $forcePassword);
+    $fnret or osh_exit $fnret;
+    $forcePassword = $fnret->value->{'hash'};
+}
+
 if (not $force) {
-    $fnret = OVH::Bastion::ssh_test_access_way(account => $self, user => $user, port => $port, ip => $ip, forceKey => $forceKey);
+    $fnret = OVH::Bastion::ssh_test_access_way(account => $self, user => $user, port => $port, ip => $ip, forceKey => $forceKey, forcePassword => $forcePassword);
     if ($fnret->is_ok and $fnret->err ne 'OK') {
 
         # we have something to say, say it
@@ -126,6 +134,7 @@ push @command, '--ip', $ip;
 push @command, '--user', $user if $user;
 push @command, '--port', $port if $port;
 push @command, '--force-key', $forceKey if $forceKey;
+push @command, '--force-password', $forcePassword if $forcePassword;
 push @command, '--ttl', $ttl if $ttl;
 push @command, '--comment', $comment if $comment;
 

--- a/bin/plugin/restricted/selfAddPersonalAccess.json
+++ b/bin/plugin/restricted/selfAddPersonalAccess.json
@@ -11,17 +11,13 @@
         "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl" , {"pr" : ["<SECONDS>"]},
         "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+" , {"ac" : ["--force-key","--force-password","<enter>"]},
         "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-key" , {"pr" : ["<FINGERPRINT>"]},
-        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-key \\S+" , {"pr" : ["<enter>"]},
         "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-password" , {"pr" : ["<HASH>"]},
-        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-password \\S+" , {"pr" : ["<enter>"]},
+        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-(key|password) \\S+" , {"pr" : ["<enter>"]},
         "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key" , {"pr" : ["<FINGERPRINT>"]},
-        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key \\S+" , {"ac" : ["--ttl","<enter>"]},
-        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key \\S+ --ttl" , {"pr" : ["<SECONDS>"]},
-        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key \\S+ --ttl \\S+" , {"pr" : ["<enter>"]},
         "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password" , {"pr" : ["<HASH>"]},
-        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password \\S+" , {"ac" : ["--ttl","<enter>"]},
-        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password \\S+ --ttl" , {"pr" : ["<SECONDS>"]},
-        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password \\S+ --ttl \\S+" , {"pr" : ["<enter>"]}
+        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-(key|password) \\S+" , {"ac" : ["--ttl","<enter>"]},
+        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-(key|password) \\S+ --ttl" , {"pr" : ["<SECONDS>"]},
+        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-(key|password) \\S+ --ttl \\S+" , {"ac" : ["<enter>"]}
     ],
     "master_only": true
 }

--- a/bin/plugin/restricted/selfAddPersonalAccess.json
+++ b/bin/plugin/restricted/selfAddPersonalAccess.json
@@ -7,14 +7,21 @@
         "selfAddPersonalAccess --host \\S+ .*--port" , {"pr" : ["<PORT>"]},
         "selfAddPersonalAccess --host \\S+ --user \\S+"                          , {"ac" : ["<enter>", "--port"]},
         "selfAddPersonalAccess --host \\S+ --port \\S+"                          , {"ac" : ["<enter>", "--user"]},
-        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+" , {"ac" : ["--force-key","--ttl","<enter>"]},
+        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+" , {"ac" : ["--force-key","--force-password","--ttl","<enter>"]},
         "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl" , {"pr" : ["<SECONDS>"]},
-        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+" , {"ac" : ["--force-key","<enter>"]},
-        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-key" , {"pr" : ["<enter>"]},
+        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+" , {"ac" : ["--force-key","--force-password","<enter>"]},
+        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-key" , {"pr" : ["<FINGERPRINT>"]},
+        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-key \\S+" , {"pr" : ["<enter>"]},
+        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-password" , {"pr" : ["<HASH>"]},
+        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --ttl \\S+ --force-password \\S+" , {"pr" : ["<enter>"]},
         "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key" , {"pr" : ["<FINGERPRINT>"]},
         "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key \\S+" , {"ac" : ["--ttl","<enter>"]},
         "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key \\S+ --ttl" , {"pr" : ["<SECONDS>"]},
-        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key \\S+ --ttl \\S+" , {"pr" : ["<enter>"]}
+        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-key \\S+ --ttl \\S+" , {"pr" : ["<enter>"]},
+        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password" , {"pr" : ["<HASH>"]},
+        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password \\S+" , {"ac" : ["--ttl","<enter>"]},
+        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password \\S+ --ttl" , {"pr" : ["<SECONDS>"]},
+        "selfAddPersonalAccess --host \\S+ --(port|user) \\S+ --(port|user) \\S+ --force-password \\S+ --ttl \\S+" , {"pr" : ["<enter>"]}
     ],
     "master_only": true
 }

--- a/bin/shell/autologin
+++ b/bin/shell/autologin
@@ -4,8 +4,8 @@
 set ::env(TERM) ""
 
 # we need 6 arguments
-if { [llength $argv] < 7 } {
-    puts "BASTION SAYS: autologin usage error, expected 6 args: <ssh|telnet> <login> <ip> <port> <file_with_password> <timeout> <fallback_delay> [passthrough arguments to ssh or telnet]"
+if { [llength $argv] < 8 } {
+    puts "BASTION SAYS: autologin usage error, expected 6 args: <ssh|telnet> <login> <ip> <port> <file_with_password> <password_id> <timeout> <fallback_delay> [passthrough arguments to ssh or telnet]"
     exit 1
 }
 
@@ -15,9 +15,10 @@ set arg_login          [lindex $argv 1]
 set arg_ip             [lindex $argv 2]
 set arg_port           [lindex $argv 3]
 set arg_file           [lindex $argv 4]
-set arg_timeout        [lindex $argv 5]
-set arg_fallback_delay [lindex $argv 6]
-set arg_remaining      [lrange $argv 7 end]
+set arg_password_id    [lindex $argv 5]
+set arg_timeout        [lindex $argv 6]
+set arg_fallback_delay [lindex $argv 7]
+set arg_remaining      [lrange $argv 8 end]
 
 # start the program
 if { $arg_prog == "ssh" } {
@@ -103,12 +104,18 @@ proc attempt_to_login args {
     exit 5
 }
 
-# try to login with the main password file
+# if no specific pasword was requested, try to login with the main password file, then try the fallbacks
 set tryid 0
-set last_attempt [attempt_to_login $tryid $arg_prog $arg_login $arg_file $arg_fallback_delay $spawn_args]
-while { $last_attempt == 100 && $tryid < 10 } {
-    # auth failed, might want to try with the fallback
-    incr tryid
-    set last_attempt [attempt_to_login $tryid $arg_prog $arg_login "$arg_file.$tryid" $arg_fallback_delay $spawn_args]
+if { $arg_password_id == -1 } {
+    set last_attempt [attempt_to_login $tryid $arg_prog $arg_login $arg_file $arg_fallback_delay $spawn_args]
+    while { $last_attempt == 100 && $tryid < 10 } {
+        # auth failed, might want to try with the fallback
+        incr tryid
+        set last_attempt [attempt_to_login $tryid $arg_prog $arg_login "$arg_file.$tryid" $arg_fallback_delay $spawn_args]
+    }
+} elseif { $arg_password_id == 0 } {
+    set last_attempt [attempt_to_login $tryid $arg_prog $arg_login $arg_file $arg_fallback_delay $spawn_args]
+} else {
+    set last_attempt [attempt_to_login $tryid $arg_prog $arg_login "$arg_file.$arg_password_id" $arg_fallback_delay $spawn_args]
 }
 exit $last_attempt

--- a/bin/shell/osh.pl
+++ b/bin/shell/osh.pl
@@ -1151,7 +1151,7 @@ if ($userPasswordClue) {
         if (
             $grant->{'forcePassword'}
             && (   ($userPasswordContext eq 'self' && $grant->{'type'} eq 'personal')
-                || ($userPasswordContext eq 'group' && $grant->{'type'} eq 'group-member' && $grant->{'group'} eq $userPasswordClue))
+                || ($userPasswordContext eq 'group' && $grant->{'type'} =~ /^group-(member|guest)$/ && $grant->{'group'} eq $userPasswordClue))
           )
         {
 

--- a/bin/shell/osh.pl
+++ b/bin/shell/osh.pl
@@ -1155,6 +1155,7 @@ if ($userPasswordClue) {
           )
         {
 
+            # FIXME: force-password and force-key don't work yet for guest accesses, see #256
             # fetch the hashes of the main password and all its fallbacks
             my $fnrethashes;
             if   ($userPasswordContext eq 'self') { $fnrethashes = OVH::Bastion::get_hashes_list(context => 'account', account => $userPasswordClue); }

--- a/bin/shell/osh.pl
+++ b/bin/shell/osh.pl
@@ -1158,19 +1158,31 @@ if ($userPasswordClue) {
             # FIXME: force-password and force-key don't work yet for guest accesses, see #256
             # fetch the hashes of the main password and all its fallbacks
             my $fnrethashes;
-            if   ($userPasswordContext eq 'self') { $fnrethashes = OVH::Bastion::get_hashes_list(context => 'account', account => $userPasswordClue); }
-            else                                  { $fnrethashes = OVH::Bastion::get_hashes_list(context => 'group',   group   => $userPasswordClue); }
-            if (!$fnrethashes) { main_exit(OVH::Bastion::EXIT_GET_HASH_FAILED, "get_hashes_list", $fnrethashes->msg); }
+            if ($userPasswordContext eq 'self') {
+                $fnrethashes = OVH::Bastion::get_hashes_list(context => 'account', account => $userPasswordClue);
+            }
+            else {
+                $fnrethashes = OVH::Bastion::get_hashes_list(context => 'group', group => $userPasswordClue);
+            }
+
+            if (!$fnrethashes) {
+                main_exit(OVH::Bastion::EXIT_GET_HASH_FAILED, "get_hashes_list", $fnrethashes->msg);
+            }
 
             # is our forced password's hash one of them ?
             for my $id (0 .. $#{$fnrethashes->value}) {
                 foreach my $hash (values(%{$fnrethashes->value->[$id]->{'hashes'}})) {
-                    if ($grant->{'forcePassword'} eq $hash) { $forcePasswordId = $id; print " forcing password with hash: " . $grant->{'forcePassword'} . "\n\n" unless $quiet }
+                    if ($grant->{'forcePassword'} eq $hash) {
+                        $forcePasswordId = $id;
+                        print " forcing password with hash: " . $grant->{'forcePassword'} . "\n\n" unless $quiet;
+                    }
                 }
             }
 
             # if the password was not found, abort
-            if ($forcePasswordId == -1) { main_exit(OVH::Bastion::EXIT_PASSFILE_NOT_FOUND, "forced-password-not-found", "The forced password could not be found"); }
+            if ($forcePasswordId == -1) {
+                main_exit(OVH::Bastion::EXIT_PASSFILE_NOT_FOUND, "forced-password-not-found", "The forced password could not be found");
+            }
         }
     }
 }

--- a/doc/sphinx/plugins/group-aclkeeper/groupAddServer.rst
+++ b/doc/sphinx/plugins/group-aclkeeper/groupAddServer.rst
@@ -55,6 +55,10 @@ Add an IP or IP block to a group's servers list
 
    Only use the key with the specified fingerprint to connect to the server (cf groupInfo)
 
+.. option:: --force-password HASH  
+
+   Only use the password with the specified hash to connect to the server (cf groupListPasswords)
+
 .. option:: --ttl SECONDS|DURATION 
 
    Specify a number of seconds (or a duration string, such as "1d7h8m") after which the access will automatically expire

--- a/doc/sphinx/plugins/restricted/accountAddPersonalAccess.rst
+++ b/doc/sphinx/plugins/restricted/accountAddPersonalAccess.rst
@@ -50,6 +50,10 @@ Add a personal server access to an account
 
    Only use the key with the specified fingerprint to connect to the server (cf selfListEgressKeys)
 
+.. option:: --force-password HASH  
+
+   Only use the password with the specified hash to connect to the server (cf accountListPasswords)
+
 .. option:: --ttl SECONDS|DURATION 
 
    Specify a number of seconds (or a duration string, such as "1d7h8m") after which the access will automatically expire

--- a/doc/sphinx/plugins/restricted/selfAddPersonalAccess.rst
+++ b/doc/sphinx/plugins/restricted/selfAddPersonalAccess.rst
@@ -50,6 +50,10 @@ Add a personal server access on your account
 
    Only use the key with the specified fingerprint to connect to the server (cf selfListEgressKeys)
 
+.. option:: --force-password HASH  
+
+   Only use the password with the specified hash to connect to the server (cf selfListPasswords)
+
 .. option:: --ttl SECONDS|DURATION 
 
    Specify a number of seconds (or a duration string, such as "1d7h8m") after which the access will automatically expire

--- a/lib/perl/OVH/Bastion.pm
+++ b/lib/perl/OVH/Bastion.pm
@@ -93,6 +93,7 @@ use constant {
     EXIT_INVALID_REMOTE_USER         => 127,
     EXIT_INVALID_REMOTE_HOST         => 128,
     EXIT_PIV_REQUIRED                => 129,
+    EXIT_GET_HASH_FAILED             => 130,
 };
 
 use constant {
@@ -143,7 +144,7 @@ my %_autoload_files = (
     os => [
         qw{ sysinfo is_linux is_debian is_redhat is_bsd is_freebsd is_openbsd is_netbsd has_acls sys_useradd sys_groupadd sys_userdel sys_groupdel sys_addmembertogroup sys_delmemberfromgroup sys_changepassword sys_neutralizepassword sys_setpasswordpolicy sys_getpasswordinfo sys_getsudoersfolder sys_setfacl }
     ],
-    password => [qw{ get_hashes_from_password get_hashes_list }],
+    password => [qw{ get_hashes_from_password get_hashes_list is_valid_hash }],
     ssh      => [
         qw{ has_piv_helper verify_piv get_authorized_keys_from_file add_key_to_authorized_keys_file put_authorized_keys_to_file get_ssh_pub_key_info is_valid_public_key get_from_for_user_key generate_ssh_key get_bastion_ips get_supported_ssh_algorithms_list is_allowed_algo_and_size is_valid_fingerprint print_public_key account_ssh_config_get account_ssh_config_set ssh_ingress_keys_piv_apply is_effective_piv_account_policy_enabled }
     ],

--- a/lib/perl/OVH/Bastion/allowdeny.inc
+++ b/lib/perl/OVH/Bastion/allowdeny.inc
@@ -786,14 +786,14 @@ sub is_access_granted {
 
             # the guy must have a guest access but the group itself must also still have access
             if ($grantedGuest && $grantedGroup) {
-                push @grants, {type => 'group-guest', group => $shortGroup, %{$grantedGroup->value}};
+                push @grants, {type => 'group-guest', group => $shortGroup, %{$grantedGuest->value}};
                 osh_debug("is_access_granted: adding grantedGuest to grants because is guest and group has access");
             }
 
             # special legacy case; we also check if account has a legacy access for ip AND that the group ALSO has access to this ip
             if ($grantedLegacy && $grantedGroup) {
                 osh_debug("is_access_granted: adding grantedLegacy to grants because legacy not null and group has access");
-                push @grants, {type => 'group-guest-legacy', group => $shortGroup, %{$grantedGroup->value}};
+                push @grants, {type => 'group-guest-legacy', group => $shortGroup, %{$grantedLegacy->value}};
             }
         }
         else {

--- a/lib/perl/OVH/Bastion/allowdeny.inc
+++ b/lib/perl/OVH/Bastion/allowdeny.inc
@@ -786,14 +786,14 @@ sub is_access_granted {
 
             # the guy must have a guest access but the group itself must also still have access
             if ($grantedGuest && $grantedGroup) {
-                push @grants, {type => 'group-guest', group => $shortGroup, %{$grantedGuest->value}};
+                push @grants, {type => 'group-guest', group => $shortGroup, %{$grantedGroup->value}};
                 osh_debug("is_access_granted: adding grantedGuest to grants because is guest and group has access");
             }
 
             # special legacy case; we also check if account has a legacy access for ip AND that the group ALSO has access to this ip
             if ($grantedLegacy && $grantedGroup) {
                 osh_debug("is_access_granted: adding grantedLegacy to grants because legacy not null and group has access");
-                push @grants, {type => 'group-guest-legacy', group => $shortGroup, %{$grantedLegacy->value}};
+                push @grants, {type => 'group-guest-legacy', group => $shortGroup, %{$grantedGroup->value}};
             }
         }
         else {

--- a/lib/perl/OVH/Bastion/allowdeny.inc
+++ b/lib/perl/OVH/Bastion/allowdeny.inc
@@ -65,7 +65,7 @@ sub get_group_keys {
 # on the access way that is tested. note that for e.g. group accesses, we don't
 # check if a given account has access to the group or not, we just check if the
 # group itself has access. this check must be done by our caller.
-# returns: { match, size, forceKey } for best match, if any
+# returns: { match, size, forceKey, forcePassword } for best match, if any
 sub is_access_way_granted {
     my %params = @_;
 
@@ -98,12 +98,13 @@ sub is_access_way_granted {
 "checking way $way/$account/$group with ignorePort=$ignorePort ignoreUser=$ignoreUser exactIpMatch=$exactIpMatch exactPortMatch=$exactPortMatch exactUserMatch=$exactUserMatch"
     );
 
-    my ($bestMatch, $bestMatchSize, $bestMatchComment, $forceKey);
+    my ($bestMatch, $bestMatchSize, $bestMatchComment, $forceKey, $forcePassword);
     foreach my $entry (@acl) {
-        my $allowedIp     = $entry->{'ip'};         # can be a prefix
-        my $allowedUser   = $entry->{'user'};       # can be undef (if any-user)
-        my $allowedPort   = $entry->{'port'};       # can be undef (if any-port)
-        my $localForceKey = $entry->{'forceKey'};
+        my $allowedIp          = $entry->{'ip'};              # can be a prefix
+        my $allowedUser        = $entry->{'user'};            # can be undef (if any-user)
+        my $allowedPort        = $entry->{'port'};            # can be undef (if any-port)
+        my $localForceKey      = $entry->{'forceKey'};
+        my $localForcePassword = $entry->{'forcePassword'};
 
         osh_debug("checking wanted "
               . (defined $wantedUser ? $wantedUser : '<u>') . '@'
@@ -114,7 +115,7 @@ sub is_access_way_granted {
               . (defined $allowedIp   ? $allowedIp   : '<u>') . ':'
               . (defined $allowedPort ? $allowedPort : '<u>'));
 
-        $allowedIp or next;                         # can't be empty
+        $allowedIp or next;    # can't be empty
 
         # first, check port stuff
         # if we get ignorePort, we skip the checks entirely
@@ -201,6 +202,7 @@ sub is_access_way_granted {
 
             # here, we got a perfect match
             $forceKey         = $localForceKey;
+            $forcePassword    = $localForcePassword;
             $bestMatch        = $allowedIp;
             $bestMatchComment = $entry->{'userComment'};
             $bestMatchSize    = undef;                     # not needed
@@ -217,6 +219,7 @@ sub is_access_way_granted {
                 osh_debug("... we got a slash match !");
                 if (not defined $bestMatchSize or $ipCheck->size() < $bestMatchSize) {
                     $forceKey         = $localForceKey;
+                    $forcePassword    = $localForcePassword;
                     $bestMatch        = $allowedIp;
                     $bestMatchComment = $entry->{'userComment'};
                     $bestMatchSize    = $ipCheck->size();
@@ -229,6 +232,7 @@ sub is_access_way_granted {
             if ($allowedIp eq $wantedIp) {
                 osh_debug("... we got a singleip match !");
                 $forceKey         = $localForceKey;
+                $forcePassword    = $localForcePassword;
                 $bestMatch        = $allowedIp;
                 $bestMatchComment = $entry->{'userComment'};
                 $bestMatchSize    = 1;
@@ -238,7 +242,7 @@ sub is_access_way_granted {
     }
 
     if (defined $bestMatch) {
-        return R('OK', value => {match => $bestMatch, size => $bestMatchSize, forceKey => $forceKey, comment => $bestMatchComment});
+        return R('OK', value => {match => $bestMatch, size => $bestMatchSize, forceKey => $forceKey, forcePassword => $forcePassword, comment => $bestMatchComment});
     }
     return R('KO_ACCESS_DENIED');
 }
@@ -505,7 +509,7 @@ sub print_acls {
     # also take this opportunity to remember the longest field for each column
     my @printRows;
     my @jsonRows;
-    my @columnNames       = qw( IP PORT USER ACCESS-BY ADDED-BY ADDED-AT EXPIRY? COMMENT FORCED-KEY );
+    my @columnNames       = qw( IP PORT USER ACCESS-BY ADDED-BY ADDED-AT EXPIRY? COMMENT FORCED-KEY FORCED-PASSWORD);
     my @printColumnLength = map { length } @columnNames;
     foreach my $contextAcl (@$acls) {
         my $type  = $contextAcl->{'type'};
@@ -519,8 +523,9 @@ sub print_acls {
             my $addedBy   = $entry->{'addedBy'}   || '-';
             my $addedDate = $entry->{'addedDate'} || '-';
             $addedDate = substr($addedDate, 0, 10);
-            my $forceKey = $entry->{'forceKey'} || '-';
-            my $expiry   = $entry->{'expiry'} ? (duration2human(seconds => ($entry->{'expiry'} - time()))->value->{'human'}) : '-';
+            my $forceKey      = $entry->{'forceKey'}      || '-';
+            my $forcePassword = $entry->{'forcePassword'} || '-';
+            my $expiry = $entry->{'expiry'} ? (duration2human(seconds => ($entry->{'expiry'} - time()))->value->{'human'}) : '-';
 
             # resolve reverse if asked for it
             my $ipReverse;
@@ -531,7 +536,8 @@ sub print_acls {
                 $ipReverse       ? $ipReverse       : $entry->{'ip'},
                 $entry->{'port'} ? $entry->{'port'} : '(any)',
                 $entry->{'user'} ? $entry->{'user'} : '(any)',
-                $accessType, $addedBy, $addedDate, $expiry, $entry->{'userComment'} || '-', $forceKey
+                $accessType, $addedBy, $addedDate, $expiry, $entry->{'userComment'} || '-',
+                $forceKey, $forcePassword
             );
 
             # if we have includes or excludes, match fields against the built regex
@@ -638,7 +644,7 @@ sub _is_in_any_net {
 # by calling is_access_way_granted() multiple times with the proper params.
 # it can also add the fullpath of the keys to try for allowed accesses if asked to
 # returns: arrayref of contextualized grants, contextualized-grant: { type, group, $granthashref }
-# granthashref: returned by is_access_way_granted, i.e. { match, size, forceKey }
+# granthashref: returned by is_access_way_granted, i.e. { match, size, forceKey, forcePassword }
 sub is_access_granted {
     my %params = @_;
 
@@ -1026,7 +1032,7 @@ sub get_acls {
 # this function simply returns the requested acl
 # i.e. personal or legacy access of an account, group access, or groupguest access.
 # it just calls get_acl_from_file() with the proper file location
-# returns: arrayref of entries, entry: { ip,user,port,forceKey,addedBy,addedDate,comment }
+# returns: arrayref of entries, entry: { ip,user,port,forceKey,forcePassword,addedBy,addedDate,comment }
 my %_cache_get_acl_way;
 
 sub get_acl_way {
@@ -1160,7 +1166,7 @@ sub _get_acl_from_file {
 
     my @entries;
     foreach my $line (@lines) {
-        my ($ip, $user, $port, $comment, $forceKey, $expiry, $addedBy, $addedDate, $extra, $comment, $userComment);
+        my ($ip, $user, $port, $comment, $forceKey, $forcePassword, $expiry, $addedBy, $addedDate, $extra, $comment, $userComment);
 
         # extract comment if any
         $line =~ s/(#.*)// and $comment = $1;
@@ -1224,6 +1230,15 @@ sub _get_acl_from_file {
                 $forceKey = $fnret->value->{'fingerprint'};
                 osh_debug("found a valid forced key <$forceKey>");
             }
+            if ($comment =~ s/# FORCEPASSWORD=(\S+)//) {
+                $fnret = OVH::Bastion::is_valid_hash(hash => $1);
+                if (!$fnret) {
+                    osh_debug("skipping line <$line> because invalid forcepassword hash ($1) found");
+                    next;
+                }
+                $forcePassword = $fnret->value->{'hash'};
+                osh_debug("found a valid forced password <$forcePassword>");
+            }
             if ($comment =~ s/# COMMENT=<([^>]+)>//) {
                 $userComment = $1;
             }
@@ -1236,15 +1251,16 @@ sub _get_acl_from_file {
 
         push @entries,
           {
-            ip          => $ip,
-            user        => $user,
-            port        => $port,
-            forceKey    => $forceKey,
-            expiry      => $expiry,
-            addedBy     => $addedBy,
-            addedDate   => $addedDate,
-            userComment => $userComment,
-            comment     => $extra,
+            ip            => $ip,
+            user          => $user,
+            port          => $port,
+            forceKey      => $forceKey,
+            forcePassword => $forcePassword,
+            expiry        => $expiry,
+            addedBy       => $addedBy,
+            addedDate     => $addedDate,
+            userComment   => $userComment,
+            comment       => $extra,
           };
     }
 

--- a/lib/perl/OVH/Bastion/allowkeeper.inc
+++ b/lib/perl/OVH/Bastion/allowkeeper.inc
@@ -301,7 +301,8 @@ sub access_modify {
     my $group   = $params{'group'};                                                 # only for way=group or way=groupguest
     my $account = $params{'account'};                                               # only for way=personal
 
-    my $forceKey = $params{'forceKey'};
+    my $forceKey      = $params{'forceKey'};
+    my $forcePassword = $params{'forcePassword'};
 
     my $fnret;
 
@@ -382,6 +383,13 @@ sub access_modify {
         $fnret = OVH::Bastion::is_valid_fingerprint(fingerprint => $forceKey);
         $fnret or return $fnret;
         $forceKey = $fnret->value->{'fingerprint'};
+    }
+
+    # check password hash
+    if ($forcePassword) {
+        $fnret = OVH::Bastion::is_valid_hash(hash => $forcePassword);
+        $fnret or return $fnret;
+        $forcePassword = $fnret->value->{'hash'};
     }
 
     if ($ttl) {
@@ -486,7 +494,7 @@ sub access_modify {
         my $date         = $t->strftime($fmt);
         my $entryComment = "# $action by $requester on $date";
 
-        # if we're adding it, add comment and potential FORCEKEY
+        # if we're adding it, append other parameters as comments
         if ($action eq 'add') {
 
             $entry .= " $entryComment";
@@ -496,6 +504,9 @@ sub access_modify {
                 # hash is case-sensitive only for new SHA256 format
                 $forceKey = lc($forceKey) if ($forceKey !~ /^sha256:/i);
                 $entry .= " # FORCEKEY=" . $forceKey;
+            }
+            if ($forcePassword) {
+                $entry .= " # FORCEPASSWORD=" . $forcePassword;
             }
             if ($ttl) {
                 $entry .= " # EXPIRY=" . (time() + $ttl);
@@ -559,16 +570,17 @@ sub access_modify {
             severity => 'info',
             type     => 'acl',
             fields   => [
-                ['action',    $params{'action'}],
-                ['type',      $params{'way'}],
-                ['group',     $shortGroup],
-                ['account',   $params{'account'}],
-                ['user',      $params{'user'}],
-                ['ip',        $params{'ip'}],
-                ['port',      $params{'port'}],
-                ['ttl',       $params{'ttl'}],
-                ['force_key', $params{'forceKey'}],
-                ['comment',   $params{'comment'}],
+                ['action',         $params{'action'}],
+                ['type',           $params{'way'}],
+                ['group',          $shortGroup],
+                ['account',        $params{'account'}],
+                ['user',           $params{'user'}],
+                ['ip',             $params{'ip'}],
+                ['port',           $params{'port'}],
+                ['ttl',            $params{'ttl'}],
+                ['force_key',      $params{'forceKey'}],
+                ['force_password', $params{'forcePassword'}],
+                ['comment',        $params{'comment'}],
             ]
         );
         return R('OK', msg => $returnmsg) if $returnmsg;

--- a/lib/perl/OVH/Bastion/password.inc
+++ b/lib/perl/OVH/Bastion/password.inc
@@ -154,4 +154,24 @@ sub get_hashes_list {
     return R('OK', value => \@ret);
 }
 
+sub is_valid_hash {
+    my %params = @_;
+    my $hash   = $params{'hash'};
+
+    if (not $hash) {
+        return R('ERR_MISSING_PARAMETER', msg => "Missing parameter 'hash'");
+    }
+    elsif ($hash =~ /^\$1\$[a-zA-Z0-9]+\$[a-zA-Z0-9\.\/]+$/) {
+        return R('OK', value => {type => 'md5crypt', hash => $hash});
+    }
+    elsif ($hash =~ /^\$5\$[a-zA-Z0-9]+\$[a-zA-Z0-9\.\/]+$/) {
+        return R('OK', value => {type => 'sha256crypt', hash => $hash});
+    }
+    elsif ($hash =~ /^\$6\$[a-zA-Z0-9]+\$[a-zA-Z0-9\.\/]+$/) {
+        return R('OK', value => {type => 'sha512crypt', hash => $hash});
+    }
+    return R('ERR_INVALID_PARAMETER',
+        msg => 'Specified hash is invalid, examples of hashes: $1$Pl44$BEyG04AjjH0TRhLuhAs4A1 $5$8BzocSDA$Hu/FdA/KrFe9HFWvXL4F5csJFxV1HlrLt4c3AOac5N5');
+}
+
 1;

--- a/lib/perl/OVH/Bastion/password.inc
+++ b/lib/perl/OVH/Bastion/password.inc
@@ -161,14 +161,14 @@ sub is_valid_hash {
     if (not $hash) {
         return R('ERR_MISSING_PARAMETER', msg => "Missing parameter 'hash'");
     }
-    elsif ($hash =~ /^\$1\$[a-zA-Z0-9]+\$[a-zA-Z0-9\.\/]+$/) {
-        return R('OK', value => {type => 'md5crypt', hash => $hash});
+    elsif ($hash =~ /^(\$1\$[a-zA-Z0-9]+\$[a-zA-Z0-9\.\/]+)$/) {
+        return R('OK', value => {type => 'md5crypt', hash => $1});
     }
-    elsif ($hash =~ /^\$5\$[a-zA-Z0-9]+\$[a-zA-Z0-9\.\/]+$/) {
-        return R('OK', value => {type => 'sha256crypt', hash => $hash});
+    elsif ($hash =~ /^(\$5\$[a-zA-Z0-9]+\$[a-zA-Z0-9\.\/]+)$/) {
+        return R('OK', value => {type => 'sha256crypt', hash => $1});
     }
-    elsif ($hash =~ /^\$6\$[a-zA-Z0-9]+\$[a-zA-Z0-9\.\/]+$/) {
-        return R('OK', value => {type => 'sha512crypt', hash => $hash});
+    elsif ($hash =~ /^(\$6\$[a-zA-Z0-9]+\$[a-zA-Z0-9\.\/]+)$/) {
+        return R('OK', value => {type => 'sha512crypt', hash => $1});
     }
     return R('ERR_INVALID_PARAMETER',
         msg => 'Specified hash is invalid, examples of hashes: $1$Pl44$BEyG04AjjH0TRhLuhAs4A1 $5$8BzocSDA$Hu/FdA/KrFe9HFWvXL4F5csJFxV1HlrLt4c3AOac5N5');

--- a/tests/functional/tests.d/341-selfaccesses-force-password.sh
+++ b/tests/functional/tests.d/341-selfaccesses-force-password.sh
@@ -56,8 +56,8 @@ testsuite_selfaccesses_force_password()
     fi
 
 
-    # the tests for personal and group access are almost the same
-    for mode in personal group
+    # the tests for personal/group/guest accesses are almost the same
+    for mode in personal group-member group-guest
     do
         # create account1, it will be used to connect to account4
         grant accountCreate
@@ -65,7 +65,7 @@ testsuite_selfaccesses_force_password()
         json .error_code OK .command accountCreate
         revoke accountCreate
 
-        if test $mode = "personal"
+        if [ $mode = "personal" ]
         then
             # in personal mode, we manipulate account1's own personal accesses to connect to account4
             target="--account ${account1}"
@@ -81,8 +81,8 @@ testsuite_selfaccesses_force_password()
             grant accountListPasswords
             grant accountAddPersonalAccess
             grant accountDelPersonalAccess
-        else
-            # in group mode, account1 is a member of group1 and we manipulate group1's accesses to connect to account4
+        else # group-*
+            # in group mode, account1 is a member/guest of group1 and we manipulate group1's accesses to connect to account4
             target="--group ${group1}"
             gen_pass_plugin="groupGeneratePassword"
             list_pass_plugin="groupListPasswords"
@@ -97,9 +97,24 @@ testsuite_selfaccesses_force_password()
             json .error_code OK .command groupCreate
             revoke groupCreate
 
-            # add account1 as member
-            success g1_member_a1 $a0 --osh groupAddMember --group $group1 --account $account1
-            json .error_code OK .command groupAddMember
+            if [ $mode = "group-member" ]
+            then
+                # add account1 as member
+                success g1_member_a1 $a0 --osh groupAddMember --group $group1 --account $account1
+                json .error_code OK .command groupAddMember
+            else # group-guest
+                # add a temporary group server, so we can set the groupAddGuestAccess, the user/host/port are the same for all connections
+                success g1_add_tmpserver $a0 --osh $add_access_plugin $target --host $remote_ip --user $account4 --port $remote_port
+                json .error_code OK .command $add_access_plugin
+
+                # add account1 guest access
+                success g1_guest_a1 $a0 --osh groupAddGuestAccess --group $group1 --account $account1 --host $remote_ip --user $account4 --port $remote_port
+                json .error_code OK .command groupAddGuestAccess
+
+                # remove temporary server
+                success g1_del_tmpserver $a0 --osh $del_access_plugin $target --host $remote_ip --user $account4 --port $remote_port
+                json .error_code OK .command $del_access_plugin
+            fi
         fi
 
         # missing hash
@@ -121,8 +136,14 @@ testsuite_selfaccesses_force_password()
 
         grant accountListAccesses
         success ${mode}_listaccess $a0 --osh accountListAccesses --account $account1
-        contain "FORCED-PASSWORD"
-        json .error_code OK .command accountListAccesses .value[0].acl[0].forcePassword $fake_hash
+        json .error_code OK .command accountListAccesses
+        if [ $mode = "group-guest" ]
+        then
+            nocontain "FORCED-PASSWORD" # guests don't see all accesses infos
+        else
+            contain "FORCED-PASSWORD"
+            json .value[0].acl[0].forcePassword $fake_hash
+        fi
         revoke accountListAccesses
 
         success ${mode}_del_a4_fp_fake $a0 --osh $del_access_plugin $target --host $remote_ip --user $account4 --port $remote_port
@@ -144,8 +165,8 @@ testsuite_selfaccesses_force_password()
         # fetch checksums for a1|g1's second and third egress passwords
         success ${mode}_listpass $a0 --osh $list_pass_plugin $target
         json .error_code OK .command $list_pass_plugin
-        password2_sha256=$(get_json |  jq '.value[1].hashes.sha256crypt' | sed -e 's/"//g')
-        password3_sha256=$(get_json |  jq '.value[2].hashes.sha256crypt' | sed -e 's/"//g')
+        password2_sha256=$(get_json | jq -r '.value[1].hashes.sha256crypt')
+        password3_sha256=$(get_json | jq -r '.value[2].hashes.sha256crypt')
 
         # account1 => account4 *without* force-password: success because the correct password is one of the fallbacks
         success ${mode}_add_a4_nofp $a0 --osh $add_access_plugin $target --host $remote_ip --user $account4 --port $remote_port

--- a/tests/functional/tests.d/341-selfaccesses-force-password.sh
+++ b/tests/functional/tests.d/341-selfaccesses-force-password.sh
@@ -1,0 +1,239 @@
+# vim: set filetype=sh ts=4 sw=4 sts=4 et:
+# shellcheck shell=bash
+# shellcheck disable=SC2086,SC2016,SC2046
+# below: convoluted way that forces shellcheck to source our caller
+# shellcheck source=tests/functional/launch_tests_on_instance.sh
+. "$(dirname "${BASH_SOURCE[0]}")"/dummy
+
+testsuite_selfaccesses_force_password()
+{
+    # create account4, it will be used as an egress target to test password connections
+    grant accountCreate
+    success a4_create $a0 --osh accountCreate --always-active --account $account4 --uid $uid4 --public-key "\"$(cat $account4key1file.pub)\""
+    json .error_code OK .command accountCreate
+    revoke accountCreate
+
+    # set account4 to require a password
+    grant accountModify
+    success a4_setup_passreq $a0 --osh accountModify --account $account4 --mfa-password-required yes
+    json .error_code OK .command accountModify .value.mfa_password_required.error_code OK
+    revoke accountModify
+
+    # set a4's ingress password
+    a4_password="276r8q76ZF5Y3"
+    run a4_setup_pass_1of2 $a4f --osh selfMFASetupPassword --yes
+    retvalshouldbe 124
+    contain 'enter this:'
+    a4_password_tmp=$(get_stdout | grep -Eo 'enter this: [a-zA-Z0-9_-]+' | sed -e 's/enter this: //')
+    script a4_setup_pass_2of2 "echo 'set timeout 30; \
+        spawn $a4 --osh selfMFASetupPassword --yes; \
+        expect \":\" { sleep 0.2; send \"$a4_password_tmp\\n\"; }; \
+        expect \":\" { sleep 0.2; send \"$a4_password\\n\"; }; \
+        expect \":\" { sleep 0.2; send \"$a4_password\\n\"; }; \
+        expect eof; \
+        lassign [wait] pid spawnid value value; \
+        exit \$value' | expect -f -"
+    retvalshouldbe 0
+    unset a4_password_tmp
+    nocontain 'enter this:'
+    nocontain 'unchanged'
+    nocontain 'sorry'
+    json .error_code OK .command selfMFASetupPassword
+
+    # disable account4's pubkey requirement because autologin doesn't handle that
+    grant accountModify
+    success a4_unset_pubkey $a0 --osh accountModify --account $account4 --pubkey-auth-optional yes
+    json .error_code OK .command accountModify .value.pubkey_auth_optional.error_code OK
+    revoke accountModify
+
+    # on non-mfa systems, temporarily update sshd's config to accept passwords for account4
+    if [ "${capabilities[mfa]}" = 0 ] && [ "${capabilities[mfa-password]}" = 0 ]
+    then
+        success sshd_config_backup $r0 "\"cp -a /etc/ssh/sshd_config /etc/ssh/sshd_config.bak\""
+        success sshd_config_patch $r0 "\"sed -i 's/^ChallengeResponseAuthentication no/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config\""
+        success sshd_config_patch $r0 "\"echo -e 'Match User ${account4}\n  KbdInteractiveAuthentication yes\n  AuthenticationMethods keyboard-interactive' >> /etc/ssh/sshd_config\""
+        success sshd_reload $r0 "\"pkill -SIGHUP -f '^(/usr/sbin/sshd\\\$|sshd.+listener)'\""
+    fi
+
+
+    # the tests for personal and group access are almost the same
+    for mode in personal group
+    do
+        # create account1, it will be used to connect to account4
+        grant accountCreate
+        success a1_create $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key "\"$(cat $account1key1file.pub)\""
+        json .error_code OK .command accountCreate
+        revoke accountCreate
+
+        if test $mode = "personal"
+        then
+            # in personal mode, we manipulate account1's own personal accesses to connect to account4
+            target="--account ${account1}"
+            gen_pass_plugin="accountGeneratePassword"
+            list_pass_plugin="accountListPasswords"
+            add_access_plugin="accountAddPersonalAccess"
+            del_access_plugin="accountDelPersonalAccess"
+            password_switch="-P"
+            password_base_path="/home/${account1}/pass/${account1}"
+
+            # a few rights are needed
+            grant accountGeneratePassword
+            grant accountListPasswords
+            grant accountAddPersonalAccess
+            grant accountDelPersonalAccess
+        else
+            # in group mode, account1 is a member of group1 and we manipulate group1's accesses to connect to account4
+            target="--group ${group1}"
+            gen_pass_plugin="groupGeneratePassword"
+            list_pass_plugin="groupListPasswords"
+            add_access_plugin="groupAddServer"
+            del_access_plugin="groupDelServer"
+            password_switch="--password ${group1}"
+            password_base_path="/home/key${group1}/pass/${group1}"
+
+            # create group1
+            grant groupCreate
+            success g1_create $a0 --osh groupCreate --group $group1 --owner $account0 --no-key
+            json .error_code OK .command groupCreate
+            revoke groupCreate
+
+            # add account1 as member
+            success g1_member_a1 $a0 --osh groupAddMember --group $group1 --account $account1
+            json .error_code OK .command groupAddMember
+        fi
+
+        # missing hash
+        run ${mode}_add_a4_fp_nohash $a0 --osh $add_access_plugin $target --host $remote_ip --user $account4 --port $remote_port --force-password
+        retvalshouldbe 100
+        contain "Option force-password requires an argument"
+        json .error_code ERR_BAD_OPTIONS .command $add_access_plugin
+
+        # invalid hash
+        run ${mode}_add_a4_fp_invalidhash $a0 --osh $add_access_plugin $target --host $remote_ip --user $account4 --port $remote_port --force-password "invalid"
+        retvalshouldbe 100
+        contain "Specified hash is invalid"
+        json .error_code ERR_INVALID_PARAMETER .command $add_access_plugin
+
+        # test if the forced password appears in the access list
+        fake_hash='$5$fakefake$fakefakefakefakefakefakefakefakefakefakefak'
+        success ${mode}_add_a4_fp_fake $a0 --osh $add_access_plugin $target --host $remote_ip --user $account4 --port $remote_port --force-password "'${fake_hash}'"
+        json .error_code OK .command $add_access_plugin
+
+        grant accountListAccesses
+        success ${mode}_listaccess $a0 --osh accountListAccesses --account $account1
+        contain "FORCED-PASSWORD"
+        json .error_code OK .command accountListAccesses .value[0].acl[0].forcePassword $fake_hash
+        revoke accountListAccesses
+
+        success ${mode}_del_a4_fp_fake $a0 --osh $del_access_plugin $target --host $remote_ip --user $account4 --port $remote_port
+        json .error_code OK .command $del_access_plugin
+
+        # add a few egress passwords to account1|group1
+        success ${mode}_gen_pass1 $a0 --osh $gen_pass_plugin $target --do-it
+        json .error_code OK .command $gen_pass_plugin
+        success ${mode}_gen_pass2 $a0 --osh $gen_pass_plugin $target --do-it
+        json .error_code OK .command $gen_pass_plugin
+        success ${mode}_gen_pass3 $a0 --osh $gen_pass_plugin $target --do-it
+        json .error_code OK .command $gen_pass_plugin
+        success ${mode}_gen_pass4 $a0 --osh $gen_pass_plugin $target --do-it
+        json .error_code OK .command $gen_pass_plugin
+
+        # overwrite a1|g1's second egress password with account4's ingress password
+        success ${mode}_overwrite_pass2 $r0 "\"echo ${a4_password} > ${password_base_path}.1\""
+
+        # fetch checksums for a1|g1's second and third egress passwords
+        success ${mode}_listpass $a0 --osh $list_pass_plugin $target
+        json .error_code OK .command $list_pass_plugin
+        password2_sha256=$(get_json |  jq '.value[1].hashes.sha256crypt' | sed -e 's/"//g')
+        password3_sha256=$(get_json |  jq '.value[2].hashes.sha256crypt' | sed -e 's/"//g')
+
+        # account1 => account4 *without* force-password: success because the correct password is one of the fallbacks
+        success ${mode}_add_a4_nofp $a0 --osh $add_access_plugin $target --host $remote_ip --user $account4 --port $remote_port
+        json .error_code OK .command $add_access_plugin
+
+        success ${mode}_connect_a4_nofp $a1 $account4@$remote_ip $password_switch -- --osh help --json-greppable
+        contain "will use SSH with password autologin"
+        contain "trying with fallback password 1 after sleeping"
+        nocontain "trying with fallback password 2 after sleeping"
+        nocontain "forcing password with hash"
+        json .error_code OK .command help
+
+        success ${mode}_del_a4_nofp $a0 --osh $del_access_plugin $target --host $remote_ip --user $account4 --port $remote_port
+        json .error_code OK .command $del_access_plugin
+
+        # account1 => account4 with force-password but with a non existant hash: fail because --force-password aborts when the forced password cannot be found
+        success ${mode}_add_a4_fp_hashnotfound $a0 --osh $add_access_plugin $target --host $remote_ip --user $account4 --port $remote_port --force-password "'${fake_hash}'"
+        json .error_code OK .command $add_access_plugin
+
+        run ${mode}_connect_a4_fp_hashnotfound $a1 $account4@$remote_ip $password_switch -- --osh help
+        retvalshouldbe 108
+        json .error_code KO_FORCED-PASSWORD-NOT-FOUND
+        nocontain "will use SSH with password autologin"
+
+        success ${mode}_del_a4_fp_hashnotfound $a0 --osh $del_access_plugin $target --host $remote_ip --user $account4 --port $remote_port
+        json .error_code OK .command $del_access_plugin
+
+        # account1 => account4 with force-password and an existing but wrong hash: autologin fails because it's the wrong password
+        success ${mode}_add_a4_fp_wrong $a0 --osh $add_access_plugin $target --host $remote_ip --user $account4 --port $remote_port --force-password "'${password3_sha256}'"
+        json .error_code OK .command $add_access_plugin
+
+        run ${mode}_connect_a4_fp_wrong $a1 $account4@$remote_ip $password_switch -- --osh help
+        retvalshouldbe 100
+        contain "forcing password with hash: ${password3_sha256}"
+        contain "will use SSH with password autologin"
+        contain "authentication failed"
+        nocontain "trying with fallback password 1 after sleeping"
+
+        success ${mode}_del_a4_fp_wrong $a0 --osh $del_access_plugin $target --host $remote_ip --user $account4 --port $remote_port
+        json .error_code OK .command $del_access_plugin
+
+        # account1 => account4 with force-password and the correct hash: success
+        success ${mode}_add_a4_fp_ok $a0 --osh $add_access_plugin $target --host $remote_ip --user $account4 --port $remote_port --force-password "'${password2_sha256}'"
+        json .error_code OK .command $add_access_plugin
+
+        success ${mode}_connect_a4_fp_ok $a1 $account4@$remote_ip $password_switch -- --osh help --json-greppable
+        contain "forcing password with hash: ${password2_sha256}"
+        contain "will use SSH with password autologin"
+        nocontain "trying with fallback password 1 after sleeping"
+        json .error_code OK .command help
+
+        success ${mode}_del_a4_fp_ok $a0 --osh $del_access_plugin $target --host $remote_ip --user $account4 --port $remote_port
+        json .error_code OK .command $del_access_plugin
+
+        # cleanup
+        if test $mode = "personal"
+        then
+            revoke accountGeneratePassword
+            revoke accountListPasswords
+            revoke accountAddPersonalAccess
+            revoke accountDelPersonalAccess
+        else
+            grant groupDelete
+            success ${mode}_delete_g1 $a0 --osh groupDelete --group $group1 --no-confirm
+            json .error_code OK .command groupDelete
+            revoke groupDelete
+        fi
+
+        # cleanup account1
+        grant accountDelete
+        success ${mode}_delete_a1 $a0 --osh accountDelete --account $account1 --no-confirm
+        json .error_code OK .command accountDelete
+        revoke accountDelete
+    done
+
+    # final cleanup
+    grant accountDelete
+    success a4_delete $a0 --osh accountDelete --account $account4 --no-confirm
+    json .error_code OK .command accountDelete
+    revoke accountDelete
+
+    # restore sshd_config on non-mfa systems
+    if [ "${capabilities[mfa]}" = 0 ] && [ "${capabilities[mfa-password]}" = 0 ]
+    then
+        success sshd_config_restore $r0 "\"mv -f /etc/ssh/sshd_config.bak /etc/ssh/sshd_config\""
+        success sshd_reload $r0 "\"pkill -SIGHUP -f '^(/usr/sbin/sshd\\\$|sshd.+listener)'\""
+    fi
+
+}
+
+testsuite_selfaccesses_force_password


### PR DESCRIPTION
This is like --force-key, but for passwords

When this option is set, instead of autologin trying all the passwords until one works, only the one matching the hash is tried
If no password matches the hash then it aborts

This works for both personal accesses and group accesses
