### PR TITLE
fix: dont return status code 1 if unlock-home.sh is already linked

### DIFF
--- a/bin/admin/setup-encryption.sh
+++ b/bin/admin/setup-encryption.sh
@@ -214,5 +214,7 @@ else
     action_error "Couldn't umount /home to run the test, ignoring"
 fi
 
-[ ! -e /root/unlock-home.sh ] && ln -s /opt/bastion/bin/admin/unlock-home.sh /root/
+if [ ! -e /root/unlock-home.sh ]; then
+    ln -s /opt/bastion/bin/admin/unlock-home.sh /root/
+fi
 


### PR DESCRIPTION
I'm not exactly sure how I got into this situation, but I managed to have this symlink in place, without having my disk encrypted (probably due to some testings I did). 

At the moment, the script will always exit with status `1`, if that symlink already exists. In my opinion, it should still exit with `0`, but simply skip the `ln` command if the link already exists.