### PR TITLE
feat: httpproxy: add support for more HTTP methods

### DIFF
--- a/bin/proxy/osh-http-proxy-daemon
+++ b/bin/proxy/osh-http-proxy-daemon
@@ -90,10 +90,11 @@ OVH::Bastion::ProxyHTTP->new()->run(
     timeout_idle => 3600,
     proxy_config => {
         insecure                      => $config->{'insecure'} ? 1 : 0,
-        timeout                       => $config->{'timeout'},                                 # our worker will wait for up to this amount of time for the egress connection to complete
+        timeout                       => $config->{'timeout'},                         # our worker will wait for up to this amount of time for the egress connection to complete
         log_request_response          => $config->{'log_request_response'} ? 1 : 0,
         log_request_response_max_size => $config->{'log_request_response_max_size'},
         allowed_egress_protocols      => $config->{'allowed_egress_protocols'} || ['https'],
+        allowed_methods               => $config->{'allowed_methods'}          || ['GET', 'POST'],
     },
 ) or die "Proxy launch failed!";
 

--- a/bin/proxy/osh-http-proxy-worker
+++ b/bin/proxy/osh-http-proxy-worker
@@ -162,6 +162,15 @@ if (not grep { $egress_protocol eq $_ } @{$config->{'allowed_egress_protocols'}}
     );
 }
 
