### PR TITLE
fix: missing syslog-ng config for bastion-scripts

### DIFF
--- a/etc/syslog-ng/conf.d/20-bastion.conf.dist
+++ b/etc/syslog-ng/conf.d/20-bastion.conf.dist
@@ -5,11 +5,11 @@
 # Don't forget to logrotate! (included in logrotate.d/bastion-syslog)
 #
 # Also don't forget to exclude bastion logs from system-wide logs, by excluding
-# the filter(f_bastion) from those, under debian it usually means:
+# the filter(f_bastion) and filter(f_bastion_scripts) from those, under debian it usually means:
 #
-# filter f_syslog3 { not facility(auth, authpriv, mail) and not filter(f_debug) and not filter(f_bastion); };
+# filter f_syslog3 { not facility(auth, authpriv, mail) and not filter(f_debug) and not filter(f_bastion) and not filter(f_bastion_scripts); };
 # filter f_messages { level(info,notice,warn) and
-#                    not facility(auth,authpriv,cron,daemon,mail,news) and not filter(f_bastion); };
+#                    not facility(auth,authpriv,cron,daemon,mail,news) and not filter(f_bastion) and not filter(f_bastion_scripts); };
 
 
 # we define destinations, might be a good idea to log to a remote syslog in addition to locally
@@ -38,11 +38,24 @@ destination d_bastion_security {
     );
 };
 
+destination d_bastion_scripts {
+    file("/var/log/bastion/bastion-scripts.log"
+        perm(0640) dir_perm(0750) create_dirs(yes)
+    );
+};
+
 # this filter catches all bastion syslogs
 
 filter f_bastion {
     facility(local7);
     match("bastion" value("PROGRAM") type("string"));
+};
+
+# this filter catches bastion satellite scripts (cron jobs)
+
+filter f_bastion_scripts {
+    facility(local6);
+    match("^osh-" value("PROGRAM") type("pcre"));
 };
 
 # split message just to get the msgtype and filter on it
@@ -100,5 +113,11 @@ log {
     parser(p_bastion_msg);
     filter(f_bastion_security);
     destination(d_bastion_security);
+};
+
+log {
+    source(s_src);
+    filter(f_bastion_scripts);
+    destination(d_bastion_scripts);
 };
 


### PR DESCRIPTION
Hi there,

The docs as well as the nrpe checks in the repository mention that the output from the `osh-` scripts should be forwarded to `/var/log/bastion/bastion-scripts.log`, but the distributed syslog-ng config option was missing.