### PR TITLE
Correction of error message and documentation

### DIFF
--- a/bin/plugin/group-gatekeeper/groupAddGuestAccess
+++ b/bin/plugin/group-gatekeeper/groupAddGuestAccess
@@ -47,10 +47,10 @@ Usage: --osh SCRIPT_NAME --group GROUP --account ACCOUNT [OPTIONS]
                               must not specify --user in that case. However, for this protocol to be usable under a given
                               remote user, access to the USER@HOST:PORT tuple must also be allowed.
                               PROTO must be one of:
-                              scpup    allow SCP upload, you--bastion-->server
-                              scpdown  allow SCP download, you<--bastion--server
-                              sftp     allow usage of the SFTP subsystem, through the bastion
-                              rsync    allow usage of rsync, through the bastion
+                              scpupload    allow SCP upload, you--bastion-->server
+                              scpdownload  allow SCP download, you<--bastion--server
+                              sftp         allow usage of the SFTP subsystem, through the bastion
+                              rsync        allow usage of rsync, through the bastion
   --ttl SECONDS|DURATION  Specify a number of seconds after which the access will automatically expire
   --comment '"ANY TEXT"'  Add a comment alongside this access. Quote it twice as shown if you're under a shell.
                             If omitted, we'll use the closest preexisting group access' comment as seen in groupListServers

--- a/bin/plugin/group-gatekeeper/groupDelGuestAccess
+++ b/bin/plugin/group-gatekeeper/groupDelGuestAccess
@@ -44,10 +44,10 @@ Usage: --osh SCRIPT_NAME --group GROUP --account ACCOUNT [OPTIONS]
                               must not specify --user in that case. However, for this protocol to be usable under a given
                               remote user, access to the USER@HOST:PORT tuple must also be allowed.
                               PROTO must be one of:
-                              scpup    allow SCP upload, you--bastion-->server
-                              scpdown  allow SCP download, you<--bastion--server
-                              sftp     allow usage of the SFTP subsystem, through the bastion
-                              rsync    allow usage of rsync, through the bastion
+                              scpupload    allow SCP upload, you--bastion-->server
+                              scpdownload  allow SCP download, you<--bastion--server
+                              sftp         allow usage of the SFTP subsystem, through the bastion
+                              rsync        allow usage of rsync, through the bastion
 
 This command removes, from an existing bastion account, access to a given server, using the
 egress keys of the group. The list of such servers is given by ``groupListGuestAccesses``

--- a/bin/plugin/open/scp
+++ b/bin/plugin/open/scp
@@ -258,8 +258,8 @@ For example:
 
 Please note that you need to be granted for uploading or downloading files
 with scp to/from the remote host, in addition to having the right to SSH to it.
-For a group, the right should be added with --scpup/--scpdown of the groupAddServer command.
-For a personal access, the right should be added with --scpup/--scpdown of the selfAddPersonalAccess command.
+For a group, the right should be added with --protocol scpupload/--protocol scpdownload of the groupAddServer command.
+For a personal access, the right should be added with --protocol scpupload/--protocol scpdownload of the selfAddPersonalAccess command.
 EOF
     osh_ok({script => $base64, "content-encoding" => 'base64-gzip'});
     return 0;

