### PR TITLE
fix: adding run command in code to match doc

### DIFF
--- a/docker/devenv/run-tool.sh
+++ b/docker/devenv/run-tool.sh
@@ -89,7 +89,7 @@ Usage: $0 COMMAND [OPTIONS]
   sphinx-view-objects  shows the named objects of the Sphinx documentation that can be referenced
   doc-serve <PORT>     starts a local HTTP python server on PORT to view generated documentation
 
-  bash                 spawn an interactive shell to run any arbitrary command in the devenv docker
+  bash                 spawns an interactive shell to run any arbitrary command in the devenv docker
   run <COMMAND>        run an arbitrary command in the devenv docker
   rebuild              forces the rebuild of the devenv docker image that is needed to run all the above commands
 

--- a/docker/devenv/run-tool.sh
+++ b/docker/devenv/run-tool.sh
@@ -90,7 +90,7 @@ Usage: $0 COMMAND [OPTIONS]
   doc-serve <PORT>     starts a local HTTP python server on PORT to view generated documentation
 
   bash                 spawns an interactive shell to run any arbitrary command in the devenv docker
-  run <COMMAND>        run an arbitrary command in the devenv docker
+  run <COMMAND>        runs an arbitrary command in the devenv docker
   rebuild              forces the rebuild of the devenv docker image that is needed to run all the above commands
 
 EOF

--- a/docker/devenv/run-tool.sh
+++ b/docker/devenv/run-tool.sh
@@ -72,6 +72,7 @@ case "$cmd" in
         fi
         ;;
     bash) docker exec -it $NAME bash;;
+    run) docker exec -it $NAME bash;;
     *)
         cat <<EOF
 Usage: $0 COMMAND [OPTIONS]

--- a/docker/devenv/run-tool.sh
+++ b/docker/devenv/run-tool.sh
@@ -72,7 +72,7 @@ case "$cmd" in
         fi
         ;;
     bash) docker exec -it $NAME bash;;
-    run) docker exec -it $NAME bash;;
+    run) docker exec -it $NAME "$@";;
     *)
         cat <<EOF
 Usage: $0 COMMAND [OPTIONS]
@@ -80,15 +80,18 @@ Usage: $0 COMMAND [OPTIONS]
   COMMAND may be one of the following:
 
   tidy       [FILES..] runs perltidy on several or all the Perl source files, modifying them if needed
-  tidycheck  [FILES..] runs perltidy in dry-run mode, and returns an error if files are not tidy
+  checktidy  [FILES..] runs perltidy in dry-run mode, and returns an error if files are not tidy
   perlcritic           runs perlcritic on all the Perl source files
   shellcheck [FILES..] runs shellcheck on all the shell source files
   lint                 runs tidy, perlcritic and shellcheck on all files in one command
+
   doc                  generates the documentation
   sphinx-view-objects  shows the named objects of the Sphinx documentation that can be referenced
-  rebuild              forces the rebuild of the devenv docker image that is needed to run all the above commands
-  run <COMMAND>        spawn an interactive shell to run any arbitrary command in the devenv docker
   doc-serve <PORT>     starts a local HTTP python server on PORT to view generated documentation
+
+  bash                 spawn an interactive shell to run any arbitrary command in the devenv docker
+  run <COMMAND>        run an arbitrary command in the devenv docker
+  rebuild              forces the rebuild of the devenv docker image that is needed to run all the above commands
 
 EOF
 esac


### PR DESCRIPTION
Hi,
The documentation of the `docker/devenv/run-tool.sh` state that the run command should be used. But it doesn't exist in code. As I understood it was the same behavior as bash command in code so I added it.
Hope it will be helpful.
