### PR TITLE
fix: typo in the 'alive' command

### DIFF
--- a/bin/plugin/open/alive
+++ b/bin/plugin/open/alive
@@ -14,7 +14,7 @@ my $remainingOptions = OVH::Bastion::Plugin::begin(
     header   => "ping until host is alive",
     options  => {},
     helptext => <<'EOF',
-Ping a host and exist as soon as it answers
+Ping a host and exit as soon as it answers
 
 This command can be used to monitor a host that is expected to go back online soon.
 Note that if you want to ssh to it afterwards, you can simply use the ``--wait`` main option.

--- a/doc/sphinx/plugins/open/alive.rst
+++ b/doc/sphinx/plugins/open/alive.rst
@@ -2,8 +2,8 @@
 alive
 ======
 
-Ping a host and exist as soon as it answers
-===========================================
+Ping a host and exit as soon as it answers
+==========================================
 
 
 This command can be used to monitor a host that is expected to go back online soon.


### PR DESCRIPTION
Hello,

Small pull-request to fix a typo in the `alive` command.