--- a/bin/plugin/restricted/accountAddPersonalAccess
+++ b/bin/plugin/restricted/accountAddPersonalAccess
@@ -46,10 +46,10 @@ Usage: --osh SCRIPT_NAME --account ACCOUNT --host HOST --user USER --port PORT [
                               must not specify --user in that case. However, for this protocol to be usable under a given
                               remote user, access to the USER@HOST:PORT tuple must also be allowed.
                               PROTO must be one of:
-                              scpup    allow SCP upload, you--bastion-->server
-                              scpdown  allow SCP download, you<--bastion--server
-                              sftp     allow usage of the SFTP subsystem, through the bastion
-                              rsync    allow usage of rsync, through the bastion
+                              scpupload    allow SCP upload, you--bastion-->server
+                              scpdownload  allow SCP download, you<--bastion--server
+                              sftp         allow usage of the SFTP subsystem, through the bastion
+                              rsync        allow usage of rsync, through the bastion
   --force-key FINGERPRINT  Only use the key with the specified fingerprint to connect to the server (cf accountListEgressKeys)
   --force-password HASH    Only use the password with the specified hash to connect to the server (cf accountListPasswords)
   --ttl SECONDS|DURATION   Specify a number of seconds (or a duration string, such as "1d7h8m") after which the access will automatically expire

--- a/bin/plugin/restricted/accountDelPersonalAccess
+++ b/bin/plugin/restricted/accountDelPersonalAccess
@@ -40,10 +40,10 @@ Usage: --osh SCRIPT_NAME --account ACCOUNT --host HOST --user USER --port PORT [
   --protocol PROTO         Specify that a special protocol allowance should be removed from this HOST:PORT tuple, note that you
                               must not specify --user in that case.
                               PROTO must be one of:
-                              scpup    allow SCP upload, you--bastion-->server
-                              scpdown  allow SCP download, you<--bastion--server
-                              sftp     allow usage of the SFTP subsystem, through the bastion
-                              rsync    allow usage of rsync, through the bastion
+                              scpupload    allow SCP upload, you--bastion-->server
+                              scpdownload  allow SCP download, you<--bastion--server
+                              sftp         allow usage of the SFTP subsystem, through the bastion
+                              rsync        allow usage of rsync, through the bastion
 EOF
 );
 

--- a/bin/plugin/restricted/selfAddPersonalAccess
+++ b/bin/plugin/restricted/selfAddPersonalAccess
@@ -45,10 +45,10 @@ Usage: --osh SCRIPT_NAME --host HOST --user USER --port PORT [OPTIONS]
                               must not specify --user in that case. However, for this protocol to be usable under a given
                               remote user, access to the USER@HOST:PORT tuple must also be allowed.
                               PROTO must be one of:
-                              scpup    allow SCP upload, you--bastion-->server
-                              scpdown  allow SCP download, you<--bastion--server
-                              sftp     allow usage of the SFTP subsystem, through the bastion
-                              rsync    allow usage of rsync, through the bastion
+                              scpupload    allow SCP upload, you--bastion-->server
+                              scpdownload  allow SCP download, you<--bastion--server
+                              sftp         allow usage of the SFTP subsystem, through the bastion
+                              rsync        allow usage of rsync, through the bastion
   --force                  Add the access without checking that the public SSH key is properly installed remotely
   --force-key FINGERPRINT  Only use the key with the specified fingerprint to connect to the server (cf selfListEgressKeys)
   --force-password HASH    Only use the password with the specified hash to connect to the server (cf selfListPasswords)

--- a/bin/plugin/restricted/selfDelPersonalAccess
+++ b/bin/plugin/restricted/selfDelPersonalAccess
@@ -38,10 +38,10 @@ Usage: --osh SCRIPT_NAME --host HOST --user USER --port PORT [OPTIONS]
   --protocol PROTO         Specify that a special protocol allowance should be removed from this HOST:PORT tuple, note that you
                               must not specify --user in that case.
                               PROTO must be one of:
-                              scpup    allow SCP upload, you--bastion-->server
-                              scpdown  allow SCP download, you<--bastion--server
-                              sftp     allow usage of the SFTP subsystem, through the bastion
-                              rsync    allow usage of rsync, through the bastion
+                              scpupload    allow SCP upload, you--bastion-->server
+                              scpdownload  allow SCP download, you<--bastion--server
+                              sftp         allow usage of the SFTP subsystem, through the bastion
+                              rsync        allow usage of rsync, through the bastion
 EOF
 );
 

