### PR TITLE
fix: execute systemctl daemon-reload after /etc/fstab changes

### DIFF
--- a/bin/admin/setup-encryption.sh
+++ b/bin/admin/setup-encryption.sh
@@ -177,6 +177,14 @@ rm -f "$newfstab"
 action_done
 
 action_doing "Remounting /home after encryption"
+if command -v systemctl >/dev/null 2>&1; then
+    if systemctl daemon-reload; then
+        action_done "systemd daemon-reload successful"
+    else
+        action_error "systemd daemon-reload failed"
+        exit 1
+    fi
+fi
 if mount /home; then
     action_done
 else


### PR DESCRIPTION
Hi,

Most servers using systemd require a `sytemctl daemon-reload` after making changes to `/etc/fstab` because systemd generates systemd-mounts for all mount points under the hood.

Without the daemon-reload, I'm getting this warning:

```
mount: (hint) your fstab has been modified, but systemd still uses the old version; 
use 'systemctl daemon-reload' to reload.
```