### PR TITLE
enh: http proxy: graceful zero-downtime reload + pass body via STDIN

### DIFF
--- a/bin/admin/install
+++ b/bin/admin/install
@@ -81,6 +81,7 @@ set_default_options()
     opt[overwrite-syslog-ng]=1
     opt[check-ttyrec]=1
     opt[install-fake-ttyrec]=0
+    opt[reload-http-proxy]=1
 }
 set_default_options
 
@@ -111,6 +112,7 @@ while [ -n "$1" ]; do
         opt[overwrite-cron]=0
         opt[syslog-ng]=0
         opt[overwrite-syslog-ng]=0
+        opt[reload-http-proxy]=0
         [ "$1" = "--nothing" ] && nothing=1
     elif [ "$1" = "--managed-upgrade" ] || [ "$1" = "--puppet" ]; then
         set_default_options
@@ -133,7 +135,7 @@ while [ -n "$1" ]; do
             modify-pam-lastlog remove-weak-moduli regen-hostkeys overwrite-logrotate overwrite-cron \
             overwrite-syslog-ng logrotate cron syslog-ng migration-grant-aclkeeper-to-gatekeepers \
             init systemd-units profile modify-pam-sshd wait check-ttyrec install-fake-ttyrec \
-            install-selinux-module generate-mfa-secret
+            install-selinux-module generate-mfa-secret reload-http-proxy
         do
             if [ "$1" = "--no-$allowedopt" ]; then
                 opt[$allowedopt]=0
@@ -227,6 +229,9 @@ Usage:
     --[no-]check-ttyrec          verify that the ttyrec installed version is compatible with our code [N, U, M]
     --[no-]install-fake-ttyrec   install a fake ttyrec binary if ttyrec is not present; useful mainly for tests,
                                  or if you *really* don't want to use the real ttyrec
+
+    --[no-]reload-http-proxy     gracefully reload the HTTP proxy daemon, but only if it's already running, so
+                                 that a code upgrade is applied to it with zero downtime [N, U, M]
 
 EOF
     exit 1
@@ -1141,6 +1146,31 @@ if [ "${opt[systemd-units]}" = 1 ]; then
     done
     systemctl daemon-reload || true
     action_done
+fi
+
+if [ "${opt[reload-http-proxy]}" = 1 ]; then
+    # Gracefully reload the HTTP proxy daemon (only if it's already running)
+    action_doing "Gracefully reload the HTTP proxy daemon if it's already running"
+    proxy_daemon="$basedir/bin/proxy/osh-http-proxy-daemon"
+    if ! pgrep -f "$proxy_daemon" >/dev/null 2>&1; then
+        action_na "not running"
+    else
+        reloaded=0
+        if command -v systemctl >/dev/null && [ -d /var/run/systemd ] \
+            && systemctl is-active --quiet osh-http-proxy 2>/dev/null; then
+            systemctl reload osh-http-proxy && reloaded=1
+        elif [ -x /etc/init.d/osh-http-proxy ]; then
+            /etc/init.d/osh-http-proxy reload && reloaded=1
+        else
+            # last resort: signal the daemon directly, it'll re-exec itself in place
+            pkill -HUP -f "$proxy_daemon" && reloaded=1
+        fi
+        if [ "$reloaded" = 1 ]; then
+            action_done "reloaded"
+        else
+            action_error "failed to reload, you might want to do it manually"
+        fi
+    fi
 fi
 
 if [ "$autodetect_selinux" = 1 ]; then