--- a/doc/sphinx-plugins-override/scp.override.rst
+++ b/doc/sphinx-plugins-override/scp.override.rst
@@ -22,7 +22,7 @@ Or to recursively download a folder contents::
 
 Please note that you need to be granted for uploading or downloading files
 with scp to/from the remote host, in addition to having the right to SSH to it.
-For a group, the right should be added with ``--scpup``/``--scpdown`` of the :doc:`/plugins/group-aclkeeper/groupAddServer` command.
-For a personal access, the right should be added with ``--scpup``/``--scpdown`` of the :doc:`/plugins/restricted/selfAddPersonalAccess` command.
+For a group, the right should be added with ``--protocol scpupload``/``--protocol scpdownload`` of the :doc:`/plugins/group-aclkeeper/groupAddServer` command.
+For a personal access, the right should be added with ``--protocol scpupload``/``--protocol scpdownload`` of the :doc:`/plugins/restricted/selfAddPersonalAccess` command.
 
 You'll find more information and examples in :doc:`/using/sftp_scp_rsync`.

--- a/doc/sphinx/installation/upgrading.rst
+++ b/doc/sphinx/installation/upgrading.rst
@@ -41,7 +41,7 @@ when using the ``--user`` option for plugins such as ``groupAddServer``, ``group
 ``selfDelPersonalAccess``.
 
 We also deprecate all the ``--sftp``, ``--scpdown``, ``--scpup`` options that are now replaced by a more generic
-``--protocol`` option, which supports ``sftp``, ``scpdown ``, ``scpup`` and now also ``rsync`` as parameters.
+``--protocol`` option, which supports ``sftp``, ``scpdownload``, ``scpupload`` and now also ``rsync`` as parameters.
 The use of rsync is similar to sftp and scp, and is detailed here: :doc:`/plugins/open/rsync`.
 
 Last but not least, the ``sntrup761x25519-sha512@openssh.com`` KEX algorithm is now enabled by default on shipped

--- a/doc/sphinx/plugins/group-gatekeeper/groupAddGuestAccess.rst
+++ b/doc/sphinx/plugins/group-gatekeeper/groupAddGuestAccess.rst
@@ -41,10 +41,10 @@ Add a specific group server access to an account
                               must not specify --user in that case. However, for this protocol to be usable under a given
                               remote user, access to the USER@HOST:PORT tuple must also be allowed.
                               PROTO must be one of:
-                              scpup    allow SCP upload, you--bastion-->server
-                              scpdown  allow SCP download, you<--bastion--server
-                              sftp     allow usage of the SFTP subsystem, through the bastion
-                              rsync    allow usage of rsync, through the bastion
+                              scpupload    allow SCP upload, you--bastion-->server
+                              scpdownload  allow SCP download, you<--bastion--server
+                              sftp         allow usage of the SFTP subsystem, through the bastion
+                              rsync        allow usage of rsync, through the bastion
 .. option:: --ttl SECONDS|DURATION
 
    Specify a number of seconds after which the access will automatically expire

--- a/doc/sphinx/plugins/group-gatekeeper/groupDelGuestAccess.rst
+++ b/doc/sphinx/plugins/group-gatekeeper/groupDelGuestAccess.rst
@@ -40,10 +40,10 @@ Remove a specific group server access from an account
                               must not specify --user in that case. However, for this protocol to be usable under a given
                               remote user, access to the USER@HOST:PORT tuple must also be allowed.
                               PROTO must be one of:
-                              scpup    allow SCP upload, you--bastion-->server
-                              scpdown  allow SCP download, you<--bastion--server
-                              sftp     allow usage of the SFTP subsystem, through the bastion
-                              rsync    allow usage of rsync, through the bastion
+                              scpupload    allow SCP upload, you--bastion-->server
+                              scpdownload  allow SCP download, you<--bastion--server
+                              sftp         allow usage of the SFTP subsystem, through the bastion
+                              rsync        allow usage of rsync, through the bastion
 
 This command removes, from an existing bastion account, access to a given server, using the
 egress keys of the group. The list of such servers is given by ``groupListGuestAccesses``

