### PR TITLE
fix: return accountInfo if grace period is set

### DIFF
--- a/bin/plugin/restricted/accountInfo
+++ b/bin/plugin/restricted/accountInfo
@@ -546,7 +546,7 @@ sub print_account_info {
             osh_info("- PIV grace period for this account is "
                   . colored('set', 'green')
                   . " and expires in "
-                  . $fnret->value->{'human'});
+                  . $fnret->{'human'});
         }
         else {
             osh_info "- PIV grace period for this account is " . colored('inactive', 'blue');


### PR DESCRIPTION
Hi, 

This PR fixes a small issue where `accountInfo` fails if the account has an active PIV grace period.