### PR TITLE
fix: groupCreate: specify the UID of the group's corresponding user

### DIFF
--- a/bin/admin/fix-group-gid.sh
+++ b/bin/admin/fix-group-gid.sh
@@ -1,9 +1,14 @@
 #! /usr/bin/env bash
 # vim: set filetype=sh ts=4 sw=4 sts=4 et:
 # This script ensures that GIDs of bastion groups (including their group system
-# roles) are higher than the configured groupGidMin value.
-# It shifts group GIDs from the low range (where they may collide with reserved
-# account UIDs) to the high range defined by groupGidMin.
+# roles), as well as the UID of the system user matching each group, are higher
+# than the configured groupGidMin value.
+# It shifts group GIDs and the matching group user's UID from the low range
+# (where they may collide with reserved account UIDs/GIDs) to the high range
+# defined by groupGidMin.
+# Note that a group might already have a correct GID (e.g. because it was fixed
+# by a previous run of this script, or created by a recent version of the code)
+# while its system user still has a low UID: such groups are handled too.
 set -e
 
 basedir=$(readlink -f "$(dirname "$0")"/../..)
@@ -41,9 +46,31 @@ _run()
 next_available_gid=$((MINGID + 1))
 find_next_available_gid()
 {
-    while getent group "$next_available_gid" >/dev/null; do
-        next_available_gid=$((next_available_gid + 1))
-    done
+    next_available_gid=$(
+        getent group 2>/dev/null | cut -d: -f3 | sort -n | awk -v start="$MINGID" '
+          BEGIN { candidate = start }
+          {
+            if ($1 + 0 == candidate) { candidate++; }
+            else if ($1 + 0 > candidate) { exit }
+          }
+          END { print candidate }
+        '
+    )
+}
+
+next_available_uid=$MINGID
+find_next_available_uid()
+{
+    next_available_uid=$(
+        getent passwd 2>/dev/null | cut -d: -f3 | sort -n | awk -v start="$MINGID" '
+          BEGIN { candidate = start }
+          {
+            if ($1 + 0 == candidate) { candidate++; }
+            else if ($1 + 0 > candidate) { exit }
+          }
+          END { print candidate }
+        '
+    )
 }
 
 change_gid()
@@ -84,6 +111,46 @@ change_gid()
     fi
 }
 
+# only the main group has a matching system user; this shifts that user's UID to
+# the high range, mirroring what osh-groupCreate does for newly created groups.
+change_uid()
+{
+    group="$1"
+
+    getent passwd "$group" >/dev/null || fail "user $group doesn't exist"
+    getent group  "$group" >/dev/null || fail "group $group doesn't exist"
+
+    olduid=$(getent passwd "$group" | awk -F: '{print $3}')
+
+    # nothing to do if the UID is already in the high range
+    [ "$olduid" -ge "$MINGID" ] && return
+
+    # prefer uid == gid: at this point the group's GID is already in the high
+    # range (either it was already correct, or change_gid() fixed it earlier in
+    # this batch), so reuse it as the UID when that value is free in the passwd
+    # namespace; otherwise scan for the next free UID in the high range.
+    gid=$(getent group "$group" | awk -F: '{print $3}')
+    if [ "$gid" -ge "$MINGID" ] && ! getent passwd "$gid" >/dev/null; then
+        newuid=$gid
+    else
+        find_next_available_uid
+        newuid=$next_available_uid
+    fi
+
+    _run usermod_changeuid_compat "$group" "$newuid"
+
+    # re-own the files that belonged to the old UID: usermod only reassigns the
+    # home directory on some systems, and not at all on others
+    tocheck=""
+    for dir in "/home/$group" "/home/keykeeper/$group"; do
+        test -d "$dir" && tocheck="$tocheck $dir"
+    done
+    if [ -n "$tocheck" ]; then
+        # shellcheck disable=SC2086
+        _run find $tocheck -uid "$olduid" -exec chown "$group" '{}' \;
+    fi
+}
+
 batchrun()
 {
     something_to_do=0
@@ -91,6 +158,7 @@ batchrun()
     change_gid "key$from-gatekeeper" secondary
     change_gid "key$from-aclkeeper"  secondary
     change_gid "key$from-owner"      secondary
+    change_uid "key$from"
 }
 
 main()

