### PR TITLE
fix: 'edcsa-sk' typo in default allowedIngressSshAlgorithms list

### DIFF
--- a/lib/perl/OVH/Bastion/configuration.inc
+++ b/lib/perl/OVH/Bastion/configuration.inc
@@ -368,7 +368,7 @@ sub load_configuration {
         ## no critic(RegularExpressions::ProhibitFixedStringMatches)
         {
             name    => 'allowedIngressSshAlgorithms',
-            default => [qw{ rsa ecdsa ed25519 edcsa-sk ed25519-sk }],
+            default => [qw{ rsa ecdsa ed25519 ecdsa-sk ed25519-sk }],
             validre => qr/^(rsa|ecdsa|ed25519|ecdsa-sk|ed25519-sk)$/
         },
         ## no critic(RegularExpressions::ProhibitFixedStringMatches)


### PR DESCRIPTION
Only used when the directive is entirely missing from the config file, which is not the case on default installations