### PR TITLE
Adjust etc/pam.d/sshd.rhel configuration

### DIFF
--- a/etc/pam.d/sshd.rhel
+++ b/etc/pam.d/sshd.rhel
@@ -7,11 +7,12 @@
 
 # --- PASSWORD CHECK SECTION
 # proceed in this section ONLY if the user is in group mfa-password-configd, skip it entirely otherwise
-auth       [success=ignore ignore=ignore default=4] pam_succeed_if.so quiet user ingroup mfa-password-configd
+auth       [success=ignore ignore=ignore default=3] pam_succeed_if.so quiet user ingroup mfa-password-configd
 auth       optional                                 pam_echo.so       Your account has Multi-Factor Authentication enabled, an additional authentication factor is required (password).
 auth       optional                                 pam_exec.so       quiet debug stdout /opt/bastion/bin/shell/pam_exec_pwd_info.sh
 # lock account after 6 failures, for 5 minutes
 # ... but disabled, as at least the official CentOS docker images don't seem to have pam_tally nor pam_tally2
+# ... if you uncomment the below line, set the default= line above to default=4 instead of default=3
 #auth       required                                 pam_tally2.so     onerr=fail deny=6 unlock_time=300
 # then check password
 auth       required                                 pam_unix.so


### PR DESCRIPTION
Due to `pam_tally2.so` not being readily available in RHEL/derivatives (base/EPEL), it was commented out of the `pam.d/sshd` template used for RHEL. However, this change didn't take into account the `pam_succeed_if.so` module skipping a specific number of rules, and commenting out this rule without adjusting the `default=` line caused strange behavior in certain configurations.

I adjusted the `default=` line to account for this and added a verbose comment to the template for future people.

The templates for the other distributions look fine.

`Signed-off-by: Cody Robertson <cody@nerdymuffin.com>`