--- a/bin/proxy/osh-http-proxy-daemon
+++ b/bin/proxy/osh-http-proxy-daemon
@@ -82,12 +82,18 @@ OVH::Bastion::ProxyHTTP->new()->run(
     max_spare_servers => $config->{'max_spare_servers'},
     access_log_file   => "/home/proxyhttp/access.log",
 
+    # Needed for graceful zero-downtime reload: on SIGHUP, Net::Server re-exec's this daemon while keeping
+    # the bound listening socket open. This option ensures the pre-existing children are left to drain
+    # and exit. As max_requests is 1, this happens as soon as the in-flight request is completed.
+    leave_children_open_on_hup => 1,
+
     # This is the max time allowed for http_process_request(), which is where we spawn our worker.
     # This value is defined when the proxy starts and is only applicable to the master process, hence it can't be
     # modified afterwards with X-Bastion-Timeout.
     # So we set it to the max value allowed for X-Bastion-Timeout,
     # which is also the max allowed value of the 'timeout' config param (see above).
     timeout_idle => 3600,
+
     proxy_config => {
         insecure                      => $config->{'insecure'} ? 1 : 0,
         timeout                       => $config->{'timeout'},                         # our worker will wait for up to this amount of time for the egress connection to complete

--- a/bin/proxy/osh-http-proxy-worker
+++ b/bin/proxy/osh-http-proxy-worker
@@ -90,13 +90,19 @@ GetOptions(
 );
 push @headers, ["X-Bastion-Remote-Host" => $remotemachine];
 
+# the daemon normally passes --post-data-stdin and feeds the body on our STDIN (below). The env
+# branch is the fallback for the upgrade window: a not-yet-restarted daemon runs the previous in-RAM
+# code and still passes the body via PROXY_POST_DATA. Keep it until that path is no longer possible.
 if (!$postDataStdin) {
+    # TODO: remove this a few releases after --post-data-stdin is shipped.
     $content = delete $ENV{'PROXY_POST_DATA'};
     $content = decode_base64($content) if $content;
 }
 else {
+    binmode STDIN;
     local $/ = undef;
     $content = <STDIN>;
+    $content //= '';    # readline returns undef on an empty stream (e.g. a body-less GET)
 }
 push @headers, ["X-Bastion-Request-Length" => "" . length($content)];
 

--- a/doc/sphinx/administration/configuration/osh-http-proxy_conf.rst
+++ b/doc/sphinx/administration/configuration/osh-http-proxy_conf.rst
@@ -56,12 +56,14 @@ do the trick.
 port
 ****
 
-:Type: ``int, 1 to 65535``
+:Type: ``int, 1024 to 65535``
 
 :Default: ``8443``
 
-The port to listen to. You can use ports < 1024, in which case privileges will be dropped after binding,
-but please ensure your systemd unit file starts the daemon as root in that case.
+The port to listen to. The daemon runs unprivileged (as the 'proxyhttp' user) and never
+binds as root, so this must be a non-privileged port (>= 1024). If you need to expose the
+proxy on a privileged port such as 443, redirect it to this port at the firewall level
+(e.g. an iptables/pf REDIRECT rule).
 
 ssl_certificate
 ***************

--- a/etc/bastion/osh-http-proxy.conf.dist
+++ b/etc/bastion/osh-http-proxy.conf.dist
@@ -28,9 +28,11 @@
 # DEFAULT: false
 "enabled": false,
 #
-# port (int, 1 to 65535)
-#     DESC: The port to listen to. You can use ports < 1024, in which case privileges will be dropped after binding,
-#           but please ensure your systemd unit file starts the daemon as root in that case.
+# port (int, 1024 to 65535)
+#     DESC: The port to listen to. The daemon runs unprivileged (as the 'proxyhttp' user) and never
+#           binds as root, so this must be a non-privileged port (>= 1024). If you need to expose the
+#           proxy on a privileged port such as 443, redirect it to this port at the firewall level
+#           (e.g. an iptables/pf REDIRECT rule).
 #  DEFAULT: 8443
 "port": 8443,
 #

--- a/etc/init.d/osh-http-proxy
+++ b/etc/init.d/osh-http-proxy
@@ -39,25 +39,39 @@ case "$1" in
     stop)
         echo -n "Shutting down osh-http-proxy-daemon daemon... "
         if pgrep -c -f $DAEMON >/dev/null ; then
-            pkill -f $DAEMON
+            # SIGQUIT asks the daemon to stop accepting and drain in-flight requests before exiting,
+            # instead of killing them mid-request (which would surface as 500s to clients)
+            pkill -QUIT -f $DAEMON
             echo done
         else
             echo "not running"
         fi
         ;;
-    force-reload|restart)
-        echo -n "Restarting osh-http-proxy-daemon daemon"
+    reload|force-reload)
+        # Graceful, zero-downtime reload: SIGHUP makes the daemon re-exec itself in place (picking up
+        # new code and config) while keeping the listening socket open and draining in-flight requests.
+        # This is the command to use after a code upgrade.
+        echo -n "Reloading osh-http-proxy-daemon daemon... "
         if pgrep -c -f $DAEMON >/dev/null ; then
-            pkill -f $DAEMON
+            pkill -HUP -f $DAEMON
             echo done
         else
             echo "not running"
         fi