+if (not grep { $method eq $_ } @{$config->{'allowed_methods'} || []}) {
+    log_and_exit(
+        400,
+        "Bad Request (method forbidden)",
+        "The $method method is forbidden by policy",
+        {comment => 'method_forbidden'}
+    );
+}
+
 my $shortGroup;
 if ($group) {
     $fnret = OVH::Bastion::is_valid_group_and_existing(group => $group, groupType => 'key');

--- a/doc/sphinx/administration/configuration/osh-http-proxy_conf.rst
+++ b/doc/sphinx/administration/configuration/osh-http-proxy_conf.rst
@@ -29,6 +29,7 @@ These options modify the behavior of the HTTP Proxy, an optional module of The B
 - `timeout`_
 - `log_request_response`_
 - `log_request_response_max_size`_
+- `allowed_methods`_
 - `allowed_egress_protocols`_
 
 Option Reference
@@ -176,6 +177,18 @@ the query response will only be partially logged, with full status and headers b
 to the specified size. This is a way to avoid turning off request response logging completely on
 very busy bastions, by ensuring logs growth don't get out of hand, as some responses to queries can
 take megabytes, with possibly limited added value to traceability.
+
+allowed_methods
+***************
+
+:Type: ``array of strings``
+
+:Default: ``["GET","POST"]``
+
+:Example: ``["GET","POST","PUT","PATCH","DELETE"]``
+
+This array lists the allowed HTTP methods. By default, only GET and POST are allowed.
+If required, other methods can be added such as PUT, PATCH, DELETE, etc.
 
 allowed_egress_protocols
 ************************

--- a/etc/bastion/osh-http-proxy.conf.dist
+++ b/etc/bastion/osh-http-proxy.conf.dist
@@ -104,6 +104,13 @@
 #  DEFAULT: 65536
 "log_request_response_max_size": 65536,
 #
+# allowed_methods (array of strings)
+#     DESC: This array lists the allowed HTTP methods. By default, only GET and POST are allowed.
+#           If required, other methods can be added such as PUT, PATCH, DELETE, etc.
+#  EXAMPLE: ["GET","POST","PUT","PATCH","DELETE"]
+#  DEFAULT: ["GET","POST"]
+"allowed_methods": ["GET","POST"],
+#
 # allowed_egress_protocols (array of strings)
 #     DESC: This array lists the allowed egress protocols. By default, only https is allowed.
 #           If required, plain http egress can be enabled here, which is of course strongly discouraged,

--- a/tests/functional/docker/target_role.sh
+++ b/tests/functional/docker/target_role.sh
@@ -162,6 +162,8 @@ if [ "$WANT_HTTP_PROXY" = 1 ]; then
     sed -i -re 's="insecure":.+="insecure":true,=' /etc/bastion/osh-http-proxy.conf
     # also build a config with disallowed https egress and allowed http egress
     sed -re 's="allowed_egress_protocols":.+="allowed_egress_protocols":["http"]=' /etc/bastion/osh-http-proxy.conf > /etc/bastion/osh-http-proxy-httponly.conf
+    # and another one with more allowed methods
+    sed -re 's="allowed_methods":.+="allowed_methods":["GET","POST","PUT","PATCH","DELETE"],=' /etc/bastion/osh-http-proxy.conf > /etc/bastion/osh-http-proxy-methods.conf
 
     # ensure the remote daemon is executable
     chmod 0755 "$basedir"/tests/functional/proxy/remote-daemon

--- a/tests/functional/launch_tests_on_instance.sh
+++ b/tests/functional/launch_tests_on_instance.sh
@@ -478,7 +478,14 @@ run()
         [ "$case" = "sshd_reload" ] && sleep 1
         flock "$outdir/$basename.retval" $screen "$outdir/$basename.cc" -D -m -fn -ln $r0 '
                 /opt/bastion/bin/admin/check-consistency.pl ; echo _RETVAL_CC=$?= ;
-                grep -Fw -e warn -e die -e code-warning /var/log/bastion/bastion.log | grep -Fv -e "'"${code_warn_exclude:-__none__}"'" -e "System does not support IPv6" | sed "s/^/_SYSLOG=/" ;
+                grep -Fw -e warn -e die -e code-warning /var/log/bastion/bastion.log
+                | grep -Fv
+                  -e "'"${code_warn_exclude:-__none__}"'"
+                  -e "System does not support IPv6"
+                  -e "Defaulting to E[UG]ID"
+                  -e "starting!"
+                  -e "Binding to SSL port"
+                | sed "s/^/_SYSLOG=/" ;
                 : > /var/log/bastion/bastion.log
             '
         flock "$outdir/$basename.retval" true

--- a/tests/functional/proxy/remote-daemon
+++ b/tests/functional/proxy/remote-daemon
@@ -19,10 +19,15 @@ sub process_http_request {
     my $hasContentType;
     my $wantedResponseSize = 64;
 
+    # this is to get the unparsed body of the request, portion of code
+    # taken from lib/perl/OVH/Bastion/ProxyHTTP.pm, more context available over there
+    my $content;
     my $real_content_type = $ENV{'CONTENT_TYPE'};
     $ENV{'CONTENT_TYPE'} = 'application/xml';
-    my $content = CGI->new->param('XForms:Model');
-    $ENV{'CONTENT_TYPE'} = $real_content_type;
+    my %verb2param = (POST=>'XForms:Model', PUT=>'PUTDATA', PATCH=>'PATCHDATA');
+    if (my $param = $verb2param{$self->{'request_info'}{'request_method'}}) {
+       $content =  CGI->new->param($param);
+    }
 
     foreach my $headerTuple (@{ $self->{'request_info'}{'request_headers'} }) {
         if ($headerTuple->[0] =~ /^x-test-add-response-header-(.+)/i) {
@@ -35,11 +40,13 @@ sub process_http_request {
     }
     print "Content-type: text/plain\n" if !$hasContentType;
 
+    # if the request had a body, include it verbatim in our answer
     if ($content) {
         print "Content-Length: ".length($content)."\n\n";
         print $content;
     }
     else {
+        # otherwise, generate some data in our answer
         print "Content-Length: ".$wantedResponseSize."\n\n";
         my @chars = ('0'..'9', 'a'..'z', 'A'..'Z', "\n");
 


### PR DESCRIPTION
By default this stays as before (GET and POST),
but more methods can be allowed through the
HTTP Proxy configuration.