### PR TITLE
feat: accept -l as user option

### DIFF
--- a/bin/shell/osh.pl
+++ b/bin/shell/osh.pl
@@ -353,7 +353,7 @@ my $remainingOptions;
     "verbose+"                  => \my $verbose,
     "tty|t"                     => \my $tty,
     "no-tty|T"                  => \my $notty,
-    "user|u=s"                  => \my $user,
+    "user|u|l=s"                => \my $user,
     "osh=s"                     => \my $osh_command,
     "telnet|e"                  => \my $telnet,
     "password=s"                => \my $passwordFile,


### PR DESCRIPTION
Hi,

I think it would be nice if you could use `-l` to pass in the user option.
This feels a bit more consistent with openssh, as it also uses `-l` and not `-u`.