### PR TITLE
fix: http proxy: validate user properly

### DIFF
--- a/bin/proxy/osh-http-proxy-worker
+++ b/bin/proxy/osh-http-proxy-worker
@@ -16,7 +16,6 @@ use HTTP::Message;
 use IO::Pipe;
 use IO::Select;
 use IO::Socket::SSL;
-use IO::Socket::SSL;
 use LWP::UserAgent;
 use MIME::Base64;
 use POSIX    ();
@@ -117,7 +116,15 @@ $egress_protocol ||= "https";
 
 $fnret = OVH::Bastion::is_bastion_account_valid_and_existing(account => $account);    # time: 20ms
 $fnret or log_and_exit(400, "Bad Request (bad account)", "Account name is invalid\n", {comment => "invalid_account"});
-$account               = $fnret->value->{'account'};                                  # untaint
+$account = $fnret->value->{'account'};                                                # untaint
+
+# re-validate the remote user here, the daemon already checks this, but as a privileged helper
+# we must revalidate everything that is passed on to us
+if (!defined $user || !($fnret = OVH::Bastion::is_valid_remote_user(user => $user, stricter => 1))) {
+    log_and_exit(400, "Bad Request (bad user name)", "User name is invalid\n", {comment => "bad_user_name"});
+}
+$user = $fnret->value;    # untaint
+
 $log_params{'account'} = $account;
 $log_params{'user'}    = $user;
 $log_params{'hostto'}  = $remotemachine;

--- a/lib/perl/OVH/Bastion.pm
+++ b/lib/perl/OVH/Bastion.pm
@@ -818,11 +818,17 @@ sub is_valid_remote_user {
     my %params         = @_;
     my $user           = $params{'user'};
     my $allowWildcards = $params{'allowWildcards'};
+    my $stricter       = $params{'stricter'};
+
+    my $extraChars = '';
+
+    # by default, allow those
+    $extraChars .= '@!:' if !$stricter;
 
     # if allowWildcards, then additional chars are allowed in the regex
-    my $extraChars = ($allowWildcards ? '?*' : '');
+    $extraChars .= '?*' if $allowWildcards;
 
-    if ($user =~ /^([\Q${extraChars}\Ea-zA-Z0-9._@!:-]{1,128})$/) {
+    if ($user =~ /^([\Q${extraChars}\Ea-zA-Z0-9._-]{1,128})$/) {
         return R('OK', value => $1);
     }
     return R('ERR_INVALID_PARAMETER', msg => "Specified user doesn't seem to be valid");

--- a/lib/perl/OVH/Bastion/ProxyHTTP.pm
+++ b/lib/perl/OVH/Bastion/ProxyHTTP.pm
@@ -484,7 +484,7 @@ sub process_http_request {
     $account = $fnret->value->{'account'};                      # untaint
     $self->{'_log'}{'account'} = $account;
 
-    if ($user !~ /^[a-zA-Z0-9._-]+/) {
+    if (!OVH::Bastion::is_valid_remote_user(user => $user, stricter => 1)) {
         return $self->log_and_exit(
             400,
             "Bad Request (bad user name)",

--- a/tests/functional/tests.d/500-http-proxy.sh
+++ b/tests/functional/tests.d/500-http-proxy.sh
@@ -96,6 +96,17 @@ testsuite_proxy()
 
     proxy_password="$proxy_password2"
 
+    # a remote user name with forbidden characters must be rejected (regression test for the
+    # user revalidation done by both the daemon and the worker, see is_valid_remote_user(stricter => 1)).
+    # '!' is rejected under stricter mode; the daemon's previous (loose, unanchored) regex let it through.
+    script bad_user_name "curl -m $default_timeout -ski -u '$account0@te!st@127.0.0.1:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
+    retvalshouldbe 0
+    contain 'HTTP/1.0 400 Bad Request (bad user name)'
+    testsuite_proxy_check_headers
+    nocontain 'WWW-Authenticate: '
+    contain 'Content-Type: text/plain'
+    contain "User name 'te!st' has forbidden characters"
+
     script good_auth_no_access "curl -m $default_timeout -ski -u '$account0@test@127.0.0.1:$proxy_password' https://$remote_ip:$remote_proxy_port/test | cat; exit \${PIPESTATUS[0]}"
     retvalshouldbe 0
     contain 'HTTP/1.0 403 Access Denied (access denied to remote)'


### PR DESCRIPTION
Recheck it in worker, and fix the check regex in the daemon. Not exploitable due to the additional get_passfile() sanitization, but still apply defense-in-depth and fix it.