### PR TITLE
Implement ssh --forward-agent | -x functionality

### DIFF
--- a/doc/sphinx/administration/configuration/bastion_conf.rst
+++ b/doc/sphinx/administration/configuration/bastion_conf.rst
@@ -140,6 +140,7 @@ These options are either discouraged (in which case this is explained in the des
 - `remoteCommandEscapeByDefault`_
 - `sshClientDebugLevel`_
 - `sshClientHasOptionE`_
+- `sshAddKeysToAgentAllowed`_
 
 Option Reference
 ================
@@ -1063,4 +1064,15 @@ sshClientHasOptionE
 :Default: ``false``
 
 Set to ``true`` if your ssh client supports the ``-E`` option and you want to use it to log debug info on opened sessions. **Discouraged** because it has some annoying side effects (some ssh errors then go silent from the user perspective).
+
+.. _sshAddKeysToAgentAllowed:
+
+sshAddKeysToAgentAllowed
+************************
+
+:Type: ``boolean``
+
+:Default: ``false``
+
+Set to ``true`` if you want to allow to spawn an ssh-agent and forward it over the egress session when specifically requested with the '--forward-agent' or '-x' flag, with the egress key added to the agent. Useful if you need the ssh-key for authentication on other systems (another jumpserver for example). 
 

--- a/doc/sphinx/presentation/features.rst
+++ b/doc/sphinx/presentation/features.rst
@@ -25,6 +25,7 @@ Features
   splitting the authentication and authorization phases while still enforcing local policies
 - Supports SSH password autologin on the egress side for legacy devices not supporting pubkey authentication,
   while still forcing proper pubkey authentication on the ingress side
+- Supports ssh-agent forwarding with the egress ssh key added to the agent
 - Supports telnet password autologin on the egress side for ancient devices not supporting SSH,
   while still forcing proper SSH pubkey authentication on the ingress side
 - Supports HTTPS proxying with man-in-the-middle authentication and authorization handling,

--- a/etc/bastion/bastion.conf.dist
+++ b/etc/bastion/bastion.conf.dist
@@ -492,5 +492,10 @@
 # sshClientHasOptionE (boolean)
 #     DESC: Set to ``true`` if your ssh client supports the ``-E`` option and you want to use it to log debug info on opened sessions. **Discouraged** because it has some annoying side effects (some ssh errors then go silent from the user perspective).
 #  DEFAULT: false
-"sshClientHasOptionE": false
+"sshClientHasOptionE": false,
+#
+# sshAddKeysToAgentAllowed (boolean)
+#     DESC: Set to ``true`` if you want to allow to spawn an ssh-agent and forward it over the egress session when specifically requested with the '--forward-agent' or '-x' flag, with the egress key added to the agent. Useful if you need the ssh-key for authentication on other systems (another jumpserver for example). 
+#  DEFAULT: false
+"sshAddKeysToAgentAllowed": false
 }

--- a/lib/perl/OVH/Bastion/configuration.inc
+++ b/lib/perl/OVH/Bastion/configuration.inc
@@ -275,7 +275,7 @@ sub load_configuration {
                 qw{
                   interactiveModeAllowed readOnlySlaveMode sshClientHasOptionE ingressKeysFromAllowOverride
                   moshAllowed debug keyboardInteractiveAllowed passwordAllowed telnetAllowed remoteCommandEscapeByDefault
-                  accountExternalValidationDenyOnFailure ingressRequirePIV IPv6Allowed
+                  accountExternalValidationDenyOnFailure ingressRequirePIV IPv6Allowed sshAddKeysToAgentAllowed
                   }
             ],
         }