-        start-stop-daemon --start --background --exec $DAEMON
+        ;;
+    restart)
+        echo -n "Restarting osh-http-proxy-daemon daemon"
+        if pgrep -c -f $DAEMON >/dev/null ; then
+            pkill -QUIT -f $DAEMON
+            echo done
+        else
+            echo "not running"
+        fi
+        start-stop-daemon --start --background --chuid $USER --exec $DAEMON
         echo "."
         ;;
     *)
-        echo "Usage: $0 {start|stop|restart|force-reload}"
+        echo "Usage: $0 {start|stop|restart|reload|force-reload}"
         exit 1
 esac
 exit 0

--- a/etc/sudoers.d/osh-bastion-http-proxy
+++ b/etc/sudoers.d/osh-bastion-http-proxy
@@ -1,3 +1,7 @@
+# Note: PROXY_POST_DATA is no longer used by the daemon, which now passes the request body to the
+# worker through STDIN instead of the environment. It is however kept in env_keep on purpose to ensure
+# a non-breaking upgrade.
+# TODO: remove this a few releases after --post-data-stdin is shipped.
 Defaults:proxyhttp env_keep += "PROXY_POST_DATA PROXY_ACCOUNT_PASSWORD REMOTE_ADDR REMOTE_PORT SERVER_ADDR SERVER_PORT REQUEST_URI HTTP_USER_AGENT"
 
 proxyhttp ALL=(%bastion-users) NOPASSWD:/usr/bin/env perl -T /opt/bastion/bin/proxy/osh-http-proxy-worker *

--- a/etc/systemd/osh-http-proxy.service
+++ b/etc/systemd/osh-http-proxy.service
@@ -10,7 +10,20 @@ ConditionPathExists=/home/allowkeeper/healthcheck/allowed.ip
 
 [Service]
 ExecStart=/opt/bastion/bin/proxy/osh-http-proxy-daemon
+
+# Graceful, zero-downtime reload: `systemctl reload osh-http-proxy` sends SIGHUP, which makes the
+# daemon re-exec itself in place (picking up new code and config) while keeping the listening socket
+# open and letting in-flight requests drain. Use this use after a code upgrade.
+ExecReload=/bin/kill -HUP $MAINPID
+
+# On stop/restart, drain rather than kill: SIGQUIT triggers a graceful shutdown.
+# KillMode=process required, so that systemd only signals the master, not the children.
+# TimeoutStopSec must be long enough for an in-flight request to complete; keep it slightly above the largest expected
+# egress 'timeout' (default 120s) and raise it if you raise that config value.
 KillMode=process
+KillSignal=SIGQUIT
+TimeoutStopSec=130s
+
 Restart=on-failure
 RestartSec=5s
 User=proxyhttp

--- a/lib/perl/OVH/Bastion/ProxyHTTP.pm
+++ b/lib/perl/OVH/Bastion/ProxyHTTP.pm
@@ -189,14 +189,17 @@ sub run {
 }
 
 # used twice in process_http_request(): get the worker cmd to execute, launch it
