### PR TITLE
fix(lib,bastion): make the helper error message readable

### DIFF
--- a/lib/perl/OVH/Bastion/execute.inc
+++ b/lib/perl/OVH/Bastion/execute.inc
@@ -556,7 +556,7 @@ sub helper {
         expects_stdin => $expects_stdin,
         stdin_str     => $stdin_str
     );
-    $fnret or return R('ERR_HELPER_FAILED', "something went wrong in helper script (" . $fnret->msg . ")");
+    $fnret or return R('ERR_HELPER_FAILED', msg => "something went wrong in helper script (" . $fnret->msg . ")");
 
     $fnret = OVH::Bastion::result_from_helper($fnret->value->{'stdout'});
     $fnret or return $fnret;


### PR DESCRIPTION
When the helper exists with an error, the error message can be read with `$fnret->msg`.