### PR TITLE
[Doc] Update ovh.com/blog links

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -21,7 +21,7 @@ system user, and same goes for the group private keys. This way, even if the
 code is tricked to allow access when it shouldn't have (flawed logic or bug),
 then the OS will still deny reading the key file.
 
-This concept has been explained in the [Blog Post #3 - Security at the Core](https://www.ovh.com/blog/the-bastion-part-3-security-at-the-core/).
+This concept has been explained in the [Blog Post #3 - Security at the Core](https://blog.ovhcloud.com/the-bastion-part-3-security-at-the-core/).
 
 ## Zero trust between portions of code running at different permission levels
 
@@ -37,4 +37,4 @@ run under perl tainted mode.
 Helpers communicate back their result using JSON, which is then read from
 the plugin (the unprivileged portion of code), and parsed.
 
-This concept has been explained in the [Blog Post #3 - Security at the Core](https://www.ovh.com/blog/the-bastion-part-3-security-at-the-core/).
+This concept has been explained in the [Blog Post #3 - Security at the Core](https://blog.ovhcloud.com/the-bastion-part-3-security-at-the-core/).

--- a/doc/sphinx/faq.rst
+++ b/doc/sphinx/faq.rst
@@ -42,7 +42,7 @@ It can be a highly successful if done very carefully, with a lot of security and
 certificates delivery workflows. Managing a CA correctly is no joke and can bite you quite hard if done improperly.
 This also happens to be a somewhat recent addition to OpenSSH, and if you have a lot of heterogeneous
 systems to handle, this might be a no-go.
-You can read more about this topic here: https://www.ovh.com/blog/the-ovhcloud-bastion-part-1/
+You can read more about this topic here: https://blog.ovhcloud.com/the-ovhcloud-bastion-part-1/
 
 What does `osh` mean in ``--osh``?
 ==================================

--- a/doc/sphinx/presentation/principles.rst
+++ b/doc/sphinx/presentation/principles.rst
@@ -6,7 +6,7 @@ Principles
    Most of the principles of The Bastion are well explained in the **Part 2** of the blog post
    that announced the release. The links are below.
 
-- `Part 1 - Genesis <https://www.ovh.com/blog/the-ovhcloud-bastion-part-1/>`_
-- `Part 2 - Delegation Dizziness <https://www.ovh.com/blog/the-ovhcloud-ssh-bastion-part-2-delegation-dizziness/>`_
-- `Part 3 - Security at the Core <https://www.ovh.com/blog/the-bastion-part-3-security-at-the-core/>`_
-- `Part 4 - A new era <https://www.ovh.com/blog/the-bastion-part-4-a-new-era/>`_
+- `Part 1 - Genesis <https://blog.ovhcloud.com/the-ovhcloud-bastion-part-1/>`_
+- `Part 2 - Delegation Dizziness <https://blog.ovhcloud.com/the-ovhcloud-ssh-bastion-part-2-delegation-dizziness/>`_
+- `Part 3 - Security at the Core <https://blog.ovhcloud.com/the-bastion-part-3-security-at-the-core/>`_
+- `Part 4 - A new era <https://blog.ovhcloud.com/the-bastion-part-4-a-new-era/>`_

--- a/doc/sphinx/using/basics/access_management.rst
+++ b/doc/sphinx/using/basics/access_management.rst
@@ -7,7 +7,7 @@ to understand those two ways because they're complementary.
 
 .. note::
    This section is largely inspired from the `blog post about the subject
-   <https://www.ovh.com/blog/the-ovhcloud-ssh-bastion-part-2-delegation-dizziness/>`_
+   <https://blog.ovhcloud.com/the-ovhcloud-ssh-bastion-part-2-delegation-dizziness/>`_
 
 The main idea is that delegation is at the core of the system: everybody has their own set of responsibilities,
 and potential actions, without having to ask the bastion admin.


### PR DESCRIPTION
Actual links are broken, this update now uses blog.ovhcloud.com