### PR TITLE
fix: check if /home is actually mounted before exiting the script early

### DIFF
--- a/bin/admin/unlock-home.sh
+++ b/bin/admin/unlock-home.sh
@@ -20,7 +20,7 @@ if [ -z "$DEV_ENCRYPTED" ] || [ -z "$UNLOCKED_NAME" ] || [ -z "$MOUNTPOINT" ] ||
     exit 0
 fi
 
-if [ -e "$MOUNTPOINT/allowkeeper" ] && mount -l | grep -q "/home" ; then
+if [ -e "$MOUNTPOINT/allowkeeper" ] && mountpoint -q /home ; then
     echo "Already unlocked and mounted"
     exit 0
 fi


### PR DESCRIPTION
I ran into an issue where I set up a separate `/home` partition after initially configuring The Bastion.

I copied all content from `/home` without deleting it on the root disk, and because the script currently only checks if certain folders in `/home` exist, without actually checking if there is a mount for home, it aborted too early. 