### PR TITLE
fix: don't exit with fping host is unreachable

### DIFF
--- a/bin/plugin/open/alive
+++ b/bin/plugin/open/alive
@@ -51,19 +51,18 @@ if (not $host) {
 
 osh_info "Waiting for $host to be alive...";
 my $startedat = Time::HiRes::gettimeofday();
-my $isFping   = 1;
+my $firstLoop = 1;
 my @command   = qw{ fping -- };
 push @command, $host;
 while (1) {
     $fnret = OVH::Bastion::execute(cmd => \@command, noisy_stdout => 1, noisy_stderr => 1);
     if ($fnret->err eq 'ERR_EXEC_FAILED') {
-        if ($isFping) {
-
+        if ($firstLoop) {
             # maybe fping doesn't work, fallback to ping
             @command = qw{ ping -c 1 -w 1 -- };
             push @command, $host;
-            $isFping = 0;
-            next;
+            $firstLoop = 0;
+            next;    # restart the loop to exec ping
         }
         osh_exit $fnret;    # we tried both ping and fping :(
     }
@@ -72,9 +71,6 @@ while (1) {
         my $delay = int(Time::HiRes::gettimeofday() - $startedat);
         osh_info "Alive after waiting for $delay seconds, exiting!";
         osh_ok {waited_for => $delay + 0};
-    }
-    elsif (($isFping && $fnret->value->{'sysret'} >= 3) || ($fnret->value->{'sysret'} > 0)) {
-        osh_exit 'ERR_INTERNAL', "Fatal error returned by (f)ping, aborting";
     }
     sleep 1;
 }

--- a/tests/functional/launch_tests_on_instance.sh
+++ b/tests/functional/launch_tests_on_instance.sh
@@ -654,7 +654,10 @@ sshclientconfigchg()
 
 dump_vars_and_funcs()
 {
-    set | grep -v -E '^(testno|section|code_warn_exclude|COPROC_PID|LINES|COLUMNS|PIPESTATUS|_|BASH_LINENO|basename|case|json|name|tmpscript|grepit|got|isbad|nbfailedgrep)='
+    set | grep -v -E '^('\
+'testno|section|code_warn_exclude|COPROC_PID|LINES|COLUMNS|PIPESTATUS|_|'\
+'BASH_LINENO|basename|case|json|name|tmpscript|grepit|got|isbad|'\
+'nbfailedgrep|shouldbe)='
 }
 
 runtests()

--- a/tests/functional/tests.d/360-plugins.sh
+++ b/tests/functional/tests.d/360-plugins.sh
@@ -93,6 +93,9 @@ EOS
 
     success alive_withoutHost $a0 --osh alive 127.0.0.1
     json .command alive .error_code OK .value.waited_for 0
+
+    run alive_unreachable $a0f --osh alive 192.0.2.0
+    retvalshouldbe 124
 }
 
 testsuite_plugins


### PR DESCRIPTION
As ping can return unknown exit codes for unknown cases, just never bail out to avoid taking bad decisions, as we retry each second maximum, there's no DoS risk