### PR TITLE
enh: perf: disable the admin_flag option of sudo

### DIFF
--- a/bin/admin/check-consistency.pl
+++ b/bin/admin/check-consistency.pl
@@ -907,7 +907,7 @@ while (my $distfile = glob "$BASEDIR/etc/sudoers.d/*") {
             _err "sudoers file $distfile and $prodfile differ";
         }
     }
-    else {
+    elsif ($prodfile !~ /optional/) {
         _err "sudoers file $prodfile not found";
     }
 }

--- a/bin/admin/install
+++ b/bin/admin/install
@@ -506,6 +506,11 @@ if [ "$nothing" = 0 ]; then
     for file in "$basedir/etc/sudoers.d"/osh-*; do
         filename=$(basename "$file")
         sed_compat "/\/$filename$/d" "$oldsudoers"
+        # for optional sudoers files, first verify if our sudo can parse it
+        if echo "$filename" | grep -q optional && ! visudo -cqf "$filename" >/dev/null 2>&1; then
+            action_detail "... skipping $filename (unsupported but optional, non-fatal)"
+            continue
+        fi
         action_detail "... copying $filename"
         # don't use install(1) because it doesn't overwrite in place (it unlinks then copies data)
         # this can lead to a race condition if somebody uses sudo exactly at this moment, where it'll

--- a/etc/sudoers.d/osh-bastion-optional-admin-flag
+++ b/etc/sudoers.d/osh-bastion-optional-admin-flag
@@ -1,0 +1,4 @@
+# Disable the useless dropping of a file the first time sudo succeeds for a user,
+# this is meaningless on a bastion and avoids a sudo portion of code listing
+# all the groups of the calling user ( create_admin_success_flag() in sudoers/timestamp.c )
+Defaults !admin_flag


### PR DESCRIPTION
This is usually enabled by default and forces sudo to list all the groups of the calling user, for a feature that we don't need on bastions