--- a/doc/sphinx/plugins/open/scp.rst
+++ b/doc/sphinx/plugins/open/scp.rst
@@ -26,7 +26,7 @@ Or to recursively download a folder contents::
 
 Please note that you need to be granted for uploading or downloading files
 with scp to/from the remote host, in addition to having the right to SSH to it.
-For a group, the right should be added with ``--scpup``/``--scpdown`` of the :doc:`/plugins/group-aclkeeper/groupAddServer` command.
-For a personal access, the right should be added with ``--scpup``/``--scpdown`` of the :doc:`/plugins/restricted/selfAddPersonalAccess` command.
+For a group, the right should be added with ``--protocol scpupload``/``--protocol scpdownload`` of the :doc:`/plugins/group-aclkeeper/groupAddServer` command.
+For a personal access, the right should be added with ``--protocol scpupload``/``--protocol scpdownload`` of the :doc:`/plugins/restricted/selfAddPersonalAccess` command.
 
 You'll find more information and examples in :doc:`/using/sftp_scp_rsync`.

--- a/doc/sphinx/plugins/restricted/accountAddPersonalAccess.rst
+++ b/doc/sphinx/plugins/restricted/accountAddPersonalAccess.rst
@@ -36,10 +36,10 @@ Add a personal server access to an account
                               must not specify --user in that case. However, for this protocol to be usable under a given
                               remote user, access to the USER@HOST:PORT tuple must also be allowed.
                               PROTO must be one of:
-                              scpup    allow SCP upload, you--bastion-->server
-                              scpdown  allow SCP download, you<--bastion--server
-                              sftp     allow usage of the SFTP subsystem, through the bastion
-                              rsync    allow usage of rsync, through the bastion
+                              scpupload    allow SCP upload, you--bastion-->server
+                              scpdownload  allow SCP download, you<--bastion--server
+                              sftp         allow usage of the SFTP subsystem, through the bastion
+                              rsync        allow usage of rsync, through the bastion
 .. option:: --force-key FINGERPRINT
 
    Only use the key with the specified fingerprint to connect to the server (cf accountListEgressKeys)

--- a/doc/sphinx/plugins/restricted/accountDelPersonalAccess.rst
+++ b/doc/sphinx/plugins/restricted/accountDelPersonalAccess.rst
@@ -35,7 +35,7 @@ Remove a personal server access from an account
 
                               must not specify --user in that case.
                               PROTO must be one of:
-                              scpup    allow SCP upload, you--bastion-->server
-                              scpdown  allow SCP download, you<--bastion--server
-                              sftp     allow usage of the SFTP subsystem, through the bastion
-                              rsync    allow usage of rsync, through the bastion
+                              scpupload    allow SCP upload, you--bastion-->server
+                              scpdownload  allow SCP download, you<--bastion--server
+                              sftp         allow usage of the SFTP subsystem, through the bastion
+                              rsync        allow usage of rsync, through the bastion

--- a/doc/sphinx/plugins/restricted/selfAddPersonalAccess.rst
+++ b/doc/sphinx/plugins/restricted/selfAddPersonalAccess.rst
@@ -32,10 +32,10 @@ Add a personal server access to your account
                               must not specify --user in that case. However, for this protocol to be usable under a given
                               remote user, access to the USER@HOST:PORT tuple must also be allowed.
                               PROTO must be one of:
-                              scpup    allow SCP upload, you--bastion-->server
-                              scpdown  allow SCP download, you<--bastion--server
-                              sftp     allow usage of the SFTP subsystem, through the bastion
-                              rsync    allow usage of rsync, through the bastion
+                              scpupload    allow SCP upload, you--bastion-->server
+                              scpdownload  allow SCP download, you<--bastion--server
+                              sftp         allow usage of the SFTP subsystem, through the bastion
+                              rsync        allow usage of rsync, through the bastion
 .. option:: --force
 
    Add the access without checking that the public SSH key is properly installed remotely