--- a/tests/functional/tests.d/346-testagentforward.sh
+++ b/tests/functional/tests.d/346-testagentforward.sh
@@ -1,0 +1,79 @@
+# vim: set filetype=sh ts=4 sw=4 sts=4 et:
+# shellcheck shell=bash
+# shellcheck disable=SC2086,SC2016,SC2046
+# below: convoluted way that forces shellcheck to source our caller
+# shellcheck source=tests/functional/launch_tests_on_instance.sh
+. "$(dirname "${BASH_SOURCE[0]}")"/dummy
+
+testsuite_agent_forwarding()
+{
+    #create account1
+    success accountCreate $a0 --osh accountCreate --always-active --account $account1 --uid $uid1 --public-key "\"$(cat $account1key1file.pub)\""
+    json .error_code OK .command accountCreate .value null
+
+    # Add access to $remote_ip for $shellaccount
+    success mustwork $a0 -osh selfAddPersonalAccess -h $remote_ip -u $shellaccount -p 22 --kbd-interactive
+    nocontain "already"
+    json .command selfAddPersonalAccess .error_code OK .value.user $shellaccount .value.port 22
+
+    # Patch sshd to allow Agent Forwarding, else all other steps are useless to test
+    success sshd_config_backup $r0 "\"cp -a /etc/ssh/sshd_config /etc/ssh/sshd_config.bak\""
+    success sshd_config_patch $r0 "\"command -v freebsd-version >/dev/null && sed -I '' 's=^AllowAgentForwarding no=AllowAgentForwarding yes=' /etc/ssh/sshd_config || sed -i 's=^AllowAgentForwarding no=AllowAgentForwarding yes=' /etc/ssh/sshd_config\""
+    # pkill doesn't work well under FreeBSD, so do it ourselves for all OSes
+    success sshd_reload $r0 "\"ps -U 0 -o pid,command | grep -E '/usr/sbin/sshd\\\$|sshd:.+liste[n]er' | awk '{print \\\$1}' | xargs -r kill -SIGHUP\""
+    # during tests, under some OSes it takes some time for sshd to accept new connections again after the SIGHUP
+    [ "$COUNTONLY" != 1 ] && sleep 1
+
+    # Test if ssh-agent is spawned without requesting it; it shouldn't
+    run shellaccount_noagent $a0 $shellaccount@$remote_ip --kbd-interactive -- ssh-add -L
+    retvalshouldbe 2
+    contain REGEX "$shellaccount@[a-zA-Z0-9._-]+:22"
+    contain "allowed ... log on"
+    nocontain "Permission denied"
+    contain "Could not open a connection to your authentication agent."
+
+    # test if ssh-agent is spawned whilst requesting it but with the addkeystoagentallowed-config directive set to false
+    run shellaccount_with_fwd_cfg_disallowed_noagent $a0 $shellaccount@$remote_ip --kbd-interactive -- ssh-add -L
+    retvalshouldbe 2
+    contain REGEX "$shellaccount@[a-zA-Z0-9._-]+:22"
+    contain "allowed ... log on"
+    nocontain "Permission denied"
+    contain "Could not open a connection to your authentication agent."
+
+    # test if ssh-agent is spawned whilst requesting it,  with the addkeystoagentallowed-config directive set to True
+    # Change config
+    configchg 's=^\\\\x22sshAddKeysToAgentAllowed\\\\x22.+=\\\\x22sshAddKeysToAgentAllowed\\\\x22:\\\\x20true='
+
+    # Run test with --forward-agent; agent should spawn
+    run shellaccount_with_fwd_cfg_longarg $a0 --forward-agent $shellaccount@$remote_ip -- ssh-add -L
+    retvalshouldbe 0
+    contain REGEX "$shellaccount@[a-zA-Z0-9._-]+:22"
+    contain "allowed ... log on"
+    nocontain "Permission denied"
+    nocontain "Could not open a connection to your authentication agent."
+
+    # Run test with -x; agent should spawn
+    run shellaccount_with_fwd_cfg_shortarg $a0 -x $shellaccount@$remote_ip -- ssh-add -L
+    retvalshouldbe 0
+    contain REGEX "$shellaccount@[a-zA-Z0-9._-]+:22"
+    contain "allowed ... log on"
+    nocontain "Permission denied"
+    nocontain "Could not open a connection to your authentication agent."
+
+    # Patch sshd to allow Agent Forwarding, else all other steps are useless to test
+    success sshd_config_backup $r0 "\"cp -a /etc/ssh/sshd_config.bak /etc/ssh/sshd_config\""
+    # pkill doesn't work well under FreeBSD, so do it ourselves for all OSes
+    success sshd_reload $r0 "\"ps -U 0 -o pid,command | grep -E '/usr/sbin/sshd\\\$|sshd:.+liste[n]er' | awk '{print \\\$1}' | xargs -r kill -SIGHUP\""
+
+    # Remove access for our testaccount first...
+    success removeaccess $a0 -osh selfDelPersonalAccess -h $remote_ip -u $shellaccount -p 22
+    contain "Access to $shellaccount"
+    json .command selfDelPersonalAccess .error_code OK .value.port 22
+
+    # delete account1
+    script cleanup $a0 --osh accountDelete --account $account1 "<<< \"Yes, do as I say and delete $account1, kthxbye\""
+    retvalshouldbe 0
+}
+
+testsuite_agent_forwarding
+unset -f testsuite_agent_forwarding


### PR DESCRIPTION
This pull request addresses and resolves issue #252 by implementing the capability to enable SSH agent forwarding during an SSH session, with the egress key added to the agent.

The behavior is controlled by the ``sshAddKeysToAgentAllowed`` configuration option in bastion.conf, which is set to ``false`` by default. When this option is explicitly set to ``true``, users can request SSH agent forwarding by including either the ``--forward-agent`` or ``-x`` argument on egress SSH sessions:

```
ssh --forward-agent <username>@<host>  
ssh -x <username>@<host>  
```

This enhancement provides users with greater flexibility while maintaining the secure default settings and addresses the exact scenario described in #252.

Tests have been added in its own file, as I couldn't really find a more appropriate location to add the tests.