--- a/bin/helper/osh-accountCreate
+++ b/bin/helper/osh-accountCreate
@@ -173,7 +173,7 @@ getgrgid($ttygid) and HEXIT('ERR_GID_COLLISION', msg => "This GID ($ttygid) is a
 
 if ($uid < $config->{'accountUidMin'} or $uid > $config->{'accountUidMax'}) {
     HEXIT('ERR_UID_INVALID_RANGE',
-        msg => "UID must be < " . $config->{'accountUidMin'} . " and > " . $config->{'accountUidMax'});
+        msg => "UID must be between " . $config->{'accountUidMin'} . " and " . $config->{'accountUidMax'});
 }
 
 my @vettedKeys;

--- a/bin/helper/osh-groupCreate
+++ b/bin/helper/osh-groupCreate
@@ -156,16 +156,37 @@ osh_info("Creating groups");
 
 # Create all 4 groups with allocated GIDs to avoid collisions with account UIDs
 my @groups_to_create = ($group, "$group-aclkeeper", "$group-gatekeeper", "$group-owner");
+my $group_main_gid;
 foreach my $tocreate (@groups_to_create) {
-    $fnret = OVH::Bastion::get_next_available_gid();
+    $fnret = OVH::Bastion::get_next_available_group_gid();
     $fnret or HEXIT('ERR_GID_ALLOCATION_FAILED', msg => "Failed to allocate GID for group $tocreate: " . $fnret->msg);
     my $gid = $fnret->value;
+
+    $group_main_gid //= $gid;    # save the GID of $group (first iteration)
 
     $fnret = OVH::Bastion::sys_groupadd(group => $tocreate, gid => $gid, noisy_stderr => 1);
     $fnret->err eq 'OK'
       or HEXIT('ERR_GROUPADD_FAILED',
         msg => "Error while running groupadd command for $tocreate with GID $gid (" . $fnret->msg . ")");
     osh_debug("Created group $tocreate with GID $gid");
+}
+
+# Determine the UID for the group system user.
+# Prefer the same value as its main GID (so uid == gid); if that UID is already taken,
+# fall back to the next free UID starting from groupGidMin, which is guaranteed to be
+# strictly above the bastion account UID range (accountUidMin..accountUidMax).
+# We don't let the system pick the UID itself because it could fall into the
+# bastion account UID range (even if, on recent systems, `useradd` seems
+# to pick up the max_uid_seen_in_passwd + 1)
+my $group_uid;
+if (!getpwuid($group_main_gid)) {
+    $group_uid = $group_main_gid;
+}
+else {
+    $fnret = OVH::Bastion::get_next_available_group_uid();
+    $fnret
+      or HEXIT('ERR_UID_ALLOCATION_FAILED', msg => "Failed to allocate UID for group user $group: " . $fnret->msg);
+    $group_uid = $fnret->value;
 }
 
 osh_debug("Creating directory");
@@ -176,8 +197,14 @@ osh_info("Creating user corresponding to group $shortGroup");
 
 # if a comment has been set, we'll store it as the user's GECOS corresponding to the group name
 # user is member of the group, cannot login and have no password
-$fnret =
-  OVH::Bastion::sys_useradd(user => $group, gid => $group, shell => undef, comment => $comment, noisy_stderr => 1);
+$fnret = OVH::Bastion::sys_useradd(
+    user         => $group,
+    uid          => $group_uid,
+    gid          => $group,
+    shell        => undef,
+    comment      => $comment,
+    noisy_stderr => 1
+);
 $fnret->err eq 'OK'
   or HEXIT('ERR_USERADD_FAILED',
     msg => "Error while adding corresponding user of group $shortGroup (" . $fnret->msg . ")");

