### PR TITLE
connect: interactive mode: also accept /usr/bin/perl as parent

### DIFF
--- a/bin/shell/connect.pl
+++ b/bin/shell/connect.pl
@@ -94,7 +94,7 @@ if (open(my $fh, '<', "/proc/" . getppid() . '/cmdline')) {
     }
 
     # interactive mode: our parent is osh.pl
-    elsif ($pargv[0] eq 'perl' and $pargv[1] =~ m{/bin/shell/osh\.pl$}) {
+    elsif ($pargv[0] =~ m{^(/usr/bin/)?perl$} and $pargv[1] =~ m{/bin/shell/osh\.pl$}) {
         ;             # we're being called by the interactive mode of osh.pl, ok
     }
 


### PR DESCRIPTION
When building a the-bastion Debian package with dh_perl, dh_perl may change the shebang of bin/shell/osh.pl from

    #! /usr/bin/env perl

to

    #! /usr/bin/perl

This changes cmdline[0] from 'perl' to '/usr/bin/perl'. When trying to connect to a host in interactive mode, this then fails the security check for the parent process cmdline[0] in bin/shell/connect.pl, which only accepts 'perl' (not '/usr/bin/perl'). Thus, opening a connection in interactive mode fails with a security violation.

To avoid this, accept both 'perl' and '/usr/bin/perl' in bin/shell/connect.sh.