### PR TITLE
chg: test all FreeBSD upstream supported versions

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -8,8 +8,11 @@ on:
 jobs:
   freebsd:
     runs-on: ubuntu-latest
-    name: FreeBSD
+    name: FreeBSD ${{ matrix.version }}
     if: ${{ contains(github.event.pull_request.labels.*.name, 'tests:freebsd') }}
+    strategy:
+      matrix:
+        version: ['14.4', '15.0', '15.1']
     timeout-minutes: 45
     steps:
     - uses: actions/checkout@v6
@@ -19,7 +22,7 @@ jobs:
       uses: cross-platform-actions/action@master
       with:
         operating_system: freebsd
-        version: '14.3'
+        version: ${{ matrix.version }}
         shell: bash
         sync_files: runner-to-vm
         run: |

--- a/README.md
+++ b/README.md
@@ -120,16 +120,16 @@ Linux distros below are tested with each release, but as this is a security prod
 - Debian 13 (Trixie), 12 (Bookworm), 11 (Bullseye)
 - RockyLinux 9.x, 8.x
 - Ubuntu LTS 24.04, 22.04, 20.04
-- OpenSUSE Leap 15.5\*
+- OpenSUSE Leap 15.6\*
 
 \*: Note that these versions have no out-of-the-box MFA support, as they lack packaged versions of `pamtester`, `pam-google-authenticator`, or both. Of course, you may compile those yourself.
 Any other so-called "modern" Linux version are not tested with each release, but should work with no or minor adjustments.
 
 The following OS are also tested with each release:
 
-- FreeBSD/HardenedBSD 14.3\*\*
+- FreeBSD 14.4, 15.0, 15.1\*\*
 
-\*\*: Note that these have partial MFA support, due to their reduced set of available `pam` plugins. Support for either an additional password or TOTP factor can be configured, but not both at the same time. The code is actually known to work on FreeBSD/HardenedBSD 10+, but it's only regularly tested under 14.3.
+\*\*: Note that these have partial MFA support, due to their reduced set of available `pam` plugins. Support for either an additional password or TOTP factor can be configured, but not both at the same time.
 
 Other BSD variants, such as OpenBSD and NetBSD, are unsupported as they have a severe limitation over the maximum number of supplementary groups, causing problems for group membership and restricted commands checks, as well as no filesystem-level ACL support and missing PAM support (hence no MFA).
 

--- a/doc/sphinx/installation/basic.rst
+++ b/doc/sphinx/installation/basic.rst
@@ -44,11 +44,10 @@ but should work with no or minor adjustments.
 
 The following OS are also tested with each release:
 
-- FreeBSD/HardenedBSD 14.3\*\*
+- FreeBSD 14.4, 15.0, 15.1\*\*
 
 \*\*: Note that these have partial MFA support, due to their reduced set of available ``pam`` plugins.
 Support for either an additional password or TOTP factor can be configured, but not both at the same time.
-The code is actually known to work on FreeBSD/HardenedBSD 10+, but it's only regularly tested under 14.3.
 
 Other BSD variants, such as OpenBSD and NetBSD, are unsupported as they have a severe limitation over the maximum
 number of supplementary groups, causing problems for group membership and restricted commands checks,


### PR DESCRIPTION
Also drop the HardenedBSD text, as we didn't test it recently: users can still try to use the software on FreeBSD forks, as long as they're compatible with upstream FreeBSD