--- a/lib/perl/OVH/Bastion.pm
+++ b/lib/perl/OVH/Bastion.pm
@@ -144,7 +144,7 @@ my %_autoload_files = (
         qw{ get_personal_account_keys get_group_keys is_access_way_granted get_ip ip2host get_user_groups duration2human print_acls is_access_granted ssh_test_access_way get_acls get_acl_way }
     ],
     allowkeeper => [
-        qw{ is_user_in_group is_group_existing is_valid_uid get_next_available_uid is_bastion_account_valid_and_existing is_account_valid is_account_existing access_modify is_valid_group is_valid_group_and_existing add_user_to_group get_group_list get_account_list get_realm_list is_admin is_super_owner is_auditor is_group_aclkeeper is_group_gatekeeper is_group_owner is_group_guest is_group_member get_remote_accounts_from_realm is_valid_ttl build_re_from_wildcards }
+        qw{ is_user_in_group is_group_existing is_valid_uid get_next_available_uid get_next_available_group_uid get_next_available_group_gid is_bastion_account_valid_and_existing is_account_valid is_account_existing access_modify is_valid_group is_valid_group_and_existing add_user_to_group get_group_list get_account_list get_realm_list is_admin is_super_owner is_auditor is_group_aclkeeper is_group_gatekeeper is_group_owner is_group_guest is_group_member get_remote_accounts_from_realm is_valid_ttl build_re_from_wildcards }
     ],
     configuration => [
         qw{ load_configuration_file main_configuration_directory load_configuration config account_config plugin_config group_config json_load }

--- a/lib/perl/OVH/Bastion/allowkeeper.inc
+++ b/lib/perl/OVH/Bastion/allowkeeper.inc
@@ -153,28 +153,52 @@ sub get_next_available_uid {
     return R('ERR_UID_COLLISION', msg   => "No available UID in the allowed range");
 }
 
-sub get_next_available_gid {
+# Find the next available UID or GID at or above groupGidMin. This "group range"
+# is guaranteed by the configuration sanity checks to sit strictly above the
+# account UID/GID range (accountUidMin..accountUidMax and the ttyrec GIDs), so
+# any ID returned here can never collide with a (possibly fixed) account ID.
+# The $type parameter ('uid' or 'gid') selects which namespace is scanned.
+# Internal: callers should use the get_next_available_group_uid()/_gid() wrappers.
+sub _get_next_available_id_in_group_range {
     my %params = @_;
+    my $type   = $params{'type'} // 'gid';
 
-    # Get the minimum GID from configuration (should be >> accountUidMax to avoid collisions)
+    if ($type ne 'uid' && $type ne 'gid') {
+        return R('ERR_INVALID_PARAMETER', msg => "Parameter 'type' must be 'uid' or 'gid'");
+    }
+
+    # should be >> accountUidMax to avoid collisions
     my $groupGidMin = OVH::Bastion::config('groupGidMin')->value();
 
-    # Start from groupGidMin and find the next available GID
+    # start from groupGidMin and find the next available ID in the requested namespace
     my $next        = $groupGidMin;
     my $maxAttempts = 100_000;        # safety limit
     my $attempts    = 0;
 
     while ($attempts < $maxAttempts) {
-        # Check if this GID is available
-        if (!scalar(getgrgid($next))) {
-            # Found an available GID
+        my $taken = ($type eq 'uid') ? scalar(getpwuid($next)) : scalar(getgrgid($next));
+        if (!$taken) {
+            # found an available ID
             return R('OK', value => $next);
         }
         $next++;
         $attempts++;
     }
 
-    return R('ERR_GID_COLLISION', msg => "No available GID found in the allowed range starting from $groupGidMin");
+    return R(($type eq 'uid' ? 'ERR_UID_COLLISION' : 'ERR_GID_COLLISION'),
+        msg => "No available $type found in the allowed range starting from $groupGidMin");
+}
+
+# convenience wrapper to get the next available UID in the group range
+sub get_next_available_group_uid {
+    my %params = @_;
+    return _get_next_available_id_in_group_range(%params, type => 'uid');
+}
+
+# convenience wrapper to get the next available GID in the group range
+sub get_next_available_group_gid {
+    my %params = @_;
+    return _get_next_available_id_in_group_range(%params, type => 'gid');
 }
 
 sub is_bastion_account_valid_and_existing {


### PR DESCRIPTION
Along with a better version of the `fix-group-gid.sh` admin script