-# and decapsulate the result with the proper error checks
-## no critic (Subroutines::RequireArgUnpacking)
+# and decapsulate the result with the proper error checks. The request body, if any, is
+# passed to the worker through its STDIN (the worker reads it fully before producing output).
 sub _exec_worker_and_get_result {
-    my $self = shift;
-    my @cmd  = @_;
+    my ($self, $cmdref, $stdin_str) = @_;
+    my @cmd = @$cmdref;
     my $fnret;
 
-    $fnret = OVH::Bastion::execute_simple(cmd => \@cmd);
+    # execute() natively pipes stdin_str to the worker (interleaving the write with reading the worker's
+    # stdout, so a large request body can't deadlock us), and gives us back the worker's stdout. With an
+    # empty/undef body it closes the worker's stdin right away, giving it the EOF it waits for.
+    $fnret = OVH::Bastion::execute(cmd => \@cmd, stdin_str => $stdin_str // '');
     $fnret
       or return $self->log_and_exit(
         500,
@@ -214,7 +217,10 @@ sub _exec_worker_and_get_result {
         );
     }
 
-    if (!$fnret->value->{'output'}) {
+    # execute() returns stdout already split on $/, reassemble it into the worker's JSON blob
+    my $output = join($/, @{$fnret->value->{'stdout'} || []});
+
+    if (!$output) {
         return $self->log_and_exit(
             500,
             "Internal Error (worker returned no data)",
@@ -224,15 +230,15 @@ sub _exec_worker_and_get_result {
     }
 
     my $json_decoded;
-    eval { $json_decoded = decode_json($fnret->value->{'output'}); };
+    eval { $json_decoded = decode_json($output); };
     if ($@) {
         return $self->log_and_exit(
             500,
             "Internal Error (worker returned invalid JSON)",
             "Worker returned "
-              . (length($fnret->value->{'output'}))
+              . (length($output))
               . " bytes of data but JSON decoding failed ($@). The first 500 bytes follow:\n"
-              . substr($fnret->value->{'output'}, 0, 500),
+              . substr($output, 0, 500),
             {comment => "worker_invalid_json"}
         );
     }
@@ -325,7 +331,7 @@ sub process_http_request {
         );
         push @cmd, "--monitoring", "--uniqid", $ENV{'UNIQID'};
 
-        $fnret = $self->_exec_worker_and_get_result(@cmd);
+        $fnret = $self->_exec_worker_and_get_result(\@cmd);
 
         my $workerversion = $fnret->value->{'body'};
 
@@ -575,6 +581,9 @@ sub process_http_request {
       if ($self->{'proxy_config'}{'log_request_response'});
     push @cmd, "--egress-protocol", $egress_protocol;
 
+    # the request body is passed to the worker through its STDIN (see below), not the environment
+    push @cmd, "--post-data-stdin";
+
     # X-Test-* is only used for functional tests, and has to be passed to the remote
     foreach my $pattern (qw{ accept content-type content-length content-encoding x-test-[a-z-]+ }) {
         foreach my $key (grep { /^$pattern$/i } keys %$req_headers) {
@@ -596,17 +605,16 @@ sub process_http_request {
     if (my $param = $verb2param{$self->{'request_info'}{'request_method'}}) {
         $content = CGI->new->param($param);
     }
-    $ENV{'CONTENT_TYPE'}    = $real_content_type;
-    $ENV{'PROXY_POST_DATA'} = encode_base64($content);
+    $ENV{'CONTENT_TYPE'} = $real_content_type;
 
     $ENV{'PROXY_ACCOUNT_PASSWORD'} = $pass;
     undef $pass;
-    $self->{'_log'}{'request_body_length'} = length($content);
+    $self->{'_log'}{'request_body_length'} = length($content // '');
 
-    $fnret = $self->_exec_worker_and_get_result(@cmd);
+    # the body goes to the worker through STDIN
+    $fnret = $self->_exec_worker_and_get_result(\@cmd, $content);
 
     delete $ENV{'PROXY_ACCOUNT_PASSWORD'};
-    delete $ENV{'PROXY_POST_DATA'};
 
     if (ref $fnret->value->{'headers'} eq 'ARRAY') {
         push @{$self->{'_supplementary_headers'}}, @{$fnret->value->{'headers'}};

--- a/lib/perl/OVH/Bastion/execute.inc
+++ b/lib/perl/OVH/Bastion/execute.inc
@@ -212,6 +212,12 @@ sub execute {
         # monitor our own stdin only if we expect it (we'll pipe it to our child's stdin)
         $select->add(\*STDIN);
     }
+    else {
+        # we have nothing to feed to our child's stdin (no stdin_str, and we're not piping our own
+        # stdin to it), so close it right away to give the child an EOF: otherwise a child that reads
+        # its stdin until EOF (such as our http proxy worker) would block waiting for data forever
+        close($child_stdin);
+    }
 
     # then, while we still have at least two filehandles to monitor OR we have only one which is not our own STDIN:
     while ($select->count() > 1 || ($select->count() == 1 && !$select->exists(\*STDIN))) {

--- a/tests/functional/proxy/remote-daemon
+++ b/tests/functional/proxy/remote-daemon
@@ -18,6 +18,7 @@ sub process_http_request {
 
     my $hasContentType;
     my $wantedResponseSize = 64;
+    my $responseDelay      = 0;
 
     # this is to get the unparsed body of the request, portion of code
     # taken from lib/perl/OVH/Bastion/ProxyHTTP.pm, more context available over there
@@ -37,7 +38,15 @@ sub process_http_request {
         elsif (lc $headerTuple->[0] eq 'x-test-wanted-response-size') {
             $wantedResponseSize = $headerTuple->[1];
         }
+        elsif (lc $headerTuple->[0] eq 'x-test-response-delay') {
+            # hold the response for N seconds, to keep the request in-flight on the proxy side
+            ($responseDelay) = $headerTuple->[1] =~ /^(\d+)$/;
+        }
     }
+
+    # delay the whole response if asked to (used by the graceful-reload test)
+    sleep $responseDelay if $responseDelay;
+
     print "Content-type: text/plain\n" if !$hasContentType;
 
     # if the request had a body, include it verbatim in our answer

--- a/tests/functional/tests.d/500-http-proxy.sh
+++ b/tests/functional/tests.d/500-http-proxy.sh
@@ -28,12 +28,12 @@ testsuite_proxy()
     # as a --no-color or similar option doesn't seem to exist for curl.
 
     # check that the proxy is up
-    script monitoring "curl -ski https://$remote_ip:$remote_proxy_port/bastion-health-check | cat; exit \${PIPESTATUS[0]}"
+    script monitoring "curl -m $default_timeout -ski https://$remote_ip:$remote_proxy_port/bastion-health-check | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'running nominally'
 
     # and let's go
-    script noauth "curl -ski https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script noauth "curl -m $default_timeout -ski https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     testsuite_proxy_check_headers
     contain 'HTTP/1.0 401 Authorization required (no auth provided)'
@@ -41,7 +41,7 @@ testsuite_proxy()
     contain 'Content-Type: text/plain'
     contain 'No authentication provided, and authentication is mandatory'
 
-    script bad_auth_format "curl -ski -u test:test https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script bad_auth_format "curl -m $default_timeout -ski -u test:test https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 400 Bad Request (bad login format)'
     testsuite_proxy_check_headers
@@ -49,7 +49,7 @@ testsuite_proxy()
     contain 'Content-Type: text/plain'
     contain 'Expected an Authorization line with credentials of the form'
 
-    script bad_auth "curl -ski -u test@test@test:test https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script bad_auth "curl -m $default_timeout -ski -u test@test@test:test https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 403 Access Denied'
     contain 'Server: The Bastion'
@@ -66,7 +66,7 @@ testsuite_proxy()
     proxy_password=$(get_json | jq -r '.value.password')
 
     # now try to use these
-    script good_auth_bad_host "curl -ski -u '$account0@test@test.invalid:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script good_auth_bad_host "curl -m $default_timeout -ski -u '$account0@test@test.invalid:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 400 Bad Request (ERR_HOST_NOT_FOUND)'
     testsuite_proxy_check_headers
@@ -86,7 +86,7 @@ testsuite_proxy()
     proxy_password2=$(get_json | jq -r '.value.password')
 
     # attempt to use the previous credentials (and fail)
-    script bad_auth2 "curl -ski -u test@test@test:test https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script bad_auth2 "curl -m $default_timeout -ski -u test@test@test:test https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     testsuite_proxy_check_headers
     contain 'HTTP/1.0 403 Access Denied'
@@ -96,7 +96,7 @@ testsuite_proxy()
 
     proxy_password="$proxy_password2"
 
-    script good_auth_no_access "curl -ski -u '$account0@test@127.0.0.1:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script good_auth_no_access "curl -m $default_timeout -ski -u '$account0@test@127.0.0.1:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 403 Access Denied (access denied to remote)'
     testsuite_proxy_check_headers
@@ -109,7 +109,7 @@ testsuite_proxy()
     contain 'Content-Type: text/plain'
     contain "This account doesn't have access to this user@host tuple (Access denied for $account0 to test@127.0.0.1:443)"
 
-    script good_auth_no_access_other_port "curl -ski -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script good_auth_no_access_other_port "curl -m $default_timeout -ski -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 403 Access Denied (access denied to remote)'
     testsuite_proxy_check_headers
@@ -126,7 +126,7 @@ testsuite_proxy()
     success add_personal_access $a0 --osh selfAddPersonalAccess --host 127.0.0.1 --port-any --user test --force
     json .command selfAddPersonalAccess .error_code OK
 
-    script missing_egress_pwd "curl -ski -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script missing_egress_pwd "curl -m $default_timeout -ski -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 412 Precondition Failed (egress password missing)'
     testsuite_proxy_check_headers
@@ -144,7 +144,7 @@ testsuite_proxy()
     json .command selfGeneratePassword .error_code OK .value.account $account0 .value.context account
 
     # and retry
-    script bad_certificate "curl -ski -H 'X-Bastion-Enforce-Secure: 1' -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script bad_certificate "curl -m $default_timeout -ski -H 'X-Bastion-Enforce-Secure: 1' -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     # not all versions of LWP add "(certificate verify failed)" at the end of the below error message, so omit it
     contain "HTTP/1.0 500 Can't connect to 127.0.0.1:9443"
@@ -158,7 +158,7 @@ testsuite_proxy()
     contain 'Content-Type: text/plain'
     contain "Can't connect to 127.0.0.1:9443"
 
-    script insecure "curl -ski -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script insecure "curl -m $default_timeout -ski -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain "HTTP/1.0 200 OK"
     testsuite_proxy_check_headers
@@ -177,7 +177,7 @@ testsuite_proxy()
     contain "Content-Length: 64"
 
     # generate 1MB of data
-    script one_megabyte "curl -ski -H 'X-Test-Add-Response-Header-Content-Type: application/json' -H 'X-Test-Wanted-Response-Size: 1000000' -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script one_megabyte "curl -m $default_timeout -ski -H 'X-Test-Add-Response-Header-Content-Type: application/json' -H 'X-Test-Wanted-Response-Size: 1000000' -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain "HTTP/1.0 200 OK"
     testsuite_proxy_check_headers
@@ -195,8 +195,54 @@ testsuite_proxy()
     contain "X-Bastion-Egress-Timing: "
     contain "Content-Length: 1000000"
 
+    # graceful, zero-downtime reload (SIGHUP): an in-flight request must drain to completion
+    # (not be killed), and requests issued during/after the reload must still be served because
+    # the listening socket is never closed. The daemon re-execs in place, so the watchdog in
+    # target_role.sh (which only restarts it if no process matches) doesn't interfere.
+    # The reload also logs to syslog, so ignore that for the code-warning check.
+    ignorecodewarn 'osh-http-proxy-daemon'
+    script graceful_reload "
+        out=\$(mktemp)
+        # 1) start a slow request: the fake remote holds the response for 8s, keeping it in-flight
+        curl -ski --max-time 40 -H 'X-Test-Response-Delay: 8' -H 'X-Test-Wanted-Response-Size: 54321' -u '$account0@test@127.0.0.1%9443:$proxy_password' 'https://$remote_ip:$remote_proxy_port/test' > \"\$out\" 2>&1 &
+        slowpid=\$!
+        # 2) give it time to be accepted and connected to the slow remote
+        sleep 3
+        # 3) gracefully reload the daemon while that request is still in-flight (single-word remote
+        #    command, so no shell-quoting headaches; -f matches the daemon, not the worker)
+        $r0 pkill -HUP -f osh-http-proxy-daemon
+        # 4) a brand new request right after the reload must succeed (socket stayed bound)
+        sleep 1
+        echo BEGIN_NEW_REQUEST
+        # pipe through cat so curl's stdout isn't a TTY: recent curl colorizes header names
+        # with ANSI codes otherwise, which would break the literal Content-Length match below
+        curl -ski --max-time 15 -u '$account0@test@127.0.0.1%9443:$proxy_password' 'https://$remote_ip:$remote_proxy_port/test' | cat
+        echo END_NEW_REQUEST
+        # 5) the in-flight request must have completed with its full body, not been cut off
+        wait \$slowpid
+        echo BEGIN_INFLIGHT_RESULT
+        cat \"\$out\"
+        echo END_INFLIGHT_RESULT
+        rm -f \"\$out\"
+    "
+    retvalshouldbe 0
+    # the new request (no size header -> 64-byte body) was served during/after the reload
+    contain 'BEGIN_NEW_REQUEST'
+    contain 'Content-Length: 64'
+    # the in-flight request (54321-byte body) drained to completion instead of being killed
+    contain 'Content-Length: 54321'
+    # no refused connection (listener gap) and no truncated/killed in-flight response
+    nocontain 'Connection refused'
+    nocontain 'Failed to connect'
+    nocontain 'Empty reply from server'
+
+    # the daemon must still be healthy after the in-place reload
+    script post_reload_health "curl -m $default_timeout -ski https://$remote_ip:$remote_proxy_port/bastion-health-check | cat; exit \${PIPESTATUS[0]}"
+    retvalshouldbe 0
+    contain 'running nominally'
+
     # use a disallowed method
-    script forbidden_method "curl -ski -X PUT -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script forbidden_method "curl -m $default_timeout -ski -X PUT -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 400 Bad Request (method forbidden)'
     contain 'Server: The Bastion'
@@ -216,7 +262,7 @@ testsuite_proxy()
     waitfor 4 "waiting for daemon restart"
 
     # post some data
-    script post_data "curl -ski -X POST -d somedata -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script post_data "curl -m $default_timeout -ski -X POST -d somedata -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain "HTTP/1.0 200 OK"
     testsuite_proxy_check_headers
@@ -236,7 +282,7 @@ testsuite_proxy()
     contain "somedata"
 
     # put some data
-    script patch_data "curl -ski -X PUT -d somedata -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script patch_data "curl -m $default_timeout -ski -X PUT -d somedata -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain "HTTP/1.0 200 OK"
     testsuite_proxy_check_headers
@@ -256,7 +302,7 @@ testsuite_proxy()
     contain "somedata"
 
     # put some data with no body
-    script patch_data_no_body "curl -ski -X PUT -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script patch_data_no_body "curl -m $default_timeout -ski -X PUT -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain "HTTP/1.0 200 OK"
     testsuite_proxy_check_headers
@@ -275,7 +321,7 @@ testsuite_proxy()
     contain "Content-Length: 64"
 
     # use a disallowed egress method
-    script forbidden_egress_protocol "curl -ski -H 'X-Bastion-Egress-Protocol: http' -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script forbidden_egress_protocol "curl -m $default_timeout -ski -H 'X-Bastion-Egress-Protocol: http' -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 400 Bad Request (forbidden egress protocol)'
     testsuite_proxy_check_headers
@@ -295,7 +341,7 @@ testsuite_proxy()
     # when daemon will restart, it'll log stuff, ignore it
     ignorecodewarn 'osh-http-proxy-daemon'
     # http should be allowed now
-    script allowed_http_egress "curl -ski -H 'X-Bastion-Egress-Protocol: http' -u '$account0@test@127.0.0.1%22:$proxy_password' https://$remote_ip:$remote_proxy_port/test 2>&1 | cat; exit \${PIPESTATUS[0]}"
+    script allowed_http_egress "curl -m $default_timeout -ski -H 'X-Bastion-Egress-Protocol: http' -u '$account0@test@127.0.0.1%22:$proxy_password' https://$remote_ip:$remote_proxy_port/test 2>&1 | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 200'
     testsuite_proxy_check_headers
@@ -307,7 +353,7 @@ testsuite_proxy()
     contain 'SSH-2.0'
 
     # take this opportunity to test the remote-host header (otherwise, call is the same as above)
-    script allowed_http_egress_test_host "curl -ski -H 'X-Bastion-Egress-Protocol: http' -u '$account0@test@localhost%22:$proxy_password' https://$remote_ip:$remote_proxy_port/test 2>&1 | cat; exit \${PIPESTATUS[0]}"
+    script allowed_http_egress_test_host "curl -m $default_timeout -ski -H 'X-Bastion-Egress-Protocol: http' -u '$account0@test@localhost%22:$proxy_password' https://$remote_ip:$remote_proxy_port/test 2>&1 | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 200'
     testsuite_proxy_check_headers
@@ -319,7 +365,7 @@ testsuite_proxy()
     contain 'SSH-2.0'
 
     # and https disallowed
-    script forbidden_https_egress "curl -ski -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script forbidden_https_egress "curl -m $default_timeout -ski -u '$account0@test@127.0.0.1%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 400 Bad Request (forbidden egress protocol)'
     testsuite_proxy_check_headers
@@ -328,7 +374,7 @@ testsuite_proxy()
     contain 'not allowed by policy'
 
     # try an IPv6
-    script ipv6 "curl -ski -H 'X-Bastion-Egress-Protocol: http' -u '$account0@test@[::1]%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    script ipv6 "curl -m $default_timeout -ski -H 'X-Bastion-Egress-Protocol: http' -u '$account0@test@[::1]%9443:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'ERR_IP_VERSION_DISABLED'
 }


### PR DESCRIPTION
Add a graceful, zero-downtime reload: on SIGHUP the daemon re-execs in place, while keeping the listening socket open, so in-flight requests drain instead of being killed, and no connection is refused.

Pass the request body to the worker through its STDIN instead of the environment, removing the env-size limit.

Through the install/upgrade script, we now hot-reload the proxy on upgrade (only if it's already running).