### PR TITLE
fix: allow password authentication for egress if configured

### DIFF
--- a/bin/shell/osh.pl
+++ b/bin/shell/osh.pl
@@ -1499,6 +1499,7 @@ else {
         push @command, '-A', '-o', 'AddKeysToAgent=yes';
     }
     push @command, '-o', 'PreferredAuthentications=' . (join(',', @preferredAuths));
+    push @command, '-o', 'PasswordAuthentication=yes' if $config->{'passwordAllowed'};
 
     if ($config->{'sshClientHasOptionE'}) {
         push @command, '-E', $saveFile . '.sshdebug';


### PR DESCRIPTION
The 'passwordAllowed' config option is intended to allow password authentication for egress. However, setting it to true currently has no effect, because the sshd_config templates set the SSH 'PasswordAuthentication' option to 'no'.

Fix this by manually passing '-o PasswordAuthentication=yes' to SSH if 'passwordAllowed' is set to true.