### PR TITLE
enh: sudoers sharding: sudo performance boost for big bastions

### DIFF
--- a/bin/admin/check-consistency.pl
+++ b/bin/admin/check-consistency.pl
@@ -605,6 +605,152 @@ if (keys %ALL_FILES) {
     print Dumper(sort keys %ALL_FILES);
 }
 
+# Expand a set of raw sudoers template lines into a list of normalized, atomic
+# rules (one command per rule). The templates may use line continuations ("\" at
+# the end of a line) and group several commands sharing the same
+# account/group/runas tuple into a single comma-separated rule, to reduce the
+# number of rules sudo has to parse, e.g.:
+#    SUPEROWNERS, %GROUP%-owner ALL=(root) NOPASSWD: \
+#        /path/helperA --group %GROUP% *, \
+#        /path/helperB --group %GROUP% *
+# while the per-helper "# KEYSUDOERS" declarations are always written as a single
+# command per rule. Expanding both sides to the same atomic, whitespace-normalized
+# form lets us compare them regardless of how the template is laid out. Comment
+# and blank lines expand to nothing.
+sub _expand_sudoers_rules {
+    my @rawlines = @_;
+
+    # first, join continuation lines together and drop comment/blank lines
+    my @logical;
+    my $current;
+    foreach my $line (@rawlines) {
+        if (!defined $current) {
+            next if $line =~ /^\s*(?:#|$)/;
+            $current = $line;
+        }
+        else {
+            $line =~ s/^\s+//;
+            $current .= " $line";
+        }
+        if ($current =~ s/\s*\\\s*$//) {
+            next;    # the rule continues on the next line
+        }
+        push @logical, $current;
+        undef $current;
+    }
+    push @logical, $current if defined $current;
+
+    # then split each rule's comma-separated command list into atomic rules,
+    # keeping the "user host=(runas) TAG:" prefix (which ends at the first colon)
+    my @atomic;
+    foreach my $rule (@logical) {
+        my ($prefix, $commands) = $rule =~ /^(.*?:)\s*(.+)$/ or next;
+        foreach my $command (split /\s*,\s*/, $commands) {
+            my $atom = "$prefix $command";
+            $atom =~ s/\s+/ /g;
+            $atom =~ s/^\s+|\s+$//g;
+            push @atomic, $atom;
+        }
+    }
+    return @atomic;
+}
+
+# load a sudoers template directory (account or group), returning its raw lines.
+# OS-specific templates (named xxx-name.os.sudoers) are skipped.
+sub _load_sudoers_template {
+    my $subdir = shift;
+    my @lines;
+    foreach my $tplfile (sort glob "$BASEDIR/etc/$subdir/*.sudoers") {
+        next if basename($tplfile) =~ /\..+\.sudoers$/;    # OS-specific template, skip
+        my $fh;
+        if (!open($fh, '<', $tplfile)) {
+            _err "can't open sudoers file template $tplfile to check: $!";
+            next;
+        }
+        my @l = <$fh>;
+        close($fh);
+        chomp @l;
+        push @lines, @l;
+    }
+    return @lines;
+}
+
+# compute the normalized, sudoers-alias-safe identifier the generator substitutes
+# for %NORMACCOUNT% / %NORMGROUP%: uppercased, with every non-alphanumeric (and
+# non-underscore) char turned into '_', suffixed with the first 6 hex chars of the
+# md5 of the (raw) entity name.
+sub _norm_name {
+    my $name = shift;
+    (my $norm = $name) =~ tr/[A-Za-z0-9_]/_/c;
+    return uc($norm . '_' . substr(Digest::MD5::md5_hex($name), 0, 6));
+}
+
+# parse the sharded sudoers files for the given type ('account' or 'group') and
+# return a hash mapping each entity name to the arrayref of raw lines of its block.
+# Each shard file holds several blocks delimited by the markers the generator emits:
+#     #>>> <type> <name>
+#     ...rules...
+#     #<<< <type> <name>
+sub _read_sharded_sudoers {
+    my $type = shift;
+    my %blocks;
+    foreach my $sudoersfile (sort glob "$sudoers_dir/osh-${type}s-shard-*") {
+        my $fh;
+        if (!open($fh, '<', $sudoersfile)) {
+            _err "can't open $sudoersfile to check: $!";
+            next;
+        }
+        my $name;
+        while (my $line = <$fh>) {
+            chomp $line;
+            if ($line =~ /^#>>> \Q$type\E (.+)$/) {
+                $name = $1;
+                $blocks{$name} ||= [];
+            }
+            elsif ($line =~ /^#<<< \Q$type\E /) {
+                undef $name;
+            }
+            elsif (defined $name) {
+                push @{$blocks{$name}}, $line;
+            }
+        }
+        close($fh);
+    }
+    return %blocks;
+}
+
+# verify that every sharded block of the given type contains all the rules of its
+# template, and return the set of entity names that were seen (so the caller can
+# in turn check that no expected entity is missing a block). $token is the template
+# placeholder base, i.e. 'GROUP' (for %GROUP%/%NORMGROUP%) or 'ACCOUNT'.
+sub _check_sharded_sudoers {
+    my ($type, $subdir, $token) = @_;
+    my @template = _load_sudoers_template($subdir);
+    my %blocks   = _read_sharded_sudoers($type);
+    my %seen;
+    foreach my $name (sort keys %blocks) {
+        $seen{$name} = 1;
+        my $norm     = _norm_name($name);
+        my @expected = map {
+            my $line = $_;
+            $line =~ s/%NORM\Q$token\E%/$norm/g;
+            $line =~ s/%\Q$token\E%/$name/g;
+            $line =~ s=%BASEPATH%=/opt/bastion=g;
+            $line;
+        } @template;
+
+        # the template may group commands sharing the same tuple into a single
+        # rule (continuations + comma lists), so compare on expanded atomic rules
+        my %present = map { $_ => 1 } _expand_sudoers_rules(@{$blocks{$name}});
+        foreach my $wantedrule (_expand_sudoers_rules(@expected)) {
+            if (!$present{$wantedrule}) {
+                _err "missing line in $type block '$name' (in $sudoers_dir/osh-${type}s-shard-*): $wantedrule";
+            }
+        }
+    }
+    return %seen;
+}
+
 # for new code, check sudo stuff
 sub _tocheck {
     my $file       = shift;
@@ -657,7 +803,7 @@ sub _tocheck {
                 _err "sudoers file $sudoersfile has a bad mode $mode";
             }
             if (!open(my $fh_sudoers, '<', $sudoersfile)) {
-                _err "can't open sudoers file $sudoersfile to check";
+                _err "can't open sudoers file $sudoersfile to check: $!";
             }
             else {
                 my @contents = <$fh_sudoers>;
@@ -675,7 +821,7 @@ sub _tocheck {
         my @contents;
         foreach my $sudoersfile (sort <$BASEDIR/etc/sudoers.group.template.d/*>) {
             if (!open(my $fh_sudoers, '<', $sudoersfile)) {
-                _err "can't open sudoers file template $sudoersfile to check";
+                _err "can't open sudoers file template $sudoersfile to check: $!";
             }
             else {
                 my @lines = <$fh_sudoers>;
@@ -685,10 +831,17 @@ sub _tocheck {
             }
         }
         if (@contents) {
+            # expand the (possibly grouped/multi-line) template into atomic rules
+            my %templaterules = map { $_ => 1 } _expand_sudoers_rules(@contents);
             foreach my $wantedline (@{$tocheck{'KEYSUDOERS'}}) {
                 $wantedline =~ s'@KEYGROUP@'%GROUP%'g;
-                if (not grep { $_ eq $wantedline } @contents) {
-                    _err "missing line in plugin sudoers.group.template: $wantedline";
+
+                # a KEYSUDOERS declaration may be a documentation comment rather
+                # than an actual rule: those expand to nothing and are skipped
+                foreach my $wantedrule (_expand_sudoers_rules($wantedline)) {
+                    if (!$templaterules{$wantedrule}) {
+                        _err "missing line in plugin sudoers.group.template: $wantedline";
+                    }
                 }
             }
         }
@@ -711,7 +864,7 @@ while (my $file = glob "$BASEDIR/bin/helper/*") {
     }
     my $fh_helper;
     if (!open($fh_helper, '<', $file)) {
-        _err "can't open helper file $file to check";
+        _err "can't open helper file $file to check: $!";
         next;
     }
     my %tochecklocal;
@@ -759,59 +912,29 @@ while (my $distfile = glob "$BASEDIR/etc/sudoers.d/*") {
     }
 }
 
-if (1) {
-    my @template;
-    foreach my $sudoersfile (sort <$BASEDIR/etc/sudoers.group.template.d/*>) {
-        if (!open(my $fh_sudoers, '<', $sudoersfile)) {
-            _err "can't open sudoers file template $sudoersfile to check";
-        }
-        else {
-            my @lines = <$fh_sudoers>;
-            close($fh_sudoers);
-            chomp @lines;
-            push @template, @lines;
-        }
-    }
-
-    my %seensudogroupfile;
-    while (my $sudoersfile = glob "$sudoers_dir/osh-group-*") {
-
-        # TODO check 0440
-        # TODO check there's a matching group (and the other way around)
-
-        # the unescaped group should be present in the file (see GROUPNAME below),
-        # but to backwards compatible, try to guess it by ourselves if it's not
-        my $group = $sudoersfile;
-        $group =~ s/^.*osh-group-key//;
-
-        my $fh_sudoers;
-        if (!open($fh_sudoers, '<', $sudoersfile)) {
-            _err "can't open $sudoersfile file to check: $!";
-            next;
-        }
-        my @contents = <$fh_sudoers>;
-        close($fh_sudoers);
-        chomp @contents;
-
-        # now try to get it from the file
-        foreach (@contents) {
-            /^# GROUPNAME=key(.+)/ and $group = $1;
-        }
-        $seensudogroupfile{$group} = 1;
-
-        my @expected = @template;
-        do { s/%GROUP%/key$group/g; s=%BASEPATH%=/opt/bastion=g; }
-          for @expected;
-
-        foreach my $wantedline (@expected) {
-            if (not grep { $_ eq $wantedline } @contents) {
-                _err "missing line in $sudoersfile: $wantedline";
-            }
-        }
-    }
+# check the per-entity sudoers blocks. Both accounts and groups are now sharded:
+# instead of one file per entity, the generator writes a handful of
+# "osh-accounts-shard-NN" / "osh-groups-shard-NN" files, each holding several
+# entity blocks (see _check_sharded_sudoers / _read_sharded_sudoers above).
+{
+    # groups: the block name is the full unix key-group name (e.g. "keymygroup"),
+    # which is exactly what %GROUP% expands to in the template
+    my %seengroups = _check_sharded_sudoers('group', 'sudoers.group.template.d', 'GROUP');
     foreach my $group (keys %keygroupsbyname) {
-        next if exists $seensudogroupfile{$group};
-        _err "missing $sudoers_dir/osh-group-key$group file";
+        next if $seengroups{"key$group"};
+        _err "missing sudoers block for key group 'key$group' in $sudoers_dir/osh-groups-shard-*";
+    }
+
+    # accounts: there's one block per bastion account, i.e. each account whose
+    # login shell is the bastion's osh.pl (this mirrors how the generator decides
+    # which accounts get a sudoers entry)
+    my %seenaccounts = _check_sharded_sudoers('account', 'sudoers.account.template.d', 'ACCOUNT');
+    foreach my $line (qx{getent passwd}) {    ## no critic (ProhibitBacktickOperators)
+        chomp $line;
+        my ($account, $shell) = (split /:/, $line)[0, 6];
+        next if !defined $shell || $shell ne '/opt/bastion/bin/shell/osh.pl';
+        next if $seenaccounts{$account};
+        _err "missing sudoers block for account '$account' in $sudoers_dir/osh-accounts-shard-*";
     }
 }
 

--- a/bin/dev/perlcriticrc
+++ b/bin/dev/perlcriticrc
@@ -25,6 +25,9 @@ packages = Data::Dumper File::Find FindBin Log::Log4perl DBI
 [Subroutines::RequireArgUnpacking]
 short_subroutine_statements = 3
 
+[BuiltinFunctions::ProhibitComplexMappings]
+max_statements = 5
+
 [-BuiltinFunctions::ProhibitBooleanGrep]
 [-ControlStructures::ProhibitCascadingIfElse]
 [-ControlStructures::ProhibitPostfixControls]

--- a/bin/sudogen/generate-sudoers.sh
+++ b/bin/sudogen/generate-sudoers.sh
@@ -11,197 +11,268 @@ action="$1"
 type="$2"
 name="$3"
 
+# Number of shards per entity type. MUST be identical fleet-wide (master+slaves),
+# because the shard a given account/group lands in is derived from its name.
+# Changing it requires a full `regen all` (handled below: rebuild + prune).
+case "$SUDOERS_SHARD_COUNT" in
+    '' | *[!0-9]*) echo "SUDOERS_SHARD_COUNT must be a positive integer" >&2; exit 1 ;;
+    *) ;;
+esac
+[ "$SUDOERS_SHARD_COUNT" -ge 1 ] || { echo "SUDOERS_SHARD_COUNT must be >= 1" >&2; exit 1; }
+# zero-pad shard number so sharded files sort nicely
+_maxshard=$((SUDOERS_SHARD_COUNT - 1))
+SHARD_WIDTH=${#_maxshard}
+
 die_usage() {
     echo "Usage: $0 <create|delete> <account|group> [name]" >&2
     exit 1
 }
 
-manage_account_sudoers()
-{
-    todo="$1"
-    account="$2"
-
-    # for accounts containing a ".", we need to do a little transformation
-    # as files containing a dot are ignored by sudo
-    normalized_account=$(sed -re 's/[^A-Z0-9_]/_/gi' <<< "$account")
-    # as we're reducing the amount of possible chars in normalized_account
-    # we could have collisions: use MD5 to generate a uniq suffix
-    account_suffix=$(md5sum_compat - <<< "$account" | cut -c1-6)
-    normalized_account="${normalized_account}_${account_suffix}"
-    dst="$SUDOERS_DIR/osh-account-$normalized_account"
-
-    # for delete, don't check if account is valid:
-    # our caller might be in the process of deleting it
-    if [ "$todo" = delete ]; then
-        action_detail "... deleting $dst"
-        rm -f "$dst"
-        return $?
-    fi
-
-    # otherwise, for create, we expect the account to exist
-    if ! getent passwd "$account" | grep -q ":$basedir/bin/shell/osh.pl$"; then
-        action_error "$account is not a bastion account"
-        return 1
-    fi
-
-    if [ -e "$dst" ]; then
-        action_detail "... overwriting $dst"
+# Template cache, loaded once per process (an invocation only ever handles one type: account or group)
+_TPL_LOADED=""
+_TPL_PATHS=()
+_TPL_BODIES=()
+load_templates() {
+    # $1 = account|group
+    [ "$_TPL_LOADED" = "$1" ] && return 0
+    local _tmpldir _os _t _bn
+    if [ "$1" = account ]; then
+        _tmpldir="$basedir/etc/sudoers.account.template.d"
     else
-        action_detail "... generating $dst"
+        _tmpldir="$basedir/etc/sudoers.group.template.d"
     fi
-
-    # within the sudoers file, for variables, lowercase is prohibited,
-    # names can only contain [A-Z0-9_], case sensitive, so we got a step further
-    normalized_account=$(tr '[:lower:]' '[:upper:]' <<< "$normalized_account")
-    # to avoid race conditions between this generation and master/slave sync,
-    # first prepare our file as a .tmp (sudo ignores files containing a '.')
-    touch "${dst}.tmp"
-    chmod 0440 "${dst}.tmp"
-    {
-        echo "# generated from install script"
-        echo "# ACCOUNTNAME=$account"
-        for template in $(find "$basedir/etc/sudoers.account.template.d/" -type f -name "*.sudoers" | sort)
-        do
-            # if $template has two dots, then it's of the form XXX-name.$os.sudoers,
-            # in that case we only include this template if $os is our current OS
-            if [ "$(basename "$template" | cut -d. -f3)" = "sudoers" ]; then
-                if [ "$(basename "$template" | cut -d. -f2 | tr '[:upper:]' '[:lower:]')" != "$(echo "$OS_FAMILY" | tr '[:upper:]' '[:lower:]')" ]; then
-                    # not the same OS, skip it
-                    continue
-                fi
+    _os=$(echo "$OS_FAMILY" | tr '[:upper:]' '[:lower:]')
+    _TPL_PATHS=()
+    _TPL_BODIES=()
+    for _t in $(find "$_tmpldir/" -type f -name "*.sudoers" | sort); do
+        _bn="${_t##*/}"
+        # xxx-name.$os.sudoers is OS-specific: keep only if $os matches ours
+        if [ "$(echo "$_bn" | cut -d. -f3)" = "sudoers" ]; then
+            if [ "$(echo "$_bn" | cut -d. -f2 | tr '[:upper:]' '[:lower:]')" != "$_os" ]; then
+                continue
             fi
-            echo
-            echo "# $template:"
-            perl -pe "s!%ACCOUNT%!$account!g;s!%NORMACCOUNT%!$normalized_account!g;s!%BASEPATH%!$basedir!g" "$template"
-        done
-    } > "${dst}.tmp"
-    # then move the file to its final name (potentially overwriting a previous file of the same name)
-    mv -f "${dst}.tmp" "$dst"
-    # if we have a OLD_SUDOERS file defined, remove the filename from it
-    if [ -n "$OLD_SUDOERS" ]; then
-        sed_compat "/$(basename "$dst")$/d" "$OLD_SUDOERS"
-    fi
-    return 0
+        fi
+        _TPL_PATHS+=("$_t")
+        _TPL_BODIES+=("$(<"$_t")")
+    done
+    _TPL_LOADED="$1"
 }
 
-manage_group_sudoers()
-{
-    todo="$1"
-    group="$2"
+# render one entity (group or account) sudoers block, delimited by #>>>'s and #<<<'s, to stdout, from the cached templates.
+render_block() {
+    # $1 = account|group   $2 = name   $3 = md5 hex of the name
+    local _type="$1" _name="$2" _md5="$3" _norm _i _body
+    load_templates "$_type"
 
-    # for groups containing a ".", we need to do a little transformation
-    # as files containing a dot are ignored by sudo
-    normalized_group=$(sed -re 's/[^A-Z0-9_]/_/gi' <<< "$group")
-    # as we're reducing the amount of possible chars in normalized_group
-    # we could have collisions: use MD5 to generate a uniq suffix
-    group_suffix=$(md5sum_compat - <<< "$group" | cut -c1-6)
-    normalized_group="${normalized_group}_${group_suffix}"
-    dst="$SUDOERS_DIR/osh-group-$normalized_group"
+    # %NORMACCOUNT% / %NORMGROUP%: globally-unique, sudoers-alias-safe identifier.
+    _norm="${_name//[!A-Za-z0-9_]/_}_${_md5:0:6}"
+    _norm="${_norm^^}"
 
-    # for delete, don't check if the group is valid:
-    # our caller might be in the process of deleting it
-    if [ "$todo" = delete ]; then
-        action_detail "... deleting $dst"
-        rm -f "$dst"
-        return $?
+    echo "#>>> $_type $_name"
+    for _i in "${!_TPL_PATHS[@]}"; do
+        echo "# ${_TPL_PATHS[$_i]}:"
+        _body="${_TPL_BODIES[$_i]}"
+        if [ "$_type" = account ]; then
+            _body="${_body//%ACCOUNT%/$_name}"
+            _body="${_body//%NORMACCOUNT%/$_norm}"
+        else
+            _body="${_body//%GROUP%/$_name}"
+            _body="${_body//%NORMGROUP%/$_norm}"
+        fi
+        printf '%s\n' "${_body//%BASEPATH%/$basedir}"
+    done
+    echo "#<<< $_type $_name"
+}
+
+# output $srcfile with the given entity's block removed (markers included).
+# no-op if the block isn't present, so create is idempotent and delete is safe.
+# shellcheck disable=SC2317  # reached only via with_lock-invoked _apply_shard_edit
+strip_block() {
+    # $1 = type   $2 = name   $3 = srcfile
+    awk -v b="#>>> $1 $2" -v e="#<<< $1 $2" '
+        $0 == b { skip = 1; next }
+        $0 == e { skip = 0; next }
+        !skip   { print }
+    ' "$3"
+}
+
+# syntax-validate a shard file. Tolerates aliases defined elsewhere in the global
+# sudoers (e.g. SUPEROWNERS) thanks to -q, but still fails on real syntax errors.
+validate_shard() {
+    # $1 = file
+    command -v visudo >/dev/null 2>&1 || return 0   # no visudo: skip (don't block)
+    visudo -cqf "$1" >/dev/null 2>&1
+}
+
+# the locked critical section of a single-entity edit. Called via with_lock(),
+# to ensure we're the only ones to tinker with sudoers.d/osh-* files.
+# shellcheck disable=SC2317  # invoked indirectly through with_lock "$@"
+_apply_shard_edit() {
+    # $1 = create|delete   $2 = type   $3 = name   $4 = dst   $5 = md5
+    local _todo="$1" _type="$2" _name="$3" _dst="$4" _md5="$5" _tmp="$4.tmp"
+
+    if [ -f "$_dst" ]; then
+        strip_block "$_type" "$_name" "$_dst" > "$_tmp"
+    else
+        echo "# bastion sharded sudoers - $_type shard (do not edit by hand)" > "$_tmp"
     fi
+    if [ "$_todo" = create ]; then
+        render_block "$_type" "$_name" "$_md5" >> "$_tmp"
+    fi
+    chmod 0440 "$_tmp"
 
-    # for create, we expect the group to exist
-    if ! test -f "/home/$group/allowed.ip"; then
-        action_error "$group doesn't seem to be a valid bastion group"
+    if ! validate_shard "$_tmp"; then
+        action_error "generated $_dst failed visudo validation, not applying"
+        rm -f "$_tmp"
         return 1
     fi
+    # atomic publish (sudo ignores the .tmp, so that it never sees a partial file)
+    mv -f "$_tmp" "$_dst"
 
-    if [ -e "$dst" ]; then
-        action_detail "... overwriting $dst"
-    else
-        action_detail "... generating $dst"
-    fi
-
-    # within the sudoers file, for variables, lowercase is prohibited,
-    # names can only contain [A-Z0-9_], case sensitive, so we got a step further
-    normalized_group=$(tr '[:lower:]' '[:upper:]' <<< "$normalized_group")
-    # to avoid race conditions between this generation and master/slave sync,
-    # first prepare our file as a .tmp (sudo ignores files containing a '.')
-    touch "${dst}.tmp"
-    chmod 0440 "${dst}.tmp"
-    {
-        echo "# generated from install script"
-        echo "# GROUPNAME=$group"
-        for template in $(find "$basedir/etc/sudoers.group.template.d/" -type f | sort)
-        do
-            echo
-            echo "# $template:"
-            perl -pe "s!%GROUP%!$group!g;s!%BASEPATH%!$basedir!g" "$template"
-        done
-    } > "${dst}.tmp"
-    # then move the file to its final name (potentially overwriting a previous file of the same name)
-    mv -f "${dst}.tmp" "$dst"
-    # if we have a OLD_SUDOERS file defined, remove the filename from it
-    if [ -n "$OLD_SUDOERS" ]; then
-        sed_compat "/$(basename "$dst")$/d" "$OLD_SUDOERS"
+    # if migrating via install, keep this shard out of the obsolete-files list
+    if [ -n "${OLD_SUDOERS:-}" ]; then
+        sed_compat "/${_dst##*/}$/d" "$OLD_SUDOERS"
     fi
     return 0
 }
 
-if [ -z "$type" ]; then
+# add or remove a single account/group, editing only its shard in place.
+manage_entity() {
+    # $1 = create|delete   $2 = account|group   $3 = name
+    local _todo="$1" _type="$2" _types="${2}s" _name="$3" _md5 _shard _dst
+
+    # on create we expect the entity to exist, check for this below
+    if [ "$_todo" = create ]; then
+        if [ "$_type" = account ]; then
+            if ! getent passwd "$_name" | grep -q ":$basedir/bin/shell/osh.pl$"; then
+                action_error "$_name is not a bastion account"
+                return 1
+            fi
+        else
+            if ! test -f "/home/$_name/allowed.ip"; then
+                action_error "$_name doesn't seem to be a valid bastion group"
+                return 1
+            fi
+        fi
+    fi
+    # on delete the caller may be mid-removal, so don't try to validate with that
+    # we have on the filesystem.
+    # ---
+
+    _md5=$(md5sum_compat - <<< "$_name")
+    printf -v _shard "%0${SHARD_WIDTH}d" "$(( 16#${_md5:0:8} % SUDOERS_SHARD_COUNT ))"
+    _dst="$SUDOERS_DIR/osh-$_types-shard-$_shard"
+
+    if [ "$_todo" = create ]; then
+        action_detail "... $_name -> ${_dst##*/}"
+    else
+        action_detail "... removing $_name from ${_dst##*/}"
+    fi
+
+    with_lock "osh-$_types-shard-$_shard" _apply_shard_edit "$_todo" "$_type" "$_name" "$_dst" "$_md5"
+}
+
+# rebuild every shard for a type from scratch (install / migration / count change).
+# Builds all touched shards as .tmp, validates, atomically publishes, then prunes any
+# stale shard file we didn't just write (emptied shards, orphans from a larger COUNT).
+regen_all() {
+    # $1 = account|group
+    local _type="$1" _types="${1}s" _name _md5 _shard _dst _tmp _bn _f
+    declare -A _started=()
+    declare -A _final=()
+
+    # cache the templates once before iterating (possibly) thousands of entities
+    load_templates "$_type"
+
+    while IFS= read -r _name; do
+        [ -n "$_name" ] || continue
+        _md5=$(md5sum_compat - <<< "$_name")
+        printf -v _shard "%0${SHARD_WIDTH}d" "$(( 16#${_md5:0:8} % SUDOERS_SHARD_COUNT ))"
+        _dst="$SUDOERS_DIR/osh-$_types-shard-$_shard"
+        _tmp="$_dst.tmp"
+        if [ -z "${_started[$_shard]:-}" ]; then
+            echo "# bastion sharded sudoers - $_type shard $_shard (do not edit by hand)" > "$_tmp"
+            _started[$_shard]=1
+        fi
+        render_block "$_type" "$_name" "$_md5" >> "$_tmp"
+    done < <(list_entities "$_type")
+
+    for _shard in "${!_started[@]}"; do
+        _dst="$SUDOERS_DIR/osh-$_types-shard-$_shard"
+        _tmp="$_dst.tmp"
+        chmod 0440 "$_tmp"
+        if ! validate_shard "$_tmp"; then
+            action_error "shard ${_dst##*/} failed visudo validation, skipping"
+            rm -f "$_tmp"
+            continue
+        fi
+        mv -f "$_tmp" "$_dst"
+        _final[${_dst##*/}]=1
+        if [ -n "${OLD_SUDOERS:-}" ]; then
+            sed_compat "/${_dst##*/}$/d" "$OLD_SUDOERS"
+        fi
+    done
+
+    # prune shard files for this type that we did not (re)write this run
+    for _f in "$SUDOERS_DIR"/osh-"$_types"-shard-*; do
+        [ -e "$_f" ] || continue
+        _bn="${_f##*/}"
+        case "$_bn" in
+            *.tmp) continue ;;
+            *) ;;
+        esac
+        if [ -z "${_final[$_bn]:-}" ]; then
+            action_detail "... pruning obsolete shard $_bn"
+            rm -f "$_f"
+        fi
+    done
+    return 0
+}
+
+# list existing bastion entities of a type, one name per line
+list_entities() {
+    # $1 = account|group
+    if [ "$1" = account ]; then
+        getent passwd | grep ":$basedir/bin/shell/osh.pl$" | cut -d: -f1 | sort
+    else
+        getent group | cut -d: -f1 | grep -- '-gatekeeper$' | sed -e 's/-gatekeeper$//' | sort
+    fi
+}
+
+#### main ####
+
+if [ "$type" != group ] && [ "$type" != account ]; then
+    echo "Invalid type specified" >&2
     die_usage
 fi
 
 nbfailed=0
-if [ "$type" = group ]; then
-    if [ -z "$name" ]; then
-        if [ "$action" = create ]; then
-            action_doing "Regenerating all groups sudoers files from templates"
-            for group in $(getent group | cut -d: -f1 | grep -- '-gatekeeper$' | sed -e 's/-gatekeeper$//' | sort); do
-                manage_group_sudoers create "$group" || nbfailed=$((nbfailed + 1))
-            done
-        elif [ "$action" = delete ]; then
-            echo "Cowardly refusing to delete all group sudoers, a man needs a name" >&2
-            die_usage
-        fi
+
+if [ -z "$name" ]; then
+    if [ "$action" = create ]; then
+        action_doing "Regenerating all $type sudoers shards from templates"
+        regen_all "$type" || nbfailed=$((nbfailed + 1))
+    elif [ "$action" = delete ]; then
+        echo "Cowardly refusing to delete all $type sudoers, a man needs a name" >&2
+        die_usage
     else
-        if [ "$action" = create ]; then
-            action_doing "Regenerating group '$name' sudoers file from templates"
-            manage_group_sudoers create "$name" || nbfailed=$((nbfailed + 1))
-        elif [ "$action" = delete ]; then
-            action_doing "Deleting group '$name' sudoers file"
-            manage_group_sudoers delete "$name"
-        fi
+        die_usage
     fi
-    if [ "$nbfailed" != 0 ]; then
-        action_error "Failed generating $nbfailed sudoers"
-    else
-        action_done
-    fi
-    exit $nbfailed
-elif [ "$type" = account ]; then
-    if [ -z "$name" ]; then
-        if [ "$action" = create ]; then
-            action_doing "Regenerating all accounts sudoers files from templates"
-            for account in $(getent passwd | grep ":$basedir/bin/shell/osh.pl$" | cut -d: -f1 | sort); do
-                manage_account_sudoers create "$account"|| nbfailed=$((nbfailed + 1))
-            done
-        elif [ "$action" = delete ]; then
-            echo "Cowardly refusing to delete all account sudoers, a man needs a name" >&2
-            die_usage
-        fi
-    else
-        if [ "$action" = create ]; then
-            action_doing "Regenerating account '$name' sudoers file from templates"
-            manage_account_sudoers create "$name"|| nbfailed=$((nbfailed + 1))
-        elif [ "$action" = delete ]; then
-            action_doing "Deleting account '$name' sudoers file"
-            manage_account_sudoers delete "$name"
-        fi
-    fi
-    if [ "$nbfailed" != 0 ]; then
-        action_error "Failed generating $nbfailed sudoers"
-    else
-        action_done
-    fi
-    exit $nbfailed
 else
-    echo "Invalid type specified" >&2
-    die_usage
+    if [ "$action" = create ]; then
+        action_doing "Updating $type '$name' sudoers shard"
+        manage_entity create "$type" "$name" || nbfailed=$((nbfailed + 1))
+    elif [ "$action" = delete ]; then
+        action_doing "Removing $type '$name' from its sudoers shard"
+        manage_entity delete "$type" "$name" || nbfailed=$((nbfailed + 1))
+    else
+        die_usage
+    fi
 fi
+
+if [ "$nbfailed" != 0 ]; then
+    action_error "Failed generating $nbfailed sudoers"
+else
+    action_done
+fi
+exit "$nbfailed"

--- a/etc/sudoers.account.template.d/100-header.sudoers
+++ b/etc/sudoers.account.template.d/100-header.sudoers
@@ -1,1 +1,0 @@
-## sudoers file for account %ACCOUNT%

--- a/etc/sudoers.account.template.d/500-base.sudoers
+++ b/etc/sudoers.account.template.d/500-base.sudoers
@@ -1,7 +1,5 @@
-# I need to be able to set my own UNIX account password
-%ACCOUNT% ALL=(root) NOPASSWD:/usr/bin/env perl -T %BASEPATH%/bin/helper/osh-selfMFASetupPassword --account %ACCOUNT% --step ?
-# I need to be able to enroll TOTP
-%ACCOUNT% ALL=(root) NOPASSWD:/usr/bin/env perl -T %BASEPATH%/bin/helper/osh-selfMFASetupTOTP --account %ACCOUNT%
-# I need to be able to reset my own UNIX account password and TOTP
-%ACCOUNT% ALL=(root) NOPASSWD:/usr/bin/env perl -T %BASEPATH%/bin/helper/osh-accountMFAResetPassword --account %ACCOUNT%
-%ACCOUNT% ALL=(root) NOPASSWD:/usr/bin/env perl -T %BASEPATH%/bin/helper/osh-accountMFAResetTOTP --account %ACCOUNT%
+%ACCOUNT% ALL=(root) NOPASSWD: \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-selfMFASetupPassword --account %ACCOUNT% --step ?, \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-selfMFASetupTOTP --account %ACCOUNT%, \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-accountMFAResetPassword --account %ACCOUNT%, \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-accountMFAResetTOTP --account %ACCOUNT%

--- a/etc/sudoers.group.template.d/100-header.sudoers
+++ b/etc/sudoers.group.template.d/100-header.sudoers
@@ -1,1 +1,0 @@
-## sudoers file for group %GROUP%

--- a/etc/sudoers.group.template.d/500-base.sudoers
+++ b/etc/sudoers.group.template.d/500-base.sudoers
@@ -1,41 +1,20 @@
-# as an owner, we can modify the group settings
-SUPEROWNERS, %%GROUP%-owner      ALL=(%GROUP%)     NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupModify --group %GROUP% *
-
-# as an owner, we can grant/revoke ownership
-SUPEROWNERS, %%GROUP%-owner      ALL=(root)        NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupSetRole --type owner --group %GROUP% *
-
-# as an owner, we can grant/revoke gatekeepership
-SUPEROWNERS, %%GROUP%-owner      ALL=(root)        NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupSetRole --type gatekeeper --group %GROUP% *
-
-# as an owner, we can grant/revoke aclkeepership
-SUPEROWNERS, %%GROUP%-owner      ALL=(root)        NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupSetRole --type aclkeeper --group %GROUP% *
-
-# as an owner, we can generate an egress password for the group
-SUPEROWNERS, %%GROUP%-owner      ALL=(%GROUP%)     NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupGeneratePassword --group %GROUP% *
-
-# as an owner, we can generate an egress key for the group
-SUPEROWNERS, %%GROUP%-owner      ALL=(root)        NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupGenerateEgressKey --group %GROUP% *
-
-# as an owner, we can delete an egress key of the group
-SUPEROWNERS, %%GROUP%-owner      ALL=(keykeeper)   NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupDelEgressKey --group %GROUP% *
-
-# as a gatekeeper, we can grant/revoke membership
-SUPEROWNERS, %%GROUP%-gatekeeper ALL=(root)        NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupSetRole --type member --group %GROUP% *
-
-# as a gatekeeper, to be able to symlink in /home/allowkeeper/ACCOUNT the /home/%GROUP%/allowed.ip file
-SUPEROWNERS, %%GROUP%-gatekeeper ALL=(allowkeeper) NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupAddSymlinkToAccount --group %GROUP% *
-
-# as a gatekeeper, we can grant/revoke a guest access
-SUPEROWNERS, %%GROUP%-gatekeeper ALL=(root)        NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupSetRole --type guest --group %GROUP% *
-
-# as a gatekeeper, to be able to add the servers to /home/allowkeeper/ACCOUNT/allowed.partial.%GROUP% file
-SUPEROWNERS, %%GROUP%-gatekeeper ALL=(allowkeeper) NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-accountAddGroupServer --group %GROUP% *
-
-# as an aclkeeper, we can add/del a server from the group server list in /home/%GROUP%/allowed.ip
-SUPEROWNERS, %%GROUP%-aclkeeper  ALL=(%GROUP%)     NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupAddServer --group %GROUP% *
-
-# as an aclkeeper, we can replace the group servers list in /home/%GROUP%/allowed.ip in batch with one command
-SUPEROWNERS, %%GROUP%-aclkeeper  ALL=(%GROUP%)     NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupSetServers --group %GROUP%
-
-# as an owner, we can delete our own group
-SUPEROWNERS, %%GROUP%-owner      ALL=(root)        NOPASSWD: /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupDelete --group %GROUP%
+SUPEROWNERS, %%GROUP%-owner      ALL=(%GROUP%)     NOPASSWD: \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupModify --group %GROUP% *, \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupGeneratePassword --group %GROUP% *
+SUPEROWNERS, %%GROUP%-owner      ALL=(root)        NOPASSWD: \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupSetRole --type owner --group %GROUP% *, \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupSetRole --type gatekeeper --group %GROUP% *, \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupSetRole --type aclkeeper --group %GROUP% *, \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupGenerateEgressKey --group %GROUP% *, \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupDelete --group %GROUP%
+SUPEROWNERS, %%GROUP%-owner      ALL=(keykeeper)   NOPASSWD: \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupDelEgressKey --group %GROUP% *
+SUPEROWNERS, %%GROUP%-gatekeeper ALL=(root)        NOPASSWD: \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupSetRole --type member --group %GROUP% *, \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupSetRole --type guest --group %GROUP% *
+SUPEROWNERS, %%GROUP%-gatekeeper ALL=(allowkeeper) NOPASSWD: \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupAddSymlinkToAccount --group %GROUP% *, \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-accountAddGroupServer --group %GROUP% *
+SUPEROWNERS, %%GROUP%-aclkeeper  ALL=(%GROUP%)     NOPASSWD: \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupAddServer --group %GROUP% *, \
+    /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-groupSetServers --group %GROUP%

--- a/lib/shell/functions.inc
+++ b/lib/shell/functions.inc
@@ -452,3 +452,34 @@ join_by(){
         printf "%s" "${first}" "${@/#/$delim}"
     fi
 }
+
+# number of sudoers shards per entity type (accounts, groups). Changing it
+# requires running `bin/sudogen/generate-sudoers.sh create account` and
+# `... create group` (full regen) so every entity moves to its new shard.
+# shellcheck disable=SC2034 # used in the sudogen script that sources us
+SUDOERS_SHARD_COUNT=32
+
+# with_lock <lockname> <command> [args...]
+# Serializes <command> against other holders of the same <lockname>.
+with_lock() {
+    local _name="$1"
+    shift
+    local _lockparent="${SUDOERS_DIR:-/tmp}/.osh-sudogen.lock.d"
+    local _lockdir="$_lockparent/$_name"
+    local _rc=0 _i=0
+
+    mkdir -p "$_lockparent" 2>/dev/null || true
+    while ! mkdir "$_lockdir" 2>/dev/null; do
+        _i=$((_i + 1))
+        if [ "$_i" -gt 600 ]; then
+            # ~60s elapsed: assume a crashed holder left a stale lock, steal it
+            echo "with_lock: stealing apparently-stale lock $_lockdir after 60s" >&2
+            break
+        fi
+        sleep 0.1
+    done
+
+    "$@" || _rc=$?
+    rmdir "$_lockdir" 2>/dev/null || true
+    return "$_rc"
+}


### PR DESCRIPTION
On bastions with 1k+ accounts and/or groups, there are thousands of sudoers files for sudo to parse at each helper invocation, which can take several hundreds of milliseconds, slowing down the plugins execution. This can stack up to seconds when sudo is invoked several times during a plugin execution, or if the number of accounts/groups is 10k+.

We now create and update sharded sudoers files for accounts and groups, instead of creating one file for each, as most of the sudo time, as seen by `perf`, was taken doing i/o reading these files.

We also cut down the number of sudo rules by deduplicating the rules sharing the same account/group/runas information, using the "," syntax to list them under the same tuple, further speeding up sudo's parsing.

This effectively reduces file stat/open/close i/o from O(N+M) to O(1).

On a test bastion with 1500 accounts and 1500 groups, we cut down the time it takes for "sudo true" to execute from 220ms to 50ms. As a side effect, it also cuts down sudoers regeneration time on install/upgrade from 60s to 7s on this test system.