### PR TITLE
fix: when no command-line is passed, a warn could be emitted in some …

### DIFF
--- a/bin/shell/osh.pl
+++ b/bin/shell/osh.pl
@@ -346,7 +346,7 @@ else {
 
 my $remainingOptions;
 ($result, $remainingOptions) = GetOptionsFromString(
-    $beforeOptions,
+    $beforeOptions // "",
     "port|p=i"        => \my $optPort,
     "verbose+"        => \my $verbose,
     "tty|t"           => \my $tty,


### PR DESCRIPTION
…cases

This depends on the version of Perl libs, but in any case we shouldn't pass an undef var to GetOptionsFromString, ensure this never happens