--- a/doc/sphinx/plugins/restricted/selfDelPersonalAccess.rst
+++ b/doc/sphinx/plugins/restricted/selfDelPersonalAccess.rst
@@ -31,7 +31,7 @@ Remove a personal server access from your account
 
                               must not specify --user in that case.
                               PROTO must be one of:
-                              scpup    allow SCP upload, you--bastion-->server
-                              scpdown  allow SCP download, you<--bastion--server
-                              sftp     allow usage of the SFTP subsystem, through the bastion
-                              rsync    allow usage of rsync, through the bastion
+                              scpupload    allow SCP upload, you--bastion-->server
+                              scpdownload  allow SCP download, you<--bastion--server
+                              sftp         allow usage of the SFTP subsystem, through the bastion
+                              rsync        allow usage of rsync, through the bastion

--- a/doc/sphinx/using/sftp_scp_rsync.rst
+++ b/doc/sphinx/using/sftp_scp_rsync.rst
@@ -83,13 +83,13 @@ To declare an SCP/SFTP/RSYNC access, in addition to a preexisting SSH access, yo
   if the SSH access is personal (tied to an account)
 
 In both cases, where you would use the ``--user`` option to the command, to specify the remote user to use for
-the SSH access being declared, you should replace it by either ``--protocol scpdown``, ``--protocol scpup``,
+the SSH access being declared, you should replace it by either ``--protocol scpdownload``, ``--protocol scpupload``,
 ``--protocol sftp`` or ``--protocol rsync``,
 to specify that you're about to add an SCP/SFTP/RSYNC access (and not a bare SSH one), and which direction you want
 to allow in the case of SCP.
 
-For SCP, you can allow both directions by using the command first with ``--protocol scpdown``,
-then with ``--protocol scpup``.
+For SCP, you can allow both directions by using the command first with ``--protocol scpdownload``,
+then with ``--protocol scpupload``.
 Note that for SFTP and RYSNC, you can't specify a direction, due to how these protocols work: you either have
 SFTP/RSYNC access (hence being able to upload and download files), or you don't.
 

--- a/lib/perl/OVH/Bastion/Plugin/ACL.pm
+++ b/lib/perl/OVH/Bastion/Plugin/ACL.pm
@@ -27,7 +27,8 @@ sub check {
         }
         if (!grep { $protocol eq $_ } qw{ scpupload scpdownload sftp rsync }) {
             return R('ERR_INVALID_PARAMETER',
-                msg => "The protocol '$protocol' is not supported, expected either scpupload, scpdownload, sftp or rsync");
+                msg =>
+                  "The protocol '$protocol' is not supported, expected either scpupload, scpdownload, sftp or rsync");
         }
     }
 

--- a/lib/perl/OVH/Bastion/Plugin/ACL.pm
+++ b/lib/perl/OVH/Bastion/Plugin/ACL.pm
@@ -27,7 +27,7 @@ sub check {
         }
         if (!grep { $protocol eq $_ } qw{ scpupload scpdownload sftp rsync }) {
             return R('ERR_INVALID_PARAMETER',
-                msg => "The protocol '$protocol' is not supported, expected either scpup, scpdown, sftp or rsync");
+                msg => "The protocol '$protocol' is not supported, expected either scpupload, scpdownload, sftp or rsync");
         }
     }
 

--- a/tests/functional/tests.d/395-mfa-scp-sftp-rsync.sh
+++ b/tests/functional/tests.d/395-mfa-scp-sftp-rsync.sh
@@ -125,7 +125,7 @@ EOF
     # scp
 
     success personal_scp_add_ssh_access $a0 --osh selfAddPersonalAccess -h 127.0.0.2 -u $shellaccount -p 22 --kbd-interactive
-    success personal_scp_add_scpup_access $a0 --osh selfAddPersonalAccess --host 127.0.0.2 --scpup --port 22
+    success personal_scp_add_scpup_access $a0 --osh selfAddPersonalAccess --host 127.0.0.2 --protocol scpupload --port 22
 
     sleepafter 2
     run personal_scp_download_oldhelper_mustfail scp $scp_options -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file $shellaccount@127.0.0.2:uptest /tmp/downloaded
@@ -136,7 +136,7 @@ EOF
     retvalshouldbe 1
     contain "Sorry, you have ssh access to"
 
-    success personal_scp_add_scpdown_access $a0 --osh selfAddPersonalAccess --host 127.0.0.2 --scpdown --port 22
+    success personal_scp_add_scpdown_access $a0 --osh selfAddPersonalAccess --host 127.0.0.2 --protocol scpdownload --port 22
 
     sleepafter 2
     run personal_scp_download_oldhelper_badfile scp $scp_options -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file $shellaccount@127.0.0.2:uptest /tmp/downloaded
@@ -177,8 +177,8 @@ EOF
     contain "through the bastion from"
     contain "Done,"
 
-    success personal_scp_del_scpup_access $a0 --osh selfDelPersonalAccess --host 127.0.0.2 --scpup   --port 22
-    success personal_scp_del_scpdown_access $a0 --osh selfDelPersonalAccess --host 127.0.0.2 --scpdown --port 22
+    success personal_scp_del_scpup_access $a0 --osh selfDelPersonalAccess --host 127.0.0.2 --protocol scpupload --port 22
+    success personal_scp_del_scpdown_access $a0 --osh selfDelPersonalAccess --host 127.0.0.2 --protocol scpdownload --port 22
 
     # sftp
 
@@ -208,7 +208,7 @@ EOF
     contain 'sftp> exit'
     contain '>>> Done,'
 
-    success personal_sftp_del_sftp_access $a0 --osh selfDelPersonalAccess --host 127.0.0.2 --sftp --port 22
+    success personal_sftp_del_sftp_access $a0 --osh selfDelPersonalAccess --host 127.0.0.2 --protocol sftp --port 22
 
     # rsync
 
@@ -264,7 +264,7 @@ EOF
     contain 'need to be granted specifically for scpupload'
     nocontain '>>> Done'
 
-    success groupssh_groupprotocol_scp_add_scpup_access $a0 --osh groupAddServer --group $group1 --host 127.0.0.2 --scpup --port 22
+    success groupssh_groupprotocol_scp_add_scpup_access $a0 --osh groupAddServer --group $group1 --host 127.0.0.2 --protocol scpupload --port 22
 
     success groupssh_groupprotocol_scp_upload_ok /tmp/scpwrapper -i $account0key1file /etc/passwd $shellaccount@127.0.0.2:
     contain 'MFA_TOKEN=notrequired'
@@ -277,7 +277,7 @@ EOF
     contain 'need to be granted specifically for scpdownload'
     nocontain '>>> Done'
 
-    success groupssh_groupprotocol_scp_del_scpup_access $a0 --osh groupDelServer --group $group1 --host 127.0.0.2 --scpup --port 22
+    success groupssh_groupprotocol_scp_del_scpup_access $a0 --osh groupDelServer --group $group1 --host 127.0.0.2 --protocol scpupload --port 22
 
     # sftp
 


### PR DESCRIPTION
There were an issue with the error message when trying to add a server with `--protocol scpdown` or  `--protocol scpup` (instead of the correct `--protocol scpdownload` or  `--protocol scpupload`) : 
```
The protocol 'scpup' is not supported, expected either scpup, scpdown, sftp or rsync
```
Similarly the documentation was wrong on the correct syntaxe for those kind of calls.
