### PR TITLE
enh: use IPC::Run for execute(), pass helper results over a dedicated fd

### DIFF
--- a/bin/admin/packages-check.sh
+++ b/bin/admin/packages-check.sh
@@ -36,7 +36,7 @@ if echo "$DISTRO_LIKE" | grep -q -w debian; then
                 libwww-perl libdigest-sha-perl libnet-ssleay-perl \
                 libnet-server-perl cryptsetup mosh expect openssh-server locales \
                 coreutils bash libcgi-pm-perl iputils-ping tar \
-                liblinux-prctl-perl libpam-google-authenticator pamtester"
+                liblinux-prctl-perl libpam-google-authenticator pamtester libipc-run-perl"
     # workaround for debian/armhf: curl fails to validate some SSL certificates,
     # whereas wget succeeds; this is needed for e.g. install-ttyrec.sh
     if [ "$(uname -m)" = armv7l ]; then
@@ -63,7 +63,7 @@ if echo "$DISTRO_LIKE" | grep -q -w debian; then
     installed=$(dpkg -l | awk '/^ii/ {print $2}' | cut -d: -f1)
     install_cmd="apt-get install"
 elif echo "$DISTRO_LIKE" | grep -q -w rhel; then
-    wanted_list="perl perl-JSON perl-Net-Netmask perl-Net-IP \
+    wanted_list="perl perl-JSON perl-Net-Netmask perl-Net-IP perl-IPC-Run \
             perl-Net-DNS perl-DBD-SQLite perl-TermReadKey procps-ng \
             sudo fping xz sqlite binutils acl gnupg2 rsync perl-DateTime \
             perl-JSON-XS inotify-tools lsof curl perl-Term-ReadLine-Gnu \
@@ -117,7 +117,7 @@ elif echo "$DISTRO_LIKE" | grep -q -w rhel; then
     installed=$(rpm -qa --queryformat '%{NAME}\n')
     install_cmd="yum install"
 elif echo "$DISTRO_LIKE" | grep -q -w suse; then
-    wanted_list="perl-common-sense perl-JSON perl-Net-Netmask perl-Net-IP \
+    wanted_list="perl-common-sense perl-JSON perl-Net-Netmask perl-Net-IP perl-IPC-Run \
             perl-Net-DNS perl-DBD-SQLite perl-Term-ReadKey perl-DateTime \
             fortune sudo fping perl perl-base gzip procps \
             xz sqlite3 binutils acl gpg2 rsync \
@@ -141,7 +141,7 @@ elif [ "$OS_FAMILY" = FreeBSD ]; then
     wanted_list="base64 coreutils rsync bash sudo pamtester p5-JSON p5-JSON-XS gnupg \
             p5-common-sense p5-DateTime p5-Net-IP p5-DBD-SQLite p5-Net-Netmask lsof \
             p5-Term-ReadKey expect fping p5-Net-Server p5-CGI p5-LWP-Protocol-https \
-            p5-Test-Deep p5-Term-ReadLine-Gnu"
+            p5-Test-Deep p5-Term-ReadLine-Gnu p5-IPC-Run"
     install_cmd="pkg add"
     installed=""
     for i in $wanted_list

--- a/bin/helper/osh-accountCreate
+++ b/bin/helper/osh-accountCreate
@@ -324,7 +324,7 @@ if (ref $config->{'accountCreateDefaultPersonalAccesses'} eq 'ARRAY' && $type eq
     foreach my $defAccess (@{$config->{'accountCreateDefaultPersonalAccesses'}}) {
         my (undef, $user, $ip, undef, $port) = $defAccess =~ m{^(([^@]+)@)?([0-9./]+)(:(\d+))?$};
         next unless $ip;
-        my @command = qw{ sudo -n -u allowkeeper -- };
+        my @command = qw{ sudo -n -u allowkeeper -- /usr/bin/env perl -T };
         push @command, $OVH::Bastion::BASEPATH . '/bin/helper/osh-accountModifyPersonalAccess';
         push @command, '--target',  'any';
         push @command, '--action',  'add';
@@ -335,8 +335,8 @@ if (ref $config->{'accountCreateDefaultPersonalAccesses'} eq 'ARRAY' && $type eq
             push @command, '--user', ($user eq 'ACCOUNT' ? $account : $user);
         }
         $port and push @command, '--port', $port;
-        $fnret = OVH::Bastion::execute(cmd => \@command, noisy_stdout => 1, noisy_stderr => 1, is_helper => 1);
-        $fnret->err eq 'OK' or osh_warn("Couldn't add private access to account to $defAccess ($fnret)");
+        $fnret = OVH::Bastion::helper(cmd => \@command);
+        $fnret->is_ok or osh_warn("Couldn't add private access to account to $defAccess ($fnret)");
     }
 }
 

