### PR TITLE
feat: add ttyrecStealthStdoutPattern config

### DIFF
--- a/doc/sphinx/administration/configuration/bastion_conf.rst
+++ b/doc/sphinx/administration/configuration/bastion_conf.rst
@@ -65,6 +65,7 @@ Options to customize how logs should be produced.
 - `enableAccountSqlLog`_
 - `ttyrecFilenameFormat`_
 - `ttyrecAdditionalParameters`_
+- `ttyrecStealthStdoutPattern`_
 
 Other ingress policies options
 ------------------------------
@@ -514,6 +515,19 @@ ttyrecAdditionalParameters
 :Example: ``["-s", "This is a message with spaces", "--zstd"]``
 
 Additional parameters you want to pass to ``ttyrec`` invocation. Useful, for example, to enable on-the-fly compression, disable cheatcodes, or set/unset any other ``ttyrec`` option. This is an ARRAY, not a string.
+
+.. _ttyrecStealthStdoutPattern:
+
+ttyrecStealthStdoutPattern
+**************************
+
+:Type: ``regex``
+
+:Default: ``""``
+
+:Example: ``"^rsync --server .+"``
+
+When this is set to a non-falsy value, this is expected to be a string that will be converted to a regex which will be matched against a potential remote command specified when connecting through SSH to a remote server. If the regex matches, then we'll instruct ttyrec to NOT record stdout for this session.
 
 Other ingress policies
 ----------------------

--- a/etc/bastion/bastion.conf.dist
+++ b/etc/bastion/bastion.conf.dist
@@ -216,6 +216,13 @@
 # DEFAULT: []
 "ttyrecAdditionalParameters": [],
 #
+# ttyrecStealthStdoutPattern (regex)
+#
+#  DESC: When this is set to a non-falsy value, this is expected to be a string that will be converted to a regex which will be matched against a potential remote command specified when connecting through SSH to a remote server. If the regex matches, then we'll instruct ttyrec to NOT record stdout for this session.
+# EXAMPLE: "^rsync --server .+"
+# DEFAULT: ""
+"ttyrecStealthStdoutPattern": "",
+#
 ##########################
 # > Other ingress policies
 # >> Policies applying to the ingress connections

--- a/lib/perl/OVH/Bastion.pm
+++ b/lib/perl/OVH/Bastion.pm
@@ -1141,8 +1141,6 @@ sub build_ttyrec_cmdline_part1of2 {
     push @ttyrec, '-v' if $params{'debug'};
     push @ttyrec, '-T', 'always' if $params{'tty'};
     push @ttyrec, '-T', 'never'  if $params{'notty'};
-    push @ttyrec, '--stealth-stdout' if $params{'stealth_stdout'};
-    push @ttyrec, '--stealth-stderr' if $params{'stealth_stderr'};
 
     my $fnret = OVH::Bastion::account_config(
         account => $params{'account'},
@@ -1193,6 +1191,9 @@ sub build_ttyrec_cmdline_part2of2 {
             push @cmd, '--warn-before-kill', $warnBeforeKillSeconds if $warnBeforeKillSeconds;
         }
     }
+
+    push @cmd, '--stealth-stdout' if $params{'stealth_stdout'};
+    push @cmd, '--stealth-stderr' if $params{'stealth_stderr'};
 
     my $ttyrecAdditionalParameters = OVH::Bastion::config('ttyrecAdditionalParameters')->value;
     push @cmd, @$ttyrecAdditionalParameters if @$ttyrecAdditionalParameters;

--- a/lib/perl/OVH/Bastion/configuration.inc
+++ b/lib/perl/OVH/Bastion/configuration.inc
@@ -162,6 +162,7 @@ sub load_configuration {
         {name => 'accountExpiredMessage', default => '', validre => qr/^(.*)$/, emptyok => 1},
         {name => 'fanciness', default => 'full', validre => qr/^((none|boomer)|(basic|millenial)|(full|genz))$/},
         {name => 'accountExternalValidationProgram', default => '', validre => qr'^([a-zA-Z0-9/$_.-]*)$', emptyok => 1},
+        {name => 'ttyrecStealthStdoutPattern', default => '', validre => qr'^(.{0,4096})$', emptyok => 1},
       )
     {
         if (!$C->{$o->{'name'}} && !$o->{'emptyok'}) {


### PR DESCRIPTION
Commands that generate a lot of stdout output and are M2M workflows, such as rsync, can now be excluded from ttyrec to avoid filling up drives