### PR TITLE
fix: per-plugin lock time config was ignored

### DIFF
--- a/bin/shell/osh.pl
+++ b/bin/shell/osh.pl
@@ -1132,7 +1132,7 @@ if ($osh_command) {
         $ENV{'OSH_IP_FROM'} = $ipfrom;    # used in some plugins for is_access_granted()
 
         # check if we have a plugin override for idle lock/kill timeouts
-        foreach my $timeoutType (qw{ idle kill }) {
+        foreach my $timeoutType (qw{ lock kill }) {
             $fnret = OVH::Bastion::plugin_config(plugin => $osh_command, key => "idle_${timeoutType}_timeout");
             if ($fnret && defined $fnret->value) {
                 $idleTimeout{${timeoutType}} = $fnret->value;


### PR DESCRIPTION
due to a typo, the configured lock time was ignored (this is not used in any distributed plugin, so there was no impact).