--- a/bin/plugin/open/batch
+++ b/bin/plugin/open/batch
@@ -63,7 +63,7 @@ while ($line = <STDIN>) {
         # notify that we're under batch mode, hence if plugin requires MFA,
         # we'll require --proactive-mfa, see comment in lib/perl/OVH/Bastion.pm
         local $ENV{'OSH_BATCH'} = 1;
-        $fnret = OVH::Bastion::helper(cmd => \@cmd);
+        $fnret = OVH::Bastion::execute_osh(cmd => \@cmd);
     };
     if (!$fnret) {
         osh_warn "--- command failed!";

--- a/bin/plugin/open/rsync
+++ b/bin/plugin/open/rsync
@@ -132,18 +132,19 @@ push @cmd, "--", $ip, @$remainingOptions;
 print STDERR ">>> Hello $self, running rsync through the bastion on $machine...\n";
 
 $fnret = OVH::Bastion::execute(cmd => \@cmd, expects_stdin => 1, is_binary => 1);
-if ($fnret->err ne 'OK') {
+if (!$fnret) {
+    # we couldn't even start the transfer
     osh_exit 'ERR_TRANSFER_FAILED', "Error launching transfer: $fnret";
 }
-print STDERR sprintf(
-    ">>> Done, %d bytes uploaded, %d bytes downloaded\n",
-    $fnret->value->{'bytesnb'}{'stdin'} + 0,
-    $fnret->value->{'bytesnb'}{'stdout'} + 0
-);
-
-if ($fnret->value->{'sysret'} != 0) {
-    print STDERR ">>> On bastion side, rsync exited with return code " . $fnret->value->{'sysret'} . ".\n";
+if ($fnret->err ne 'OK') {
+    # the transfer did start: report how it actually ended instead of pretending the launch failed
+    my $reason =
+      defined($fnret->value->{'signal'})
+      ? "was killed by signal " . $fnret->value->{'signal'}
+      : "exited with return code " . $fnret->value->{'sysret'};
+    osh_exit 'ERR_TRANSFER_FAILED', "On bastion side, rsync $reason";
 }
+print STDERR ">>> Done, rsync exited successfully.\n";
 
 # don't use osh_exit() to avoid getting a footer
 exit OVH::Bastion::EXIT_OK;

--- a/bin/plugin/open/sftp
+++ b/bin/plugin/open/sftp
@@ -326,17 +326,19 @@ push @cmd, "--", $ip, 'sftp';
 print STDERR ">>> Hello $self, starting up sftp subsystem to $machine...\n";
 
 $fnret = OVH::Bastion::execute(cmd => \@cmd, expects_stdin => 1, is_binary => 1);
-if ($fnret->err ne 'OK') {
+if (!$fnret) {
+    # we couldn't even start the transfer
     osh_exit 'ERR_TRANSFER_FAILED', "Error launching transfer: $fnret";
 }
-print STDERR ">>> Done, "
-  . $fnret->value->{'bytesnb'}{'stdin'}
-  . " bytes uploaded, "
-  . $fnret->value->{'bytesnb'}{'stdout'}
-  . " bytes downloaded.\n";
-if ($fnret->value->{'sysret'} != 0) {
-    print STDERR ">>> On bastion side, sftp exited with return code " . $fnret->value->{'sysret'} . ".\n";
+if ($fnret->err ne 'OK') {
+    # the transfer did start: report how it actually ended instead of pretending the launch failed
+    my $reason =
+      defined($fnret->value->{'signal'})
+      ? "was killed by signal " . $fnret->value->{'signal'}
+      : "exited with return code " . $fnret->value->{'sysret'};
+    osh_exit 'ERR_TRANSFER_FAILED', "On bastion side, sftp $reason";
 }
+print STDERR ">>> Done, sftp exited successfully.\n";
 
 # don't use osh_exit() to avoid getting a footer
 exit OVH::Bastion::EXIT_OK;

--- a/etc/sudoers.d/osh-bastion-helpers-fd
+++ b/etc/sudoers.d/osh-bastion-helpers-fd
@@ -1,0 +1,5 @@
+# The bastion's privileged helpers receive their JSON result from the calling plugin over a
+# dedicated file descriptor (fd 3), but sudo closes fd>=3 by default (closefrom=3).
+# We raise that to 4 (for the helper commands ONLY), so fd 3 survives into the helper.
+Cmnd_Alias OSH_HELPERS_FD = /usr/bin/env perl -T %BASEPATH%/bin/helper/osh-*
+Defaults!OSH_HELPERS_FD closefrom=4

--- a/lib/perl/OVH/Bastion.pm
+++ b/lib/perl/OVH/Bastion.pm
@@ -151,7 +151,8 @@ my %_autoload_files = (
     configuration => [
         qw{ load_configuration_file main_configuration_directory load_configuration config account_config plugin_config group_config json_load }
     ],
-    execute     => [qw{ sysret2human execute execute_simple result_from_helper helper_decapsulate helper }],
+    execute =>
+      [qw{ sysret2human execute execute_simple execute_osh result_from_json_output helper_decapsulate helper }],
     interactive => [qw{ interactive }],
     jail        => [qw{ jailify }],
     log         => [
@@ -523,26 +524,50 @@ sub is_account_active {
 sub json_output {    ## no critic (ArgUnpacking)
     my $R             = shift;
     my %params        = @_;
-    my $force_default = $params{'force_default'};
     my $no_delimiters = $params{'no_delimiters'};
     my $command       = $params{'command'}    || $ENV{'PLUGIN_NAME'};
     my $filehandle    = $params{'filehandle'} || *STDOUT;
 
+    # a defined result_fh means a helper is returning its result over the dedicated fd-3 result channel
+    # that OVH::Bastion::Helper set up and HEXIT hands us. It's the only thing that ever passes this;
+    # see the branch below. Its mere presence is what routes us to the result channel.
+    my $result_fh = $params{'result_fh'};
+
     ## no critic(ValuesAndExpressions::ProhibitLongChainsOfMethodCalls)
     my $JsonObject = JSON->new->utf8->convert_blessed->ascii;
-    if ($ENV{'PLUGIN_JSON'} eq 'PRETTY' and not $force_default) {
+    if ($ENV{'PLUGIN_JSON'} eq 'PRETTY' and not defined $result_fh) {
         $JsonObject->pretty;
     }
     my $encoded_json =
       $JsonObject->encode({error_code => $R->err, error_message => $R->msg, command => $command, value => $R->value});
 
-    # rename forbidden strings
+    # result_fh is only ever passed by HEXIT, i.e. this is a helper returning its result to its caller
+    # (a plugin running execute() with capture_result_fd). It's the dedicated result channel that
+    # OVH::Bastion::Helper set up at startup from its fd 3 (relocated off fd 3 to leave it free for
+    # nested helpers). We return the result there, never over stdout: this keeps the helper's stdout
+    # clean (human output only) so the caller can tee it live without any filtering.
+    if (defined $result_fh) {
+        # a failed write must not masquerade as success (HEXIT exits 0 right after us): losing a
+        # privileged helper's result silently would leave the caller believing the action failed
+        # (or worse, kept waiting), while it has actually been performed.
+        my $print_ok = print {$result_fh} $encoded_json;
+        my $close_ok = close($result_fh);
+        if (!$print_ok || !$close_ok) {
+            warn_syslog("failed writing the helper result to the result channel ($!)");
+            die "FATAL: failed writing the helper result to the result channel\n";
+        }
+        return;
+    }
+
+    # User-facing output below (--json and friends): the JSON is framed in-band on stdout between
+    # JSON_START/JSON_END anchor lines (or after a JSON_OUTPUT= anchor in GREP mode), as documented
+    # in doc/sphinx/using/api.rst. Rename these anchor strings if they appear within the data itself.
     $encoded_json =~ s/JSON_(START|OUTPUT|END)/JSON__$1/g;
 
     if ($no_delimiters) {
         print {$filehandle} $encoded_json;
     }
-    elsif ($ENV{'PLUGIN_JSON'} eq 'GREP' and not $force_default) {
+    elsif ($ENV{'PLUGIN_JSON'} eq 'GREP') {
         $encoded_json =~ tr/\r\n/ /;
         print {$filehandle} "\nJSON_OUTPUT=$encoded_json\n";
     }

--- a/lib/perl/OVH/Bastion/Helper.pm
+++ b/lib/perl/OVH/Bastion/Helper.pm
@@ -3,7 +3,8 @@ package OVH::Bastion::Helper;
 # vim: set filetype=perl ts=4 sw=4 sts=4 et:
 use common::sense;
 
-use Fcntl       qw{ :flock :mode };
+use Fcntl       qw{ :flock :mode F_GETFD F_SETFD F_GETFL FD_CLOEXEC F_DUPFD O_ACCMODE O_RDONLY };
+use POSIX       ();
 use Time::HiRes qw{ usleep };
 
 use File::Basename;
@@ -15,6 +16,10 @@ use OVH::Result;
 use Exporter 'import';
 our $self;                          ## no critic (ProhibitPackageVars)
 our @EXPORT = qw( $self HEXIT );    ## no critic (ProhibitAutomaticExportation)
+
+# Our fd-3 result channel handle, set up at load time (see below) and handed to json_output() by
+# HEXIT() at exit. Declared here, before HEXIT(), so HEXIT() closes over this single file lexical.
+my $result_fh;
 
 # HEXIT aka "helper exit", used by helper scripts found in helpers/
 # Can be used in several ways:
@@ -36,7 +41,10 @@ sub HEXIT {    ## no critic (ArgUnpacking)
     else {
         $R = R(@_);
     }
-    OVH::Bastion::json_output($R, force_default => 1);
+    # Return our result over the dedicated fd-3 result channel, never on stdout. The load-time code
+    # below guarantees the channel is set up and usable, and dies before the helper gets to do any
+    # work otherwise, so $result_fh is always defined here.
+    OVH::Bastion::json_output($R, result_fh => $result_fh);
     exit 0;
 }
 
@@ -63,7 +71,68 @@ $SIG{'PIPE'} = 'IGNORE';    # continue even if osh_info gets a SIGPIPE because t
 # Ensure the PATH is not tainted, and has sane values
 $ENV{'PATH'} = '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/pkg/bin';
 
-# Build $self from SUDO_USER, as helpers are always run under sudo
+# If we're only being syntax-checked (perl -c / perl -Tc, as bin/dev/perl-check.sh does), $^C is true
+# and none of the helper's runtime code will run. Stop here: the setup below assumes a real bastion
+# invocation (sudo context, fd-3 result channel) and would otherwise die -- there's no fd-3 channel
+# under perl -c -- aborting the compilation check. All subs are already compiled by this point, so
+# the module still loads fully for the check.
+return 1 if $^C;
+
+# A helper run through the bastion receives its result channel as fd 3: execute() wires it with
+# IPC::Run's '3>' and sudo preserves it (closefrom=4). We return our JSON result over it (see
+# json_output()) instead of framing it on stdout, which keeps our stdout clean for the live tee.
+# We relocate it to a high fd and free fd 3, so that any nested helper we run via execute() can reuse
+# fd 3 for ITS OWN result channel without colliding with ours (which would otherwise lose both
+# results). We also mark it close-on-exec, so the external commands we exec don't inherit it (a chatty
+# or backgrounding child could otherwise write to it or hold it open, delaying our caller's EOF). We
+# keep $result_fh open for our own lifetime so the fd stays valid until we write the result at exit.
+# ($result_fh is declared at the top of this file.)
+#
+# Only adopt fd 3 if it looks like our result channel, i.e. the write end of a pipe, which is what
+# IPC::Run's '3>' always wires. This is NOT paranoia: when a helper is run by hand instead of through
+# the bastion, perl itself usually has the source file of the module it's loading -- this very file --
+# open on fd 3 while its top-level code (this very code) runs. Blindly adopting it would defeat the
+# fail-fast check below: the helper would do its privileged work, then silently lose its result at
+# HEXIT time (written to a read-only fd), exit 0, and close perl's own source filehandle on the way.
+# We probe with fstat() on the raw fd BEFORE wrapping it in a perl filehandle, as a filehandle opened
+# with '>&=' would close the foreign fd when going out of scope.
+my @fd3stat = POSIX::fstat(3);
+if (@fd3stat && S_ISFIFO($fd3stat[2]) && open(my $inherited, '>&=', 3)) {
+    my $flflags = fcntl($inherited, F_GETFL, 0);
+    if (defined $flflags && ($flflags & O_ACCMODE) != O_RDONLY) {
+        my $highfd = fcntl($inherited, F_DUPFD, 100);
+        if ($highfd && open($result_fh, '>&=', $highfd)) {
+            my $fdflags = fcntl($result_fh, F_GETFD, 0);
+            fcntl($result_fh, F_SETFD, ($fdflags // 0) | FD_CLOEXEC);
+        }
+        else {
+            # We couldn't relocate off fd 3. Rather than keep the channel on fd 3 without
+            # close-on-exec (a child could then inherit and hold it open, delaying our caller's EOF,
+            # and a nested helper would collide with it), fail loudly: leave $result_fh undef, the
+            # check right below dies. This should never happen in practice (F_DUPFD to a free high fd).
+            warn_syslog("couldn't relocate the fd-3 result channel to a high fd ($!); result channel unusable");
+        }
+    }
+    else {
+        # the read end of a pipe on our fd 3: whatever wired it, it's not our result channel
+        warn_syslog("fd 3 is not the write end of a pipe; not adopting it as the result channel");
+    }
+    close($inherited);    # free fd 3 for nested helpers (or drop it if it wasn't usable)
+}
+
+# Fail fast if the result channel is unavailable (e.g. a helper run by hand for debugging, not via
+# the bastion, or a stale sudoers missing the closefrom=4 Defaults): dying here, before the helper
+# had a chance to perform any privileged work, beats dying at HEXIT time with the work already done
+# and the caller left believing it failed.
+if (!defined $result_fh) {
+    warn_syslog(
+        "helper result channel (fd 3) is unavailable; " . "helpers must be run via the bastion (execute()/sudo)");
+    die "FATAL: helper result channel (fd 3) is unavailable; helpers must be run via the bastion\n";
+}
+
+# Build $self from SUDO_USER, as helpers are always run under sudo.
+# This check runs after the result-channel setup on purpose: this way, ERR_SUDO_NEEDED is returned
+# to our caller over the channel as a proper structured result, like any other helper error.
 ($self) = $ENV{'SUDO_USER'} =~ m{^([a-zA-Z0-9._-]+)$};
 if (not defined $self) {
     if ($< == 0) {

--- a/lib/perl/OVH/Bastion/execute.inc
+++ b/lib/perl/OVH/Bastion/execute.inc
@@ -4,12 +4,9 @@ package OVH::Bastion;
 use common::sense;
 
 use Config;
-use Fcntl qw{ :DEFAULT :seek };
-use IO::Handle;
-use IO::Select;
+use Fcntl qw{ F_GETFL F_SETFL O_NONBLOCK };
 use IPC::Open3;
 use JSON;
-use POSIX ":sys_wait_h";
 use Symbol 'gensym';
 
 # Get signal names, i.e. signal 9 is SIGKILL, etc.
@@ -43,40 +40,29 @@ sub sysret2human {
     }
 }
 
-# utility function to set a filehandle to non-blocking
-sub _set_non_blocking {
-    my $handle = shift;
-
-    my $flags = fcntl($handle, F_GETFL, 0);
-    if (!$flags) {
-        return R('ERR_SYSCALL_FAILED', msg => "Couldn't set filehandle to non-blocking (F_GETFL failed)");
-    }
-
-    $flags |= O_NONBLOCK;
-    if (!fcntl($handle, F_SETFL, $flags)) {
-        return R('ERR_SYSCALL_FAILED', msg => "Couldn't set filehandle to non-blocking (F_SETFL failed)");
-    }
-    return R('OK');
-}
-
-## no critic(ControlStructures::ProhibitDeepNests)
 sub execute {
-    my %params           = @_;
-    my $cmd              = $params{'cmd'};                 # command to execute, must be an array ref (with possible parameters)
-    my $expects_stdin    = $params{'expects_stdin'};       # the command called expects stdin, pipe caller stdin to it
-    my $noisy_stdout     = $params{'noisy_stdout'};        # capture stdout but print it too
-    my $noisy_stderr     = $params{'noisy_stderr'};        # capture stderr but print it too
-    my $is_helper        = $params{'is_helper'};           # hide JSON returns from stdout even if noisy_stdout
-    my $is_binary        = $params{'is_binary'};           # used for e.g. scp, don't bother mimicking readline(), we lose debug and stdout/stderr are NOT returned to caller
-    my $stdin_str        = $params{'stdin_str'};           # string to push to the STDIN of the command
-    my $must_succeed     = $params{'must_succeed'};        # if the executed command returns a non-zero exit value, turn OK_NON_ZERO_EXIT to ERR_NON_ZERO_EXIT
-    my $max_stdout_bytes = $params{'max_stdout_bytes'};    # if the amount of stored stdout bytes exceeds this, halt the command and return to caller
-    my $system           = $params{'system'};              # if set to 1, will use system() instead of open3(), needed for some plugins
+    my %params            = @_;
+    my $cmd               = $params{'cmd'};                  # command to execute, must be an array ref (with possible parameters)
+    my $expects_stdin     = $params{'expects_stdin'};        # the command called expects stdin, pipe caller stdin to it
+    my $noisy_stdout      = $params{'noisy_stdout'};         # capture stdout but print it too
+    my $noisy_stderr      = $params{'noisy_stderr'};         # capture stderr but print it too
+    my $capture_result_fd = $params{'capture_result_fd'};    # wire fd 3 as the child's result channel (real helpers), capture it into result_fd_output
+    my $hide_json_result  = $params{'hide_json_result'};     # suppress a JSON_START..JSON_END block from the live stdout tee (osh.pl --json, e.g. batch)
+    my $is_binary         = $params{'is_binary'};            # used for e.g. scp, stdout/stderr are NOT returned to caller
+    my $stdin_str         = $params{'stdin_str'};            # string to push to the STDIN of the command
+    my $must_succeed      = $params{'must_succeed'};         # if the executed command returns a non-zero exit value, turn OK_NON_ZERO_EXIT to ERR_NON_ZERO_EXIT
+    my $max_stdout_bytes  = $params{'max_stdout_bytes'};     # if the amount of stored stdout bytes exceeds this, halt the command and return to caller
+    my $system            = $params{'system'};               # if set to 1, will use system() instead, needed for some plugins
 
     $noisy_stderr = $noisy_stdout = 1 if ($ENV{'PLUGIN_DEBUG'} or $is_binary);
     my $fnret;
 
-    # taint check
+    # Normalize the command list: callers may pass undef positional args (e.g. osh.pl passes
+    # undef user/ip/host for plugin commands). open3/system silently stringify undef to '',
+    # but IPC::Run dies ("undef passed") on any undef element, so do it explicitly here.
+    $cmd = [map { defined $_ ? $_ : '' } @$cmd];
+
+    # taint check: refuse to silently exec a tainted command
     require Scalar::Util;
     foreach (@$cmd) {
         if (Scalar::Util::tainted($_) && /(.+)/) {
@@ -86,7 +72,8 @@ sub execute {
         }
     }
 
-    # if caller want us to use system(), just do it here and call it a day
+    # if caller wants us to use system(), just do it here and call it a day: this is a faithful
+    # full-inheritance exec, kept as-is (needed for some plugins, such as scp)
     if ($system) {
         my $child_exit_status = system(@$cmd);
         $fnret = sysret2human($child_exit_status);
@@ -102,331 +89,254 @@ sub execute {
         );
     }
 
-    # otherwise, launch the command under open3()
-    my ($child_stdin, $child_stdout, $child_stderr);
-    $child_stderr = gensym;
-    osh_debug("about to run_cmd ['" . join("','", @$cmd) . "']");
-    my $pid;
-    eval { $pid = open3($child_stdin, $child_stdout, $child_stderr, @$cmd); };
-    if ($@) {
-        chomp $@;
-        return R('ERR_EXEC_FAILED', msg => "Couldn't exec requested command ($@)");
-    }
+    # otherwise, delegate the select loop, backpressure and deadlock avoidance to IPC::Run
+    require IPC::Run;
 
-    # if some filehandles are already closed, binmode may fail, which is why we use eval{} here
-    eval { binmode $child_stdin; };
-    eval { binmode $child_stdout; };
-    eval { binmode $child_stderr; };
+    # IPC::Run resolves a bare command name (one with no '/') by searching $ENV{PATH} in pure Perl,
+    # and unlike the open3()/execvp() path we used before, it does NOT fall back to a system default
+    # path when $ENV{PATH} is empty or unset: it just dies with "Command 'x' not found". Some callers
+    # legitimately run with a cleared environment and relied on that execvp fallback -- notably the
+    # HTTP proxy, where Net::Server::HTTP does `%ENV = ()` on every request. Restore the old behavior
+    # by giving IPC::Run a sane default PATH for its lookup when none is set (scoped to this call).
+    local $ENV{'PATH'} =
+      (defined $ENV{'PATH'} && length $ENV{'PATH'})
+      ? $ENV{'PATH'}
+      : '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
+
+    # ensure our own std handles are in raw mode: we tee raw bytes (including binary payloads, e.g.
+    # selfPlaySession) to STDOUT/STDERR and pump STDIN through verbatim, so no PerlIO layer (:utf8,
+    # :crlf, ...) must be allowed to mangle them. Wrap each in eval{} as binmode may fail on an
+    # already-closed handle.
     eval { binmode STDIN; };
     eval { binmode STDOUT; };
     eval { binmode STDERR; };
 
-    # set our child's stdin to non-blocking, so that a syswrite to it is guaranteed to never block,
-    # otherwise we could get in an deadlock, where our child can't accept more data on its stdin
-    # before we read pending data from its stdout/stderr, which we will never do because we're busy
-    # waiting for the syswrite to its stdin to complete.
-    $fnret = _set_non_blocking($child_stdin);
-    $fnret or return $fnret;
+    my %bytesnb = (stdout => 0, stderr => 0);
+    my ($stdout_output, $stderr_output) = ('', '');
 
-    osh_debug("waiting for child PID $pid to complete...");
-
-    # declare vars we'll use below
-    my %output = ();
-    my $stderr_output;
-    my $stdout_output;
-    my $stdout_buffer;
-    my $child_stdin_to_write;
-    my $child_stdin_closing;
-    my $current_fh;
-    my $currently_in_json_block;
-    my %bytesnb;
-
-    # maximum number of code_info() to call, to avoid flooding the logs
-    my $info_limit = 5;
-
-    # maximum intermediate buffer size we want in $child_stdin_to_write, before we stop
-    # reading data from our own STDIN and wait our child to digest the data we send it,
-    # otherwise if we get a possibly infinite amount of data from our STDIN without ever
-    # being able to write it to our child, we'll end up in OOM
-    my $max_stdin_buf_size = 8 * 1024 * 1024;
-
-    # define our own version of syswrite to handle auto-retry if interrupted by a signal,
-    # return the number of bytes actually written
-    my $syswrite_ensure = sub {
-        my ($_bufsiz, $_FH, $_name, $_noisy_ref, $_buffer) = @_;
-        return 0 if (!$_bufsiz || !$_buffer);
-
-        my $offset       = 0;
-        my $totalwritten = 0;
-        while ($offset < $_bufsiz) {
-            my $written = eval { syswrite $_FH, $_buffer, 65535, $offset; };
-            if ($@) {
-                if ($@ =~ m{on closed filehandle}) {
-                    $child_stdin_to_write = '';
-                    return $totalwritten;
-                }
-                # don't ignore other errors
-                die($@);
-            }
-
-            if (not defined $written) {
-                if ($!{'EAGAIN'} && $_name eq 'child_stdin') {
-                    osh_debug("in syswrite_ensure, got EAGAIN on our child stdin, our caller will retry on next loop");
-                    return $totalwritten;
-                }
-                else {
-                    # is the fd still open? (maybe we got a SIGPIPE or a SIGHUP)
-                    # don't use tell() here, we use syseek() for unbuffered i/o,
-                    # note that if we're at the position "0", it's still true (see doc).
-                    my $previousError = $!;
-                    if (!sysseek($_FH, 0, SEEK_CUR)) {
-                        osh_debug("in syswrite_ensure, sysseek failed");
-                        info_syslog("execute(): error while syswriting($previousError/$!) on $_name, "
-                              . "the filehandle is closed, will no longer attempt to write to it")
-                          if $info_limit-- > 0;
-                        $$_noisy_ref = 0 if $_noisy_ref;
-                    }
-                    else {
-                        # oww, abort writing for this cycle. as this might be user-induced, use info instead of warn
-                        info_syslog(
-                            "execute(): error while syswriting($previousError) on $_name, " . "aborting this cycle")
-                          if $info_limit-- > 0;
-                    }
-                }
-                last;
-            }
-            $offset       += $written;
-            $totalwritten += $written;
-        }
-        return $totalwritten;
-    };
-
-    # as we'll always monitor our child stdout and stderr, add those to our IO::Select
-    my $select = IO::Select->new($child_stdout, $child_stderr);
-
-    if (length($stdin_str) > 0) {
-        # we have some stdin data to push to our child, so preinit our intermediate buffer with that data
-        $child_stdin_to_write = $stdin_str;
+    # --- stdin source ---
+    my ($in_spec, $stdin_wh);
+    if (defined $stdin_str && length $stdin_str) {
+        # Feed the buffer ourselves through a pipe we own (see the feeding loop below), instead of
+        # handing IPC::Run a scalar ref: its writer pump croaks on EPIPE on all the IPC::Run versions
+        # shipped by our supported OSes (only fixed upstream in 20250715), whereas a child exiting
+        # before consuming its whole stdin is a normal occurrence (e.g. passwd rejecting a password
+        # early): in that case we must keep draining its stdout/stderr and report its real exit
+        # status, as the pre-IPC::Run implementation of execute() did. The read end is passed as a
+        # GLOB: IPC::Run dup()s it straight into the child with no writer pump attached, so there's
+        # nothing left on its side to croak. Perl's default $^F guarantees both ends are
+        # close-on-exec, so the child doesn't inherit a copy of the write end (which would prevent
+        # it from ever seeing EOF on its stdin once we're done writing).
+        pipe(my $stdin_rh, $stdin_wh) or return R('ERR_SYSCALL_FAILED', msg => "Couldn't create a pipe ($!)");
+        binmode $stdin_rh;
+        binmode $stdin_wh;
+        $in_spec = $stdin_rh;
     }
     elsif ($expects_stdin) {
-        # monitor our own stdin only if we expect it (we'll pipe it to our child's stdin)
-        $select->add(\*STDIN);
+        $in_spec = \*STDIN;    # dup'ed into the child by IPC::Run: it reads our own stdin directly
     }
     else {
-        # we have nothing to feed to our child's stdin (no stdin_str, and we're not piping our own
-        # stdin to it), so close it right away to give the child an EOF: otherwise a child that reads
-        # its stdin until EOF (such as our http proxy worker) would block waiting for data forever
-        close($child_stdin);
+        $in_spec = \undef;     # child gets /dev/null (immediate EOF)
     }
 
-    # then, while we still have at least two filehandles to monitor OR we have only one which is not our own STDIN:
-    while ($select->count() > 1 || ($select->count() == 1 && !$select->exists(\*STDIN))) {
+    # --- output sinks: count bytes, capture (unless binary), optionally tee to our own fd ---
+    # hide_json_result is for running osh.pl recursively (e.g. the batch plugin): osh.pl is not a
+    # bastion helper, it emits its --json result as a JSON_START..JSON_END block on stdout. When teeing,
+    # hide any such block from the live tee (line by line): both to keep the console clean and so a
+    # caller capturing our stdout doesn't mistake it for our own result. The raw bytes are still
+    # captured in $stdout_output, which execute_osh() parses. (Real helpers don't need this: they
+    # return over fd 3 and emit nothing structured on stdout, see capture_result_fd below.)
+    my ($json_tee_buf, $in_json_block) = ('', 0);
+    my $stdout_sink = sub {
+        my $chunk = shift;
+        $bytesnb{stdout} += length $chunk;
+        $stdout_output .= $chunk if !$is_binary;
 
-        # first, if we have data to push to our child's stdin that comes from our own stdin,
-        # try to do that before checking if we have pending data to read, as to ensure we don't get deadlocked
-        if (length($child_stdin_to_write) > 0) {
-            my $written2child = $syswrite_ensure->(
-                length($child_stdin_to_write),
-                $child_stdin, 'child_stdin', undef, $child_stdin_to_write
-            );
-
-            if ($written2child) {
-                # remove the data we've written from the intermediate buffer
-                $child_stdin_to_write = substr($child_stdin_to_write, $written2child);
-
-                if (length($child_stdin_to_write) == 0) {
-                    if (length($stdin_str) > 0) {
-                        # we pushed all the data we wanted to push to our child stdin, we can close it now:
-                        osh_debug("execute: closing child stdin as we wrote everything we wanted to it (stdin_str)");
-                        close($child_stdin);
-                    }
-                    elsif ($child_stdin_closing) {
-                        # our own STDIN was already closed, and we just finished flushing the data to our child,
-                        # so we can close it as well
-                        osh_debug("execute: closing child stdin as we wrote everything we wanted to it");
-                        close($child_stdin);
-                    }
+        if ($noisy_stdout) {
+            if (!$hide_json_result) {
+                print {*STDOUT} $chunk;
+            }
+            else {
+                # consume complete lines via index()/substr() rather than a `s/^(.*\n)//` that
+                # re-scans a growing buffer from the front (O(n^2) on a long newline-less run, e.g.
+                # osh.pl's single-line encoded JSON result).
+                $json_tee_buf .= $chunk;
+                my $nl;
+                while (($nl = index($json_tee_buf, "\n")) >= 0) {
+                    my $line = substr($json_tee_buf, 0, $nl + 1, '');    # take one line incl. newline
+                    (my $bare = $line) =~ s/\r?\n\z//;
+                    if    ($bare eq 'JSON_START') { $in_json_block = 1; }
+                    elsif ($bare eq 'JSON_END')   { $in_json_block = 0; }
+                    else                          { print {*STDOUT} $line if !$in_json_block; }
                 }
+                # inside a hidden block, the leftover partial line is either the tail of a long
+                # (newline-less) data line we're hiding, or the start of the short JSON_END marker
+                # split across two chunks. Drop it only once it's too long to be a marker: this keeps
+                # the buffer bounded on a huge single-line result (still captured in $stdout_output)
+                # without ever losing a JSON_END that straddles a chunk boundary (which would otherwise
+                # wedge us in-block and hide all subsequent human output).
+                $json_tee_buf = '' if ($in_json_block && length($json_tee_buf) > length('JSON_START'));
             }
         }
 
-        # then, wait until we have something to read.
-        # block only for 10ms, if there's nothing to read anywhere for this amount of time,
-        # it'll be when we want to check if our child is dead
-        my @ready = $select->can_read(0.01);
+        # honor max_stdout_bytes: we have enough, signal the loop to stop
+        die "EXECUTE_MAX_STDOUT_BYTES\n" if ($max_stdout_bytes && $bytesnb{stdout} >= $max_stdout_bytes);
+        return;
+    };
 
-        # yep, we have something to read on at least one fh
-        if (@ready) {
+    my $stderr_sink = sub {
+        my $chunk = shift;
+        $bytesnb{stderr} += length $chunk;
+        $stderr_output .= $chunk if !$is_binary;
+        print {*STDERR} $chunk   if $noisy_stderr;
+        return;
+    };
 
-            # guarantee we're still reading this fh while it has something to say, this helps avoiding
-            # mangling stdout/stderr on the console when noisy_* vars are set
-            $current_fh = $ready[0];
+    # for real helpers (bin/helper/osh-*), capture their JSON result on a dedicated fd (3) instead of
+    # having them frame it on stdout: this keeps stdout clean (human output only) for the live tee. The
+    # helper finds this channel as its (only) open fd 3 at startup and writes its result there (see
+    # OVH::Bastion::Helper). helper() consumes result_fd_output below.
+    my $result_fd_output;
 
-            # ...unless we have piled up a big buffer from our stdin, and child is still blocking on its own stdin,
-            # in which case we'll stop reading from our stdin and prioritize other filehandles
-            # in an attempt to unblock our child
-            if ($current_fh->fileno == STDIN->fileno && length($child_stdin_to_write) > $max_stdin_buf_size) {
-                osh_debug("main loop, changing current fh to avoid deadlocking");
-                if (@ready > 1) {
-                    $current_fh = $ready[1];
+    # For binary bulk transfers (e.g. the sftp/rsync data path), keep ourselves out of the child's
+    # I/O entirely: in is_binary mode the sinks above neither capture (skipped) nor filter (no JSON
+    # to hide), they'd only relay bytes to our own std fds -- and IPC::Run pumps CODE sinks through
+    # its select loop in small chunks, a hefty CPU cost at data-transfer rates. Passing our fds as
+    # GLOBs instead makes IPC::Run dup2() them straight into the child, which then writes to them
+    # directly, with no parent-side pumping at all (just like we already do for '<' STDIN above).
+    # We can't do this when max_stdout_bytes is set: the counting sink is what stops the child. No
+    # counting happens in passthrough mode either (bytesnb stays 0, nothing consumes it here).
+    my ($out_spec, $err_spec) = ($stdout_sink, $stderr_sink);
+    ($out_spec, $err_spec) = (\*STDOUT, \*STDERR) if ($is_binary && !$max_stdout_bytes);
+
+    my @harness_args = ([@$cmd], '<', $in_spec, '>', $out_spec, '2>', $err_spec);
+    push @harness_args, '3>', \$result_fd_output if $capture_result_fd;
+
+    osh_debug("about to run_cmd ['" . join("','", @$cmd) . "'] (via IPC::Run)");
+    my $harness = IPC::Run::harness(@harness_args);
+
+    my $hit_max_stdout = 0;
+    my $ok             = eval {
+        $harness->start;
+
+        # feed stdin_str to the child ourselves, with the same graceful semantics the pre-IPC::Run
+        # implementation had: a child no longer reading its stdin is not an error, stop feeding it
+        # and keep going to collect its output and real exit status (see the pipe() creation above)
+        if ($stdin_wh) {
+            # Writing to the pipe of a child that exited raises SIGPIPE: this one is pure execute()
+            # machinery, so shield the caller from it for the duration of the feeding phase -- an
+            # unhandled caller would get killed outright, and a handled one would have its handler
+            # spuriously triggered by what is a benign event (Plugin.pm's handler tears the whole
+            # process group down!). With the signal ignored, our syswrite cleanly gets EPIPE, which
+            # the loop below handles. This is deliberately scoped to the feeding phase and NOT to
+            # finish(): a SIGPIPE raised by the stdout/stderr tee means the CALLER's own output
+            # channel died (e.g. user disconnected), and acting on that (like Plugin.pm killing the
+            # process group to tear the session down) is the caller's policy, not ours to silence.
+            local $SIG{'PIPE'} = 'IGNORE';
+
+            # the child got its own dup of the read end when it was spawned; close ours so that
+            # once the child is gone, our syswrites get a proper EPIPE instead of filling a pipe
+            # that nobody will ever read
+            close($in_spec);
+
+            # set our write end non-blocking: when the pipe is full, we must keep draining the
+            # child's stdout/stderr while it digests, or we'd deadlock each other
+            my $flflags = fcntl($stdin_wh, F_GETFL, 0);
+            fcntl($stdin_wh, F_SETFL, $flflags | O_NONBLOCK) if defined $flflags;
+
+            my $offset = 0;
+            my $len    = length $stdin_str;
+            while ($offset < $len) {
+                my $written = syswrite($stdin_wh, $stdin_str, $len - $offset, $offset);
+                if (defined $written) {
+                    $offset += $written;
+                }
+                elsif ($!{'EINTR'}) {
+                    next;    # interrupted by a signal, just retry
+                }
+                elsif ($!{'EAGAIN'} || $!{'EWOULDBLOCK'}) {
+                    # pipe full: drain the child's pending output, then wait (10ms max) for room.
+                    # waiting for room alone would deadlock us with a child that blocks writing
+                    # its stdout until we read it, hence the pump_nb (non-blocking pump) each round
+                    $harness->pump_nb if $harness->pumpable;
+                    my $win = '';
+                    vec($win, fileno($stdin_wh), 1) = 1;
+                    select(undef, $win, undef, 0.01);
                 }
                 else {
-                    warn_syslog("possible deadlock while running ['" . join("','", @$cmd) . "']") if $info_limit-- > 0;
-                    osh_debug("main loop, can't change current fh to avoid deadlock, refusing to read from it");
-                    # we have nothing to read/write from/to, except from our own STDIN but our buffer is already full,
-                    # so let's sleep for a tiny bit to help ensuring our child is not CPU-starved which could make
-                    # it incapable of accepting new data to its STDIN, hence deadlocking us in return
-                    require Time::HiRes;
-                    Time::HiRes::usleep(1000 * 15);
-                    next;
-                }
-            }
-
-            my $sub_select = IO::Select->new($current_fh);
-
-            # can_read(0) because we don't need a timeout: we KNOW there's something to read on this fh,
-            # otherwise we wouldn't be here
-            while ($sub_select->can_read(0)) {
-                my $buffer;
-                my $nbread = sysread $current_fh, $buffer, 65535;
-
-                # undef==error, we log to syslog and close. as this might be user-induced, use info instead of warn
-                if (not defined $nbread) {
-                    info_syslog("execute(): error while sysreading($!), closing fh!");
-                }
-
-                # if size 0, it means it's an EOF
-                elsif ($nbread == 0) {
-                    # we got an EOF on this fh, remove it from the monitor list
-                    osh_debug("main loop: removing current fh from select list");
-                    $select->remove($current_fh);
-
-                    # if this is an EOF on our own STDIN, we need to close our child's STDIN,
-                    # but do this only if our intermediate buffer is empty, otherwise just mark it
-                    # for close, we'll do it as soon as we empty the buffer
-                    if ($current_fh->fileno == STDIN->fileno) {
-                        close(STDIN);    # we got EOF on it, so close it
-                        if (length($child_stdin_to_write) == 0) {
-                            close($child_stdin);
-                        }
-                        else {
-                            $child_stdin_closing = 1;    # defer close to when our intermediate buffer is empty
-                        }
-                    }
-                    else {
-                        ;                                # EOF on our child's stdout or stderr, nothing to do
-                    }
-                    last;
-                }
-
-                # we got data, is this our child's stderr?
-                elsif ($current_fh->fileno == $child_stderr->fileno) {
-                    $bytesnb{'stderr'} += $nbread;
-                    $stderr_output .= $buffer if !$is_binary;
-
-                    # syswrite on our own STDERR what we received
-                    if ($noisy_stderr) {
-                        $syswrite_ensure->($nbread, *STDERR, 'stderr', \$noisy_stderr, $buffer);
-                    }
-                }
-
-                # we got data, is this our child's stdout ?
-                elsif ($current_fh->fileno == $child_stdout->fileno) {
-                    $bytesnb{'stdout'} += $nbread;
-                    $stdout_output .= $buffer if !$is_binary;
-
-                    # syswrite on our own STDOUT what we received, if asked to do so
-                    # is $is_helper, then we need to filter out the HELPER_RESULT before printing,
-                    # so handle that further below
-                    if ($noisy_stdout) {
-                        if (!$is_helper) {
-                            $syswrite_ensure->($nbread, *STDOUT, 'stdout', \$noisy_stdout, $buffer);
-                        }
-                        else {
-                            # if this is a helper, hide the HELPER_RESULT from noisy_stdout
-                            foreach my $char (split //, $buffer) {
-                                if ($char eq $/) {
-                                    # in that case, we didn't noisy print each char, we wait for $/
-                                    # then print it IF this is not the result_from_helper (json)
-                                    if ($stdout_buffer eq 'JSON_START') {
-                                        $currently_in_json_block = 1;
-                                    }
-                                    if (not $currently_in_json_block) {
-                                        $stdout_buffer .= $/;
-                                        $syswrite_ensure->(
-                                            length($stdout_buffer), *STDOUT, 'stdout', \$noisy_stdout, $stdout_buffer
-                                        );
-                                    }
-                                    if ($currently_in_json_block and $stdout_buffer eq 'JSON_END') {
-                                        $currently_in_json_block = 0;
-                                    }
-                                    $stdout_buffer = '';
-                                }
-                                else {
-                                    $stdout_buffer .= $char;
-                                }
-                            }
-                            # if we still have data in our local buffer, flush it
-                            $syswrite_ensure->(
-                                length($stdout_buffer), *STDOUT, 'stdout', \$noisy_stdout, $stdout_buffer
-                            ) if $stdout_buffer;
-                        }
-                    }
-
-                    if ($max_stdout_bytes && $bytesnb{'stdout'} >= $max_stdout_bytes) {
-                        # caller got enough data, close all our child channels
-                        $select->remove($child_stdout);
-                        $select->remove($child_stderr);
-                        close($child_stdin);
-                        close($child_stdout);
-                        close($child_stderr);
-
-                        # and also our own STDIN if we're listening for it
-                        if ($select->exists(\*STDIN)) {
-                            $select->remove(\*STDIN);
-                            close(STDIN);
-                        }
-                    }
-                }
-
-                # we got data, is this our stdin?
-                elsif ($current_fh->fileno == STDIN->fileno) {
-                    $bytesnb{'stdin'} += $nbread;
-                    # save this data for the next loop
-                    $child_stdin_to_write .= $buffer;
-                }
-
-                # wow, we got data from an unknown fh ... it's not possible ... theoretically
-                else {
-                    warn_syslog("Got data from an unknown fh ($current_fh) with $nbread bytes of data");
+                    # EPIPE & friends: the child stopped reading its stdin (most likely it exited,
+                    # or closed it on purpose); not an error, it just doesn't want our data
+                    osh_debug("execute: stopped feeding stdin_str to the child ($!)");
                     last;
                 }
             }
+            close($stdin_wh);    # done writing (or gave up): give the child its EOF
+        }
 
-            # /guarantee
+        $harness->finish;
+        1;
+    };
+    if (!$ok) {
+        my $err = $@ || 'unknown error';
+        # note: IPC::Run prepends context (e.g. "ack ") to exceptions thrown from within a sink
+        # callback, so match our sentinel anywhere in the message, not anchored at the start.
+        if ($err =~ /EXECUTE_MAX_STDOUT_BYTES/) {
+            $hit_max_stdout = 1;              # this is a deliberate stop, not a command failure
+            eval { $harness->kill_kill; };    # we got enough output, stop the child
+            eval { $harness->finish; };       # then reap it
+        }
+        else {
+            # genuine failure: either the exec itself failed, or IPC::Run hit an internal error
+            # (such as EPIPE while pumping the child's stdin), in which case the child HAS been
+            # started: kill and reap it if any, instead of leaving a zombie behind us until we exit
+            eval { $harness->kill_kill; };
+            eval { $harness->finish; };
+            chomp $err;
+            return R('ERR_EXEC_FAILED', msg => "Couldn't exec requested command ($err)");
         }
     }
 
-    # here, all fd went EOF (except maybe STDIN but we don't care)
-    # so we need to waitpid
-    # (might be blocking, but we have nothing to read/write anyway)
-    osh_debug("all fds are EOF, waiting for pid $pid indefinitely");
-    waitpid($pid, 0);
-    my $child_exit_status = $?;
+    # flush any trailing (newline-less) line we held back from the hide_json_result tee, unless it's
+    # part of a JSON result block we're hiding
+    print {*STDOUT} $json_tee_buf
+      if ($noisy_stdout && $hide_json_result && length $json_tee_buf && !$in_json_block);
+
+    # raw wait status ($?) of our single command. Use the plural full_results() and take the first
+    # element rather than full_result(0): in IPC::Run 20180523.0 (shipped on e.g. RockyLinux 8 and
+    # Ubuntu 20.04), full_result($index) does `goto &result if @_ > 1`, so it wrongly returns the
+    # already->>8-shifted exit code instead of the raw $?, and our own >>8 below would then zero out
+    # every sub-256 exit code. full_results() returns the raw RESULT and behaves identically across
+    # versions.
+    my $child_exit_status = 0;
+    eval { ($child_exit_status) = $harness->full_results; };
+    $child_exit_status = 0 if !defined $child_exit_status;
 
     $fnret = sysret2human($child_exit_status);
     osh_debug("cmd returned with $fnret");
+
+    # decide our return code. note: a signal death yields status => undef (not 0), so guard with
+    # defined() before the == 0 test, otherwise `undef == 0` is true and we'd wrongly report OK (and
+    # silently defeat must_succeed) for a killed command. A command we deliberately stopped after
+    # max_stdout_bytes is NOT a failure: keep it OK even under must_succeed (e.g. connect.pl truncating
+    # a ttyrec preview), as we killed it on purpose once we had enough output.
+    my $status = $fnret->value->{'status'};
+    my $code =
+        $hit_max_stdout                   ? 'OK'
+      : (defined $status && $status == 0) ? 'OK'
+      : $must_succeed                     ? 'ERR_NON_ZERO_EXIT'
+      :                                     'OK_NON_ZERO_EXIT';
     return R(
-        $fnret->value->{'status'} == 0 ? 'OK' : ($must_succeed ? 'ERR_NON_ZERO_EXIT' : 'OK_NON_ZERO_EXIT'),
+        $code,
         value => {
-            sysret     => $child_exit_status >> 8,
-            sysret_raw => $child_exit_status,
-            stdout     => [split($/, $stdout_output)],
-            stderr     => [split($/, $stderr_output)],
-            bytesnb    => \%bytesnb,
-            status     => $fnret->value->{'status'},
-            coredump   => $fnret->value->{'coredump'},
-            signal     => $fnret->value->{'signal'},
+            sysret           => $child_exit_status >> 8,
+            sysret_raw       => $child_exit_status,
+            stdout           => [split($/, $stdout_output // '')],
+            stderr           => [split($/, $stderr_output // '')],
+            result_fd_output => $result_fd_output,             # raw JSON from the fd-3 result channel, if any (capture_result_fd)
+            bytesnb          => \%bytesnb,
+            status           => $fnret->value->{'status'},
+            coredump         => $fnret->value->{'coredump'},
+            signal           => $fnret->value->{'signal'},
         },
         msg => "Command exited with " . sysret2human($child_exit_status)->msg,
     );
@@ -486,8 +396,12 @@ sub execute_simple {
 
     $fnret = sysret2human($child_exit_status);
     osh_debug("cmd returned with $fnret");
+
+    # a signal death yields status => undef (not 0); guard with defined() before == 0, otherwise
+    # `undef == 0` is true and we'd wrongly report OK (and silently defeat must_succeed) for a kill.
+    my $status = $fnret->value->{'status'};
     return R(
-        $fnret->value->{'status'} == 0 ? 'OK' : ($must_succeed ? 'ERR_NON_ZERO_EXIT' : 'OK_NON_ZERO_EXIT'),
+        (defined $status && $status == 0) ? 'OK' : ($must_succeed ? 'ERR_NON_ZERO_EXIT' : 'OK_NON_ZERO_EXIT'),
         value => {
             sysret     => $child_exit_status >> 8,
             sysret_raw => $child_exit_status,
@@ -500,7 +414,11 @@ sub execute_simple {
     );
 }
 
-sub result_from_helper {
+# Parse a JSON result framed as a JSON_START..JSON_END block within an array of stdout lines. This is
+# the format osh.pl emits for --json output, consumed by execute_osh() (e.g. the batch plugin, which
+# runs osh.pl recursively). Real helpers (bin/helper/osh-*) don't use this: they return their result
+# over the dedicated fd 3 (see json_output()), which helper() reads directly.
+sub result_from_json_output {
     my $input = shift;
 
     if (ref $input ne 'ARRAY') {
@@ -510,21 +428,18 @@ sub result_from_helper {
     my $state = 1;
     my @json;
     foreach my $line (@$input) {
-        chomp;
+        chomp $line;
         if ($state == 1) {
             if ($line eq 'JSON_START') {
-                # will now capture data
                 @json  = ();
                 $state = 2;
             }
         }
         elsif ($state == 2) {
             if ($line eq 'JSON_END') {
-                # done capturing data, might still see a new JSON_START however
                 $state = 1;
             }
             else {
-                # capturing data
                 push @json, $line;
             }
         }
@@ -548,26 +463,70 @@ sub helper_decapsulate {
     return R($value->{'error_code'}, value => $value->{'value'}, msg => $value->{'error_message'});
 }
 
-sub helper {
-    my %params        = @_;
-    my @command       = @{$params{'cmd'} || []};
-    my $expects_stdin = $params{'expects_stdin'};
-    my $stdin_str     = $params{'stdin_str'};
+# Shared core for helper() and execute_osh(): run a result-bearing child via execute() with the
+# caller-chosen result-transport flag ($result_flag, 'capture_result_fd' for real helpers via fd 3, or
+# 'hide_json_result' for osh.pl framing its result on stdout), tee its human output live, then hand the
+# execute() $fnret to $extract, which pulls out and decapsulates the structured JSON result.
+sub _execute_with_result {
+    my %params      = @_;
+    my $result_flag = $params{'result_flag'};
+    my $extract     = $params{'extract'};
 
     my $fnret = OVH::Bastion::execute(
-        cmd           => \@command,
+        cmd           => [@{$params{'cmd'} || []}],
         noisy_stdout  => 1,
         noisy_stderr  => 1,
-        is_helper     => 1,
-        expects_stdin => $expects_stdin,
-        stdin_str     => $stdin_str
+        $result_flag  => 1,
+        expects_stdin => $params{'expects_stdin'},
+        stdin_str     => $params{'stdin_str'},
     );
-    $fnret or return R('ERR_HELPER_FAILED', msg => "something went wrong in helper script ($fnret)");
+    $fnret or return R('ERR_HELPER_FAILED', msg => "something went wrong while running the command ($fnret)");
 
-    $fnret = OVH::Bastion::result_from_helper($fnret->value->{'stdout'});
-    $fnret or return $fnret;
+    return $extract->($fnret);
+}
 
-    return OVH::Bastion::helper_decapsulate($fnret->value);
+# Run a bastion helper (bin/helper/osh-*) under sudo via execute(), and return its decapsulated
+# result. The helper returns its JSON result over the dedicated fd 3 (see json_output()/HEXIT and
+# OVH::Bastion::Helper), which keeps its stdout clean for the live tee. To run osh.pl recursively
+# instead (which is not a helper and frames its result on stdout), use execute_osh().
+sub helper {
+    my %params = @_;
+    return _execute_with_result(
+        %params,
+        result_flag => 'capture_result_fd',
+        extract     => sub {
+            my $fnret  = shift;
+            my $result = $fnret->value->{'result_fd_output'};
+            if (!defined $result || !length $result) {
+                return R('ERR_HELPER_RETURN_EMPTY',
+                    msg => "The helper didn't return any data, maybe it crashed, please report to your sysadmin!");
+            }
+            my $decoded;
+            eval { $decoded = decode_json($result); };
+            if ($@) {
+                return R('ERR_HELPER_RETURN_INVALID', msg => $@);
+            }
+            return OVH::Bastion::helper_decapsulate($decoded);
+        },
+    );
+}
+
+# Run osh.pl recursively (the login shell) with --json, and return its decapsulated result. Unlike a
+# bastion helper, osh.pl is not run under sudo and doesn't use the fd-3 result channel: it frames its
+# result as a JSON_START..JSON_END block on stdout. We hide that block from the live tee (so the user
+# only sees human output) but still capture it, then parse it. Currently used by the batch plugin.
+sub execute_osh {
+    my %params = @_;
+    return _execute_with_result(
+        %params,
+        result_flag => 'hide_json_result',
+        extract     => sub {
+            my $fnret = shift;
+            $fnret = OVH::Bastion::result_from_json_output($fnret->value->{'stdout'});
+            $fnret or return $fnret;
+            return OVH::Bastion::helper_decapsulate($fnret->value);
+        },
+    );
 }
 
 1;

--- a/tests/functional/tests.d/330-selfkeys.sh
+++ b/tests/functional/tests.d/330-selfkeys.sh
@@ -150,9 +150,12 @@ EOS
     local account1key1fp
     account1key1fp=$(get_json | $jq '.value.keys[0].fingerprint')
 
-    ignorecodewarn "possible deadlock"
+    # feeding random garbage: the first line read is rejected as not-a-key, like any invalid key
+    # (cf. the privkey case just below, which also returns 100). Previously this returned 0 because
+    # the old execute() would deadlock on the stdin flood until ttyrec was signal-killed (status=undef
+    # -> exit 0); execute() no longer deadlocks and now propagates the plugin's real exit code.
     script  flood   $a1 -osh selfAddIngressKey '<' /dev/urandom
-    retvalshouldbe 0
+    retvalshouldbe 100
 
     script  privkey $a1 -osh selfAddIngressKey '<<< "-----BEGIN RSA PRIVATE KEY-----
     MIIBugIBAAKBgQCawvohH0r9B4NxdaYHiBT5pLWDe14o3MTE3WwtKF0l7az+zw0P"'

--- a/tests/functional/tests.d/395-mfa-scp-sftp-rsync.sh
+++ b/tests/functional/tests.d/395-mfa-scp-sftp-rsync.sh
@@ -160,19 +160,19 @@ EOF
 
     success personal_scp_upload_oldhelper_ok scp $scp_options -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file /etc/passwd $shellaccount@127.0.0.2:uptest
     contain "through the bastion to"
-    contain "Done,"
+    contain "Done, scp exited successfully"
 
     success personal_scp_upload_newwrapper_ok /tmp/scpwrapper -i $account0key1file /etc/passwd $shellaccount@127.0.0.2:uptest
     contain "through the bastion to"
-    contain "Done,"
+    contain "Done, scp exited successfully"
 
     success personal_scp_download_oldhelper_ok scp $scp_options -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file $shellaccount@127.0.0.2:uptest /tmp/downloaded
     contain "through the bastion from"
-    contain "Done,"
+    contain "Done, scp exited successfully"
 
     success personal_scp_download_newwrapper_ok /tmp/scpwrapper -i $account0key1file $shellaccount@127.0.0.2:uptest /tmp/downloaded
     contain "through the bastion from"
-    contain "Done,"
+    contain "Done, scp exited successfully"
 
     success personal_scp_del_scpup_access $a0 --osh selfDelPersonalAccess --host 127.0.0.2 --protocol scpupload --port 22
     success personal_scp_del_scpdown_access $a0 --osh selfDelPersonalAccess --host 127.0.0.2 --protocol scpdownload --port 22
@@ -197,7 +197,7 @@ EOF
     contain 'sftp> ls'
     contain 'uptest'
     contain 'sftp> exit'
-    contain '>>> Done,'
+    contain "Done, sftp exited successfully"
 
     run personal_sftp_use_newwrapper_badport /tmp/sftpwrapper -b /tmp/sftpcommands -i $account0key1file -P 9999 $shellaccount@127.0.0.2
     retvalshouldbe 1
@@ -213,7 +213,7 @@ EOF
     contain 'sftp> ls'
     contain 'uptest'
     contain 'sftp> exit'
-    contain '>>> Done,'
+    contain "Done, sftp exited successfully"
 
     success personal_sftp_del_sftp_access $a0 --osh selfDelPersonalAccess --host 127.0.0.2 --protocol sftp --port 22
 
@@ -229,13 +229,13 @@ EOF
     nocontain "rsync:"
     nocontain "rsync error:"
     contain ">>> Hello"
-    contain ">>> Done,"
+    contain "Done, rsync exited successfully"
 
     success personal_rsync_download_ok rsync --rsh \"$a0 --osh rsync --\" $shellaccount@127.0.0.2:rsync_file /tmp/downloaded
     nocontain "rsync:"
     nocontain "rsync error:"
     contain ">>> Hello"
-    contain ">>> Done,"
+    contain "Done, rsync exited successfully"
 
     success personal_rsync_del_rsync_access $a0 --osh selfDelPersonalAccess --host 127.0.0.2 --protocol rsync --port 22
 
@@ -272,7 +272,7 @@ EOF
     success groupssh_groupprotocol_scp_upload_ok /tmp/scpwrapper -i $account0key1file /etc/passwd $shellaccount@127.0.0.2:
     contain 'MFA_TOKEN=notrequired'
     contain 'transferring your file through the bastion'
-    contain '>>> Done'
+    contain "Done, scp exited successfully"
 
     run personalssh_groupprotocol_scp_download_mustfail /tmp/scpwrapper -i $account0key1file $shellaccount@127.0.0.2:passwd /tmp/
     retvalshouldbe 1
@@ -295,7 +295,7 @@ EOF
     success groupssh_groupprotocol_sftp_use_ok /tmp/sftpwrapper -i $account0key1file sftp://$shellaccount@127.0.0.2//etc/passwd
     contain 'MFA_TOKEN=notrequired'
     contain 'Fetching /etc/passwd'
-    contain '>>> Done'
+    contain "Done, sftp exited successfully"
 
     success groupssh_groupprotocol_sftp_del_sftp_access $a0 --osh groupDelServer --group $group1 --host 127.0.0.2 --protocol sftp --port 22
 
@@ -310,7 +310,7 @@ EOF
 
     success groupssh_groupprotocol_rsync_use_ok rsync --rsh \"$a0 --osh rsync --\" $shellaccount@127.0.0.2:/etc/passwd /tmp/
     contain '>>> Hello'
-    contain '>>> Done,'
+    contain "Done, rsync exited successfully"
 
     success groupssh_groupprotocol_rsync_del_rsync_access $a0 --osh groupDelServer --group $group1 --host 127.0.0.2 --protocol rsync --port 22
 
@@ -506,21 +506,21 @@ EOF
     success scp_upload_mfa_exempt_oldwrapper_ok scp $scp_options -F $mytmpdir/ssh_config -S /tmp/scphelper -i $account0key1file /etc/passwd $shellaccount@127.0.0.2:uptest
     contain 'skipping as your account is exempt from MFA'
     contain "through the bastion to"
-    contain "Done,"
+    contain "Done, scp exited successfully"
 
     success sftp_use_mfa_exempt_oldwrapper_ok sftp -F $mytmpdir/ssh_config -b /tmp/sftpcommands -S /tmp/sftphelper -i $account0key1file $shellaccount@127.0.0.2
     contain 'skipping as your account is exempt from MFA'
     contain 'sftp> ls'
     contain 'uptest'
     contain 'sftp> exit'
-    contain '>>> Done,'
+    contain "Done, sftp exited successfully"
 
     run rsync_use_mfa_exempt_ok rsync --rsh \"$a0 --osh rsync --\" $shellaccount@127.0.0.2:/etc/passwd /tmp/
     nocontain "rsync:"
     nocontain "rsync error:"
     contain "requires password MFA but your account has password MFA bypass, allowing"
     contain ">>> Hello"
-    contain ">>> Done,"
+    contain "Done, rsync exited successfully"
 
     # reset account setup
     success personal_mfa_reset_policy $a0 --osh accountModify --account $account0 --mfa-password-required no

--- a/tests/unit/tests/execute.t
+++ b/tests/unit/tests/execute.t
@@ -1,0 +1,169 @@
+#! /usr/bin/env perl
+# vim: set filetype=perl ts=4 sw=4 sts=4 et:
+use common::sense;
+use Test::More;
+
+use File::Basename;
+use lib dirname(__FILE__) . '/../../../lib/perl';
+use OVH::Bastion;
+use OVH::Result;
+
+# execute() now delegates to IPC::Run; if it's not installed here (e.g. a dev machine that
+# never ran packages-check), execute() can't run at all, so skip rather than hard-fail.
+if (!eval { require IPC::Run; 1 }) {
+    plan skip_all => "IPC::Run is not available, can't test OVH::Bastion::execute()";
+}
+
+# we use the running perl as a portable, always-present test program
+my $perl = $^X;
+
+# --- basic exec: exit code, stdout/stderr split, must_succeed -----------------------------------
+# This also guards the exit-code extraction: execute() reads the raw wait status via the plural
+# full_results() to dodge the IPC::Run 20180523.0 full_result($idx) quirk that would otherwise
+# zero out every sub-256 exit code. So a child exiting 3 MUST come back as 3, not 0.
+{
+    my $r = OVH::Bastion::execute(
+        cmd          => [$perl, '-e', 'print "out1\nout2\n"; print STDERR "err1\n"; exit 3'],
+        must_succeed => 1,
+    );
+    isa_ok($r, 'OVH::Result', "execute() returns an OVH::Result");
+    is($r->err,               'ERR_NON_ZERO_EXIT', "must_succeed turns a non-zero exit into ERR_NON_ZERO_EXIT");
+    is($r->value->{'status'}, 3, "child exit code 3 is reported as 3 (not zeroed by full_result quirk)");
+    is($r->value->{'sysret'}, 3, "sysret matches the exit code");
+    is_deeply($r->value->{'stdout'}, ['out1', 'out2'], "stdout is captured and split into lines");
+    is_deeply($r->value->{'stderr'}, ['err1'],         "stderr is captured separately");
+
+    # without must_succeed, the same non-zero exit is a soft OK_NON_ZERO_EXIT (still truthy)
+    my $r2 = OVH::Bastion::execute(cmd => [$perl, '-e', 'exit 3']);
+    ok($r2, "non-zero exit without must_succeed is still a truthy result");
+    is($r2->err, 'OK_NON_ZERO_EXIT', "non-zero exit without must_succeed -> OK_NON_ZERO_EXIT");
+}
+
+# --- stdin_str is fed to the child --------------------------------------------------------------
+{
+    my $r = OVH::Bastion::execute(
+        cmd       => [$perl, '-ne', 'print'],    # cat-like: echo stdin back to stdout
+        stdin_str => "fed-via-stdin\n",
+    );
+    ok($r, "execute() with stdin_str returns a truthy result");
+    is($r->value->{'status'}, 0, "child reading stdin_str exits cleanly");
+    is_deeply($r->value->{'stdout'}, ['fed-via-stdin'], "stdin_str is delivered to the child's stdin");
+}
+
+# --- stdin_str to a child that stops reading it: graceful, the real status is returned ----------
+# The pre-IPC::Run execute() tolerated a child exiting before consuming its whole stdin (e.g.
+# passwd rejecting a password early): it kept draining the child's output and returned its real
+# exit status and diagnostics. IPC::Run's own writer instead croaks on EPIPE on every version
+# shipped by our supported OSes, so execute() feeds stdin_str itself: guard that behavior here.
+{
+    # we deliberately run with the default SIGPIPE disposition: execute() shields its callers
+    # from the SIGPIPE its own stdin-feeding machinery can raise, and this block also guards
+    # that contract -- if it regresses, the signal kills the whole test, loudly
+
+    # 5MB, way beyond pipe capacity: writes are still pending whenever the child bails out
+    my $big = 'A' x (5 * 1024 * 1024);
+
+    # a child that reads a little, then exits cleanly
+    my $r = OVH::Bastion::execute(
+        cmd       => [$perl, '-e', 'read(STDIN, my $buf, 100); print "got100\n"; exit 0'],
+        stdin_str => $big,
+    );
+    ok($r, "a child exiting before consuming its whole stdin_str is not an error");
+    is($r->err,               'OK', "...it reports OK");
+    is($r->value->{'status'}, 0,    "...with its real exit code");
+    is_deeply($r->value->{'stdout'}, ['got100'], "...and its output is still fully collected");
+
+    # a child that fails outright without reading anything: its diagnostics must reach the caller
+    $r = OVH::Bastion::execute(
+        cmd       => [$perl, '-e', 'print STDERR "cannot comply\n"; exit 3'],
+        stdin_str => $big,
+    );
+    is($r->err,               'OK_NON_ZERO_EXIT', "a child failing without reading stdin_str reports its real exit");
+    is($r->value->{'status'}, 3,                  "...with its real exit code, not ERR_EXEC_FAILED");
+    is_deeply($r->value->{'stderr'}, ['cannot comply'], "...and its stderr diagnostics are preserved");
+
+    # a child that consumes everything gets every byte (exercises the pipe-full/pump interleaving)
+    $r = OVH::Bastion::execute(
+        cmd       => [$perl, '-e', 'my $l = 0; while (read(STDIN, my $b, 65536)) { $l += length $b } print "len=$l\n"'],
+        stdin_str => $big,
+    );
+    is($r->err, 'OK', "a child consuming a stdin_str larger than the pipe capacity succeeds");
+    is_deeply($r->value->{'stdout'}, ['len=' . length($big)], "...and receives every single byte of it");
+}
+
+# --- bare command name still resolves when $ENV{PATH} is empty (regression for the HTTP proxy) ---
+# IPC::Run looks up a bare command via $ENV{PATH} and, unlike open3()/execvp(), doesn't fall back to
+# a default path when it's empty. The HTTP proxy runs execute() with a cleared %ENV (Net::Server::HTTP
+# does `%ENV = ()` per request), so a bare 'sudo' must still be found. execute() restores the fallback.
+{
+    local $ENV{'PATH'} = '';    # mimic the proxy's cleared environment
+    my $r = OVH::Bastion::execute(cmd => ['sh', '-c', 'exit 0']);
+    ok($r, "execute() finds a bare command even with an empty \$ENV{PATH}");
+    isnt($r->err, 'ERR_EXEC_FAILED', "no 'command not found' when PATH is empty (proxy regression)");
+    is($r->value->{'status'}, 0, "the bare command ran and exited cleanly") if $r->value;
+}
+
+# --- max_stdout_bytes: below the cap, the command completes normally ----------------------------
+{
+    my $r = OVH::Bastion::execute(
+        cmd              => [$perl, '-e', 'print "short output\n"; exit 0'],
+        max_stdout_bytes => 2000,
+    );
+    ok($r, "execute() with max_stdout_bytes (below cap) returns a truthy result");
+    is($r->value->{'status'}, 0, "command under the byte cap completes normally with its real exit code");
+    is_deeply($r->value->{'stdout'}, ['short output'], "full output is returned when under the cap");
+    cmp_ok($r->value->{'bytesnb'}{'stdout'}, '<', 2000, "captured fewer than max_stdout_bytes bytes");
+}
+
+# --- max_stdout_bytes: above the cap, the child is killed and we don't hang (regression for #3) --
+# A child that floods stdout far past the cap. Pipe backpressure means it blocks long before
+# producing it all, but even if the abort were broken it stays finite, so a regression surfaces as
+# a failed byte-count assertion rather than an infinite hang. The header marker on the first line
+# mirrors the real caller (connect.pl reading the first 2k of a compressed ttyrec).
+{
+    my $flood = 'BEGIN { $| = 1 } print "HEADER_MARKER\n"; print "A" x 65536 for 1 .. 1000;';
+    my $t0    = time();
+    my $r     = OVH::Bastion::execute(
+        cmd              => [$perl, '-e', $flood],
+        max_stdout_bytes => 2000,
+    );
+    my $elapsed = time() - $t0;
+
+    ok($r, "execute() returns (does not hang) when output exceeds max_stdout_bytes");
+    cmp_ok($elapsed,                         '<',  20, "execute() aborts promptly instead of draining the whole flood");
+    cmp_ok($r->value->{'bytesnb'}{'stdout'}, '>=', 2000,      "captured at least max_stdout_bytes before aborting");
+    cmp_ok($r->value->{'bytesnb'}{'stdout'}, '<',  1_000_000, "stopped reading well before the child's full output");
+    is($r->value->{'stdout'}[0], 'HEADER_MARKER', "the truncated capture preserves the start of the stream");
+
+    # the abort path kills the child (kill_kill -> SIGKILL), so it exits on a signal, not cleanly
+    ok(!defined $r->value->{'status'}, "a killed child reports no exit status (terminated by signal)");
+    ok(defined $r->value->{'signal'},  "a killed child reports the terminating signal");
+}
+
+# --- is_binary passthrough: the child writes to our fds directly, bypassing the parent ----------
+# In is_binary mode (without max_stdout_bytes), execute() hands our own STDOUT/STDERR to IPC::Run
+# as GLOBs, which dup2()s them straight into the child: no parent-side pumping on the bulk data
+# path (sftp/rsync). Swap our STDOUT for a temp file around the call to observe the passthrough
+# without corrupting the TAP stream (Test::More writes to its own dup of the original STDOUT).
+{
+    require File::Temp;
+    my ($tmpfh, $tmpfile) = File::Temp::tempfile(UNLINK => 1);
+
+    open(my $saved_stdout, '>&', \*STDOUT) or die "can't save STDOUT: $!";
+    open(STDOUT,           '>&', $tmpfh)   or die "can't redirect STDOUT: $!";
+    my $r = OVH::Bastion::execute(
+        cmd       => [$perl, '-e', 'print "binary-passthrough\n"; exit 4'],
+        is_binary => 1,
+    );
+    open(STDOUT, '>&', $saved_stdout) or die "can't restore STDOUT: $!";
+
+    ok($r, "execute() with is_binary returns a truthy result");
+    is($r->err,               'OK_NON_ZERO_EXIT', "is_binary child's non-zero exit is still reported");
+    is($r->value->{'status'}, 4,                  "is_binary child's real exit code is preserved");
+    is_deeply($r->value->{'stdout'}, [], "is_binary mode does not capture stdout");
+
+    my $content = do { local $/; open(my $fh, '<', $tmpfile) or die "can't read $tmpfile: $!"; <$fh> };
+    is($content, "binary-passthrough\n", "child output landed directly on our (redirected) STDOUT");
+}
+
+done_testing();


### PR DESCRIPTION
Now that we support recent-enough OSes that all have a proper IPC::Run available, replace the hand-written open3 + IO::Select loop in execute() with IPC::Run, which handles all the complicated low-level I/O aspects.

In the same move, change how privileged helpers (bin/helper/osh-*) return their result to the calling plugin. Their result is now sent to a dedicated fd (3) opened by their calling plugin, to avoid having to use STDOUT which is also used for human-output. New params to execute():

  - capture_result_fd: use fd 3 as the child's result channel (helpers)
  - hide_json_result : hide a JSON_START block from the live stdout tee, notably used when running osh.pl recursively (the batch plugin)

helper() now reads the fd-3 result, and the osh.pl path gets its own execute_osh(), which parses the stdout JSON.

Introduce a new sudoers file to set "Defaults closefrom=4" for helpers.