### PR TITLE
enh: replace grep-as-boolean with List::Util any/none

### DIFF
--- a/bin/admin/check-consistency.pl
+++ b/bin/admin/check-consistency.pl
@@ -2,6 +2,7 @@
 # vim: set filetype=perl ts=4 sw=4 sts=4 et:
 use common::sense;
 use Data::Dumper;
+use List::Util qw{ none };
 use Term::ANSIColor;
 use Digest::MD5 ();
 use File::Basename;
@@ -118,7 +119,7 @@ if ($allowkeeper_groups[0] eq 'allowkeeper' && $allowkeeper_groups[1] eq ':') {
     @allowkeeper_groups = splice @allowkeeper_groups, 2;
 }
 foreach my $group (keys %keygroupsbyname) {
-    _err "allowkeeper user is not a member of group key$group" if (not grep { $_ eq "key$group" } @allowkeeper_groups);
+    _err "allowkeeper user is not a member of group key$group" if (none { $_ eq "key$group" } @allowkeeper_groups);
 }
 
 # now check if each key group has a gk
@@ -570,7 +571,7 @@ foreach my $account (keys %users) {
                 next;
             }
 
-            if (not grep { $2 eq $_ } keys %keygroupsbyname) {
+            if (none { $2 eq $_ } keys %keygroupsbyname) {
                 _err "file /home/allowkeeper/$account/$file has no corresponding known group";
             }
             if ($1 eq 'ip') {
@@ -810,7 +811,7 @@ sub _tocheck {
                 close($fh_sudoers);
                 chomp @contents;
                 foreach my $wantedline (@{$tocheck{'SUDOERS'}}) {
-                    if (not grep { $_ eq $wantedline } @contents) {
+                    if (none { $_ eq $wantedline } @contents) {
                         _err "missing line in plugin $sudoersfile: $wantedline";
                     }
                 }

--- a/bin/helper/osh-accountDelete
+++ b/bin/helper/osh-accountDelete
@@ -10,6 +10,7 @@
 #>HEADER
 use common::sense;
 use Getopt::Long qw(:config no_auto_abbrev no_ignore_case);
+use List::Util   qw{ none };
 
 use File::Basename;
 use lib dirname(__FILE__) . '/../../lib/perl';
@@ -44,7 +45,7 @@ if (!$account || !$type) {
 
 #>PARAMS:TYPE
 osh_debug("Checking type");
-if (not grep { $type eq $_ } qw{ normal realm }) {
+if (none { $type eq $_ } qw{ normal realm }) {
     HEXIT('ERR_INVALID_PARAMETER', "Expected type 'normal' or 'realm'");
 }
 

--- a/bin/helper/osh-accountModifyPersonalAccess
+++ b/bin/helper/osh-accountModifyPersonalAccess
@@ -23,6 +23,7 @@
 #>HEADER
 use common::sense;
 use Getopt::Long qw(:config no_auto_abbrev no_ignore_case);
+use List::Util   qw{ none };
 
 use File::Basename;
 use lib dirname(__FILE__) . '/../../lib/perl';
@@ -80,7 +81,7 @@ if ($target eq 'self' && $self ne $account) {
 #<RIGHTSCHECK
 
 #>PARAMS:ACTION
-if (not grep { $action eq $_ } qw{ add del }) {
+if (none { $action eq $_ } qw{ add del }) {
     return R('ERR_INVALID_PARAMETER', msg => "expected 'add' or 'del' as an action");
 }
 

--- a/bin/helper/osh-accountPIV
+++ b/bin/helper/osh-accountPIV
@@ -10,6 +10,7 @@
 #>HEADER
 use common::sense;
 use Getopt::Long qw(:config no_auto_abbrev no_ignore_case);
+use List::Util   qw{ none };
 
 use File::Basename;
 use lib dirname(__FILE__) . '/../../lib/perl';
@@ -55,7 +56,7 @@ $account = $fnret->value->{'account'};
 #<PARAMS:ACCOUNT
 
 #>PARAMS:POLICY
-if (not grep { $policy eq $_ } qw{ default enforce grace never }) {
+if (none { $policy eq $_ } qw{ default enforce grace never }) {
     HEXIT('ERR_INVALID_PARAMETER',
         "Expected either 'default,' enforce', 'grace' or 'never' as a parameter to --policy");
 }

--- a/bin/helper/osh-adminMaintenance
+++ b/bin/helper/osh-adminMaintenance
@@ -8,6 +8,7 @@
 #>HEADER
 use common::sense;
 use Getopt::Long qw(:config no_auto_abbrev no_ignore_case);
+use List::Util   qw{ none };
 
 use File::Basename;
 use lib dirname(__FILE__) . '/../../lib/perl';
@@ -38,7 +39,7 @@ if (not $action) {
     HEXIT('ERR_MISSING_PARAMETER', msg => "Missing argument 'action'");
 }
 
-if (not grep { $action eq $_ } qw{ set unset }) {
+if (none { $action eq $_ } qw{ set unset }) {
     HEXIT('ERR_INVALID_PARAMETER', msg => "Expected action 'set' or 'unset'");
 }
 

--- a/bin/helper/osh-groupAddServer
+++ b/bin/helper/osh-groupAddServer
@@ -8,6 +8,7 @@
 #>HEADER
 use common::sense;
 use Getopt::Long qw(:config no_auto_abbrev no_ignore_case);
+use List::Util   qw{ none };
 use Net::IP;
 
 use File::Basename;
@@ -55,7 +56,7 @@ if (not $ip or not $group or not $action) {
     HEXIT('ERR_MISSING_PARAMETER', msg => "Missing argument 'ip' or 'group' or 'action'");
 }
 
-if (not grep { $action eq $_ } qw{ add del }) {
+if (none { $action eq $_ } qw{ add del }) {
     HEXIT('ERR_INVALID_PARAMETER', msg => "Argument action should be 'add' or 'del'");
 }
 

--- a/bin/helper/osh-groupSetRole
+++ b/bin/helper/osh-groupSetRole
@@ -16,6 +16,7 @@
 #>HEADER
 use common::sense;
 use Getopt::Long qw(:config no_auto_abbrev no_ignore_case);
+use List::Util   qw{ any };
 
 use File::Basename;
 use lib dirname(__FILE__) . '/../../lib/perl';
@@ -98,7 +99,7 @@ elsif ($action eq 'del' && $fnret->is_ko) {
 }
 
 # add/del from sysgroup
-my $groupName = ((grep { $type eq $_ } qw{ guest member }) ? $group : "$group-$type");
+my $groupName = ((any { $type eq $_ } qw{ guest member }) ? $group : "$group-$type");
 
 osh_debug("going to $action account $account to/from $groupName");
 $fnret = R('OK', silent => 1);

--- a/bin/plugin/open/selfMFASetupTOTP
+++ b/bin/plugin/open/selfMFASetupTOTP
@@ -1,6 +1,7 @@
 #! /usr/bin/env perl
 # vim: set filetype=perl ts=4 sw=4 sts=4 et:
 use common::sense;
+use List::Util qw{ any };
 
 use File::Basename;
 use lib dirname(__FILE__) . '/../../../lib/perl';
@@ -57,10 +58,10 @@ elsif ($TOTPProvider eq 'google-authenticator') {
     $fnret = OVH::Bastion::execute(cmd => ['google-authenticator', '-h'], must_succeed => 1);
     $fnret or osh_exit($fnret);
     my @additional_params;
-    if (grep { /--issuer/ } @{$fnret->value->{'stdout'}}) {
+    if (any { /--issuer/ } @{$fnret->value->{'stdout'}}) {
         push @additional_params, "--issuer=" . OVH::Bastion::config('bastionName')->value;
     }
-    if ($noConfirm && grep { /--no-confirm/ } @{$fnret->value->{'stdout'}}) {
+    if ($noConfirm && any { /--no-confirm/ } @{$fnret->value->{'stdout'}}) {
         push @additional_params, "--no-confirm";
     }
 

--- a/bin/plugin/restricted/accountModify
+++ b/bin/plugin/restricted/accountModify
@@ -1,6 +1,7 @@
 #! /usr/bin/env perl
 # vim: set filetype=perl ts=4 sw=4 sts=4 et:
 use common::sense;
+use List::Util qw{ none };
 
 use File::Basename;
 use lib dirname(__FILE__) . '/../../../lib/perl';
@@ -88,7 +89,7 @@ if ((grep { defined } values %modify) == 0) {
 
 foreach my $key (qw{ mfa-password-required mfa-totp-required }) {
     next unless $modify{$key};
-    if (not grep { $modify{$key} eq $_ } qw{ yes no bypass }) {
+    if (none { $modify{$key} eq $_ } qw{ yes no bypass }) {
         help();
         osh_exit 'ERR_INVALID_PARAMETER',
           "Expected '--$key yes' or '--$key no' or '--$key bypass' instead of '--$key $modify{$key}'";
@@ -96,26 +97,26 @@ foreach my $key (qw{ mfa-password-required mfa-totp-required }) {
 }
 foreach my $key (qw{ always-active pam-auth-bypass idle-ignore osh-only pubkey-auth-optional }) {
     next unless $modify{$key};
-    if (not grep { $modify{$key} eq $_ } qw{ yes no }) {
+    if (none { $modify{$key} eq $_ } qw{ yes no }) {
         help();
         osh_exit 'ERR_INVALID_PARAMETER', "Expected '--$key yes' or '--$key no' instead of '--$key $modify{$key}'";
     }
 }
-if ($modify{'egress-strict-host-key-checking'} && !grep { $modify{'egress-strict-host-key-checking'} eq $_ }
+if ($modify{'egress-strict-host-key-checking'} && none { $modify{'egress-strict-host-key-checking'} eq $_ }
     qw{ yes accept-new no ask default bypass })
 {
     help();
     osh_exit 'ERR_INVALID_PARAMETER',
       "Expected option 'yes', 'accept-new', 'no', 'ask', 'default' or 'bypass' to --egress-strict-host-key-checking";
 }
-if ($modify{'personal-egress-mfa-required'} && !grep { $modify{'personal-egress-mfa-required'} eq $_ }
+if ($modify{'personal-egress-mfa-required'} && none { $modify{'personal-egress-mfa-required'} eq $_ }
     qw{ password totp any none })
 {
     help();
     osh_exit 'ERR_INVALID_PARAMETER',
       "Expected option 'password', 'totp', 'any', 'none' to --personal-egress-mfa-required";
 }
-if ($modify{'egress-session-multiplexing'} && !grep { $modify{'egress-session-multiplexing'} eq $_ }
+if ($modify{'egress-session-multiplexing'} && none { $modify{'egress-session-multiplexing'} eq $_ }
     qw{ yes no default })
 {
     help();

--- a/bin/plugin/restricted/accountPIV
+++ b/bin/plugin/restricted/accountPIV
@@ -1,6 +1,7 @@
 #! /usr/bin/env perl
 # vim: set filetype=perl ts=4 sw=4 sts=4 et:
 use common::sense;
+use List::Util qw{ none };
 
 use File::Basename;
 use lib dirname(__FILE__) . '/../../../lib/perl';
@@ -61,7 +62,7 @@ $fnret = OVH::Bastion::is_bastion_account_valid_and_existing(account => $account
 $fnret or osh_exit $fnret;
 $account = $fnret->value->{'account'};
 
-if (not grep { $policy eq $_ } qw{ default enforce never grace }) {
+if (none { $policy eq $_ } qw{ default enforce never grace }) {
     help();
     osh_exit 'ERR_INVALID_PARAMETER', "Expected either 'none,' enforce', 'never' or 'grace' as a parameter to --policy";
 }

--- a/bin/plugin/restricted/whoHasAccessTo
+++ b/bin/plugin/restricted/whoHasAccessTo
@@ -1,6 +1,7 @@
 #! /usr/bin/env perl
 # vim: set filetype=perl ts=4 sw=4 sts=4 et:
 use common::sense;
+use List::Util qw{ none };
 use Term::ANSIColor;
 
 use File::Basename;
@@ -106,7 +107,7 @@ sub process_account {
             if ($access->{'type'} =~ /^personal/ and not $ignorePersonal) {
                 $byPersonal++;
             }
-            elsif ($access->{'type'} =~ /^group/ and not grep { $access->{'group'} eq $_ } @ignoreGroups) {
+            elsif ($access->{'type'} =~ /^group/ and none { $access->{'group'} eq $_ } @ignoreGroups) {
                 $byGroups{$access->{'group'} . '(' . $access->{'type'} . ')'} = 1;
             }
         }

--- a/bin/proxy/osh-http-proxy-worker
+++ b/bin/proxy/osh-http-proxy-worker
@@ -22,7 +22,7 @@ use POSIX    ();
 use Storable qw{ freeze thaw };
 use Sys::Hostname;
 use Time::HiRes ();
-use List::Util  qw{ first };
+use List::Util  qw{ any first };
 
 $ENV{'FORCE_STDERR'} = 1;
 $ENV{'PATH'}         = '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/pkg/bin';
@@ -575,7 +575,7 @@ else {
 my @passthru_headers = qw{ content-type content-length client-ssl-cert-subject client-ssl-cipher client-ssl-warning };
 if ($res) {
     foreach my $key ($res->headers->header_field_names) {
-        next unless (grep { lc($key) eq $_ } @passthru_headers);
+        next unless (any { lc($key) eq $_ } @passthru_headers);
         push @headers, [$key => $res->header($key)];
     }
 }

--- a/bin/shell/osh.pl
+++ b/bin/shell/osh.pl
@@ -9,6 +9,7 @@ use OVH::Result;
 use OVH::Bastion;
 
 use Getopt::Long qw(GetOptionsFromString :config pass_through no_ignore_case no_auto_abbrev);
+use List::Util   qw{ none };
 use Sys::Hostname;
 use POSIX qw(strftime);
 use Term::ANSIColor;
@@ -467,7 +468,7 @@ if ($bind) {
         main_exit OVH::Bastion::EXIT_CONFLICTING_OPTIONS, "invalid_bind",
           "Couldn't verify the binding IP specified ($bind): " . $fnret->msg;
     }
-    if (not grep { $bind eq $_ } @{$fnret->value}) {
+    if (none { $bind eq $_ } @{$fnret->value}) {
         main_exit OVH::Bastion::EXIT_CONFLICTING_OPTIONS, "invalid_bind", "Invalid binding IP specified ($bind)";
     }
 }

--- a/lib/perl/OVH/Bastion.pm
+++ b/lib/perl/OVH/Bastion.pm
@@ -3,7 +3,8 @@ package OVH::Bastion;
 # vim: set filetype=perl ts=4 sw=4 sts=4 et:
 use common::sense;
 use Fcntl;
-use POSIX qw(strftime);
+use List::Util qw{ any none };
+use POSIX      qw(strftime);
 
 our $VERSION = '3.24.00';
 
@@ -173,7 +174,7 @@ sub AUTOLOAD {    ## no critic (AutoLoading)
     $subname =~ s/.*:://;
 
     foreach my $file (keys %_autoload_files) {
-        if (grep { $subname eq $_ } @{$_autoload_files{$file}}) {
+        if (any { $subname eq $_ } @{$_autoload_files{$file}}) {
             require $BASEPATH . '/lib/perl/OVH/Bastion/' . $file . '.inc';
 
             # Catch a declared but not implemented subroutine before calling it
@@ -447,7 +448,7 @@ sub is_account_active {
         # If in alwaysActive, then is active
         my $alwaysActiveAccounts = OVH::Bastion::config('alwaysActiveAccounts');
         if ($alwaysActiveAccounts and $alwaysActiveAccounts->value) {
-            if (grep { $sysaccount eq $_ } @{$alwaysActiveAccounts->value}) {
+            if (any { $sysaccount eq $_ } @{$alwaysActiveAccounts->value}) {
                 return R('OK');
             }
         }
@@ -559,7 +560,7 @@ sub osh_header {
     my $versionline = 'the-bastion-' . $VERSION;
     my $output      = '';
     my $fanciness   = OVH::Bastion::config('fanciness')->value;
-    if (OVH::Bastion::can_use_utf8() && grep { $fanciness eq $_ } qw{ basic full }) {
+    if (OVH::Bastion::can_use_utf8() && any { $fanciness eq $_ } qw{ basic full }) {
         my $line =
             "\N{U+256D}\N{U+2500}\N{U+2500}"
           . $hostname
@@ -594,7 +595,7 @@ sub osh_footer {
 
     my $output;
     my $fanciness = OVH::Bastion::config('fanciness')->value;
-    if (OVH::Bastion::can_use_utf8() && grep { $fanciness eq $_ } qw{ basic full }) {
+    if (OVH::Bastion::can_use_utf8() && any { $fanciness eq $_ } qw{ basic full }) {
         $output = colored("\N{U+2570}" . "\N{U+2500}" x (79 - length($text) - 6) . "</$text>" . "\N{U+2500}" x 3 . "\n",
             'bold blue');
     }
@@ -1072,7 +1073,7 @@ sub can_account_execute_plugin {
     if ($account =~ m{^realm_}) {
         return R('ERR_SECURITY_VIOLATION', msg => "Realm support accounts can't execute any plugin by themselves");
     }
-    if ($account =~ m{/} && !grep { $plugin eq $_ }
+    if ($account =~ m{/} && none { $plugin eq $_ }
         qw{ alive help info mtr nc ping selfForgetHostKey selfListAccesses selfListEgressKeys })
     {
         return R('ERR_REALM_USER',
@@ -1192,14 +1193,14 @@ sub set_terminal_mode_for_plugin {
         local $" = ', ';
         return R('ERR_MISSING_PARAMETER', "Missing mandatory parameter(s): @missingParameters");
     }
-    if (not grep { $action eq $_ } qw{ set restore }) {
+    if (none { $action eq $_ } qw{ set restore }) {
         return R('ERR_INVALID_PARAMETER', "Parameter 'action' is invalid, expected either 'set' or 'restore'");
     }
 
     my $mode;
     my $fnret = OVH::Bastion::plugin_config(plugin => $plugin, key => "terminal_mode");
     if ($fnret && defined $fnret->value) {
-        if (grep { $fnret->value eq $_ } qw{ noecho cbreak raw }) {
+        if (any { $fnret->value eq $_ } qw{ noecho cbreak raw }) {
             $mode = $fnret->value;
         }
         else {

--- a/lib/perl/OVH/Bastion/allowdeny.inc
+++ b/lib/perl/OVH/Bastion/allowdeny.inc
@@ -4,7 +4,8 @@ package OVH::Bastion;
 
 use common::sense;
 
-use Socket qw{ :all };
+use List::Util qw{ any };
+use Socket     qw{ :all };
 
 sub get_personal_account_keys {
     my %params   = @_;
@@ -1353,7 +1354,7 @@ sub ssh_test_access_way {
     }
     $fnret or return $fnret;
 
-    if (grep { $fnret->value->{'sysret'} eq $_ }
+    if (any { $fnret->value->{'sysret'} eq $_ }
         (0, OVH::Bastion::EXIT_ACCOUNT_INVALID(), OVH::Bastion::EXIT_HOST_NOT_FOUND()))
     {
         return R('OK');
@@ -1362,10 +1363,10 @@ sub ssh_test_access_way {
     my $hint;
 
     # 124 is the return code from the timeout system command when it times out
-    if ($fnret->value->{'sysret'} == 124 || grep { /timed out/i } @{$fnret->value->{'stderr'} || []}) {
+    if ($fnret->value->{'sysret'} == 124 || any { /timed out/i } @{$fnret->value->{'stderr'} || []}) {
         $hint = "Hint: did you remotely allow this bastion to access the SSH port?";
     }
-    elsif (grep { /Permission denied/i } @{$fnret->value->{'stderr'} || []}) {
+    elsif (any { /Permission denied/i } @{$fnret->value->{'stderr'} || []}) {
         $hint = "Hint: did you add the proper public key to the remote's authorized_keys?";
     }
     my $msg = "Couldn't connect to $user\@$ip (ssh returned error " . $fnret->value->{'sysret'} . ")";

--- a/lib/perl/OVH/Bastion/allowkeeper.inc
+++ b/lib/perl/OVH/Bastion/allowkeeper.inc
@@ -4,6 +4,7 @@ package OVH::Bastion;
 
 use common::sense;
 
+use List::Util qw{ any none };
 use Time::Piece;    # $t->strftime
 
 # Check if a system user belongs to a specific system group
@@ -21,7 +22,7 @@ sub is_user_in_group {
     my $fnret = OVH::Bastion::sys_getgr_name(name => $group, cache => $cache);
     $fnret or return $fnret;
 
-    if (grep { $user eq $_ } @{$fnret->value->{'members'} || []}) {
+    if (any { $user eq $_ } @{$fnret->value->{'members'} || []}) {
         return R('OK', value => {group => $group, account => $user});
     }
     else {
@@ -298,7 +299,7 @@ sub is_account_valid {
     elsif ($account !~ m/^realm_/ && $accountType eq 'realm') {
         return R('KO_BAD_PREFIX', msg => "$whatis should start with the realm prefix");
     }
-    elsif (grep { $account eq $_ } qw{ root proxyhttp keykeeper passkeeper logkeeper realm realm_realm }) {
+    elsif (any { $account eq $_ } qw{ root proxyhttp keykeeper passkeeper logkeeper realm realm_realm }) {
         return R('KO_FORBIDDEN_NAME', msg => "$whatis name is reserved");
     }
     elsif ($account =~ m{^([a-zA-Z0-9-]+)/([a-zA-Z0-9._-]+)$} && $accountType eq 'normal') {
@@ -422,7 +423,7 @@ sub access_modify {
 
     my $fnret;
 
-    if (!grep { $action eq $_ } qw{ add del clear }) {
+    if (none { $action eq $_ } qw{ add del clear }) {
         return R('ERR_INVALID_PARAMETER', msg => "Action should be add, del or clear");
     }
 
@@ -907,11 +908,11 @@ sub is_valid_group {
 
     # autodetect if my caller prefixed the group name with 'key' or not, and adjust accordingly.
     # we'll return normalized group and shortGroup values to our caller
-    if ($group !~ /^key/ && defined $groupType && grep { $groupType eq $_ } qw{ key gatekeeper aclkeeper owner }) {
+    if ($group !~ /^key/ && defined $groupType && any { $groupType eq $_ } qw{ key gatekeeper aclkeeper owner }) {
         $group = "key$group";
     }
 
-    if ($group =~ m/keeper$/i and not grep { $groupType eq $_ } qw{ gatekeeper aclkeeper }) {
+    if ($group =~ m/keeper$/i and none { $groupType eq $_ } qw{ gatekeeper aclkeeper }) {
         return R('KO_FORBIDDEN_SUFFIX', msg => 'Forbidden suffix in group name');
     }
     elsif ($group =~ m/owner$/i and $groupType ne 'owner') {
@@ -920,7 +921,7 @@ sub is_valid_group {
     elsif ($group =~ m/-tty$/i and $groupType ne 'tty') {
         return R('KO_FORBIDDEN_SUFFIX', msg => 'Forbidden suffix in group name');
     }
-    elsif ($group =~ m/^key/i and not grep { $groupType eq $_ } qw{ key gatekeeper owner }) {
+    elsif ($group =~ m/^key/i and none { $groupType eq $_ } qw{ key gatekeeper owner }) {
         return R('KO_FORBIDDEN_PREFIX', msg => 'Forbidden prefix in group name');
     }
     elsif ($group =~ m/^[-.]/) {
@@ -953,7 +954,7 @@ sub is_valid_group {
         }
 
         # 18 max for the short group name, because 32 - length(key) - length(-gatekeeper) == 18
-        if ((grep { $groupType eq $_ } qw{ key gatekeeper aclkeeper owner }) && (length($shortGroup) > 18)) {
+        if ((any { $groupType eq $_ } qw{ key gatekeeper aclkeeper owner }) && (length($shortGroup) > 18)) {
             return R('KO_NAME_TOO_LONG', msg => "Group name is too long (limit is 18 chars)");
         }
 
@@ -1101,7 +1102,7 @@ sub get_account_list {
     foreach my $name (keys %{$fnret->value}) {
 
         # if $accounts has been specified, only consider those
-        next if (@$accounts && !grep { $name eq $_ } @$accounts);
+        next if (@$accounts && none { $name eq $_ } @$accounts);
 
         # skip invalid accounts.
         # if !$cache, then we've filled the cache with sys_getpw_all() just above,
@@ -1138,7 +1139,7 @@ sub get_realm_list {
     foreach my $name (keys %{$fnret->value}) {
 
         # if $realms has been specified, only consider those
-        next if (@$realms && !grep { $name eq "realm_$_" } @$realms);
+        next if (@$realms && none { $name eq "realm_$_" } @$realms);
 
         # skip invalid realms.
         # if !$cache, then we've filled the cache with sys_getpw_all() just above,
@@ -1197,7 +1198,7 @@ sub is_admin {
     }
 
     my $adminList = OVH::Bastion::config('adminAccounts')->value();
-    if (grep { $account eq $_ } @$adminList) {
+    if (any { $account eq $_ } @$adminList) {
         return OVH::Bastion::is_user_in_group(group => "osh-admin", user => $account, cache => $cache);
     }
     return R('KO_ACCESS_DENIED');
@@ -1232,7 +1233,7 @@ sub is_super_owner {
     }
 
     my $superownerList = OVH::Bastion::config('superOwnerAccounts')->value();
-    if (grep { $account eq $_ } @$superownerList) {
+    if (any { $account eq $_ } @$superownerList) {
         return OVH::Bastion::is_user_in_group(group => "osh-superowner", user => $account, cache => $cache);
     }
 

--- a/lib/perl/OVH/Bastion/configuration.inc
+++ b/lib/perl/OVH/Bastion/configuration.inc
@@ -3,6 +3,7 @@ package OVH::Bastion;
 
 use common::sense;
 
+use List::Util qw{ any none };
 use JSON;
 use Fcntl qw{ :mode :DEFAULT };
 
@@ -308,7 +309,7 @@ sub load_configuration {
             }
 
             # if set to "no", "false" or "disabled", be nice and cast to false (because a string is true, otherwise)
-            elsif (grep { lc($C->{$o}) eq lc } qw{ no false disabled }) {
+            elsif (any { lc($C->{$o}) eq lc } qw{ no false disabled }) {
                 push @errors,
                     "Configuration error: found value '"
                   . $C->{$o}
@@ -530,7 +531,7 @@ sub load_configuration {
         }
         elsif ($C->{'defaultAccountEgressKeyAlgorithm'} eq 'ecdsa') {
             $C->{'defaultAccountEgressKeySize'} ||= 521;
-            if (!grep { $C->{'defaultAccountEgressKeySize'} eq $_ } qw{ 256 384 521 }) {
+            if (none { $C->{'defaultAccountEgressKeySize'} eq $_ } qw{ 256 384 521 }) {
                 push @errors,
                     "Configuration error: value of option 'defaultAccountEgressKeySize' ('"
                   . $C->{'defaultAccountEgressKeySize'}
@@ -629,7 +630,7 @@ sub load_configuration {
                         }
                     }
                 }
-                if (!grep { $rule->[2] eq $_ } qw{ ALLOW-EXCLUSIVE ALLOW DENY }) {
+                if (none { $rule->[2] eq $_ } qw{ ALLOW-EXCLUSIVE ALLOW DENY }) {
                     $C->{'ingressToEgressRules'} = [];
                     push @errors,
                         "Configuration error: option 'ingressToEgressRules' has an invalid format ('"

--- a/lib/perl/OVH/Bastion/interactive.inc
+++ b/lib/perl/OVH/Bastion/interactive.inc
@@ -2,6 +2,7 @@
 package OVH::Bastion;
 
 use common::sense;
+use List::Util qw{ any };
 use Term::ReadLine;
 use POSIX ();
 
@@ -146,7 +147,7 @@ EOM
             # check that here
 
             my ($typedPlugin) = $line =~ m{^(\S+)};
-            next unless grep { $typedPlugin eq $_ } @cmdlist;
+            next unless any { $typedPlugin eq $_ } @cmdlist;
 
             # if autocomplete specified, just return it
             if ($item->{'ac'}) {

--- a/lib/perl/OVH/Bastion/ssh.inc
+++ b/lib/perl/OVH/Bastion/ssh.inc
@@ -3,7 +3,7 @@ package OVH::Bastion;
 
 use common::sense;
 
-use List::Util qw{ first };
+use List::Util qw{ any first none };
 use File::Temp;
 use Fcntl qw{ :mode :DEFAULT };
 
@@ -437,7 +437,7 @@ EOS
         $fnret->{'msg'} = "Unknown error (" . $fnret->msg . "), please report to your sysadmin.";
     }
     else {
-        if (not grep { $fnret->value->{'family'} eq $_ } qw{ RSA ECDSA ED25519 ECDSA-SK ED25519-SK }) {
+        if (none { $fnret->value->{'family'} eq $_ } qw{ RSA ECDSA ED25519 ECDSA-SK ED25519-SK }) {
             $fnret->{'err'} = 'ERR_UNKNOWN_TYPE';
             $fnret->{'msg'} =
               "Unknown family type (" . $fnret->value->{'family'} . "), please report to your sysadmin.";
@@ -669,7 +669,7 @@ sub is_allowed_algo_and_size {
     $fnret or return $fnret;
     my @supportedList = @{$fnret->value};
 
-    if (not grep { $algo eq $_ } @supportedList) {
+    if (none { $algo eq $_ } @supportedList) {
         return R('KO_NOT_SUPPORTED',
             msg => "The algorithm '$algo' is not supported (or disabled) for $way on this bastion");
     }
@@ -688,7 +688,7 @@ sub is_allowed_algo_and_size {
     }
     elsif ($algo eq 'ecdsa') {
         $algo = 'ecdsa';                                            # untaint
-        if (not grep { $size eq $_ } qw{ 256 384 521 }) {
+        if (none { $size eq $_ } qw{ 256 384 521 }) {
             return R('KO_KEY_SIZE_INVALID', msg => "For the selected algorithm, valid key sizes are 256, 384, 521");
         }
     }
@@ -1091,25 +1091,25 @@ sub print_accepted_key_algorithms {
         osh_info("\n.. code-block:: none\n");
     }
 
-    if ($fido && grep { 'ed25519-sk' eq $_ } @algoList) {
+    if ($fido && any { 'ed25519-sk' eq $_ } @algoList) {
         osh_info("${prefix}FIDO2 Ed25519: robustness[$X$X$X] speed[$X$X$X]"
               . ($generate ? ", generate: `ssh-keygen -t ed25519-sk -O resident -O application=$appName" : ""));
         $hasFido = 1;
     }
-    if (grep { 'ed25519' eq $_ } @algoList) {
+    if (any { 'ed25519' eq $_ } @algoList) {
         osh_info("${prefix}Ed25519      : robustness[$X$X$X] speed[$X$X$X]"
               . ($generate ? ", generate: `ssh-keygen -t ed25519'" : ""));
     }
-    if ($fido && grep { 'ecdsa-sk' eq $_ } @algoList) {
+    if ($fido && any { 'ecdsa-sk' eq $_ } @algoList) {
         osh_info("${prefix}FIDO2 ECDSA  : robustness[$X$X$o] speed[$X$X$X]"
               . ($generate ? ", generate: `ssh-keygen -t ecdsa-sk -b 521 -O resident -O application=$appName" : ""));
         $hasFido = 1;
     }
-    if (grep { 'ecdsa' eq $_ } @algoList) {
+    if (any { 'ecdsa' eq $_ } @algoList) {
         osh_info("${prefix}ECDSA        : robustness[$X$X$o] speed[$X$X$X]"
               . ($generate ? ", generate: `ssh-keygen -t ecdsa -b 521'" : ""));
     }
-    if (grep { 'rsa' eq $_ } @algoList) {
+    if (any { 'rsa' eq $_ } @algoList) {
         osh_info("${prefix}RSA          : robustness[$X$o$o] speed[$X$o$o]"
               . ($generate ? ", generate: `ssh-keygen -t rsa -b 4096'" : ""));
     }

--- a/lib/perl/OVH/SimpleLog.pm
+++ b/lib/perl/OVH/SimpleLog.pm
@@ -9,6 +9,7 @@ use common::sense;
 use base qw (Exporter);
 our @EXPORT = qw(_log _warn _err);    ## no critic (ProhibitAutomaticExportation)
 
+use List::Util qw{ none };
 use Term::ANSIColor;
 use Sys::Syslog qw{};
 
@@ -112,7 +113,7 @@ sub _display {
         # valid levels: DEBUG, INFO, NOTICE, WARNING, ERR, EMERG
         my $priority = uc($level);
         $priority = 'WARNING' if $priority eq 'WARN';
-        $priority = 'INFO'    if (!grep { $priority eq $_ } qw{ DEBUG NOTICE WARNING ERR EMERG });
+        $priority = 'INFO'    if (none { $priority eq $_ } qw{ DEBUG NOTICE WARNING ERR EMERG });
         eval { Sys::Syslog::syslog($priority, $fullmsg); };
         if ($@) {
             print STDERR "Couldn't syslog, report to administrator ($@)\n";


### PR DESCRIPTION
Replace all instances of `grep` used in boolean context with proper List::Util `any { }